### PR TITLE
fix

### DIFF
--- a/tools/release_helper/helm.py
+++ b/tools/release_helper/helm.py
@@ -649,10 +649,14 @@ def publish_helm_repo_to_github_pages(
         gh_pages_dir = Path(tmpdir) / "gh-pages"
         gh_pages_dir.mkdir()
         
-        # Clone gh-pages branch or initialize if it doesn't exist
-        repo_url = f"https://github.com/{repository_owner}/{repository_name}.git"
+        # Configure git remote URL with authentication token if available
+        github_token = os.getenv('GITHUB_TOKEN', '')
+        if github_token:
+            repo_url = f"https://x-access-token:{github_token}@github.com/{repository_owner}/{repository_name}.git"
+        else:
+            repo_url = f"https://github.com/{repository_owner}/{repository_name}.git"
         
-        print(f"Cloning gh-pages branch from {repo_url}...")
+        print(f"Cloning gh-pages branch from https://github.com/{repository_owner}/{repository_name}.git...")
         result = subprocess.run(
             ["git", "clone", "--branch", "gh-pages", "--depth", "1", repo_url, str(gh_pages_dir)],
             capture_output=True,


### PR DESCRIPTION
The publish_helm_repo_to_github_pages function was failing to push to the gh-pages branch because git couldn't authenticate via HTTPS. This fix:

- Reads the GITHUB_TOKEN environment variable (set by GitHub Actions)
- Configures the git remote URL with x-access-token authentication
- Maintains backward compatibility when GITHUB_TOKEN is not set

This resolves the error:
'fatal: could not read Username for 'https://github.com': No such device or address'

Fixes: https://github.com/whale-net/everything/actions/runs/18182790887/job/51761764524