### PR TITLE
fix: update manman-worker dependency from params_base to params

### DIFF
--- a/manman/src/worker/BUILD.bazel
+++ b/manman/src/worker/BUILD.bazel
@@ -9,7 +9,7 @@ py_library(
         "//manman/src:manman_core",
         "//manman/clients:clients",
         "//manman/src/repository:manman_repository",
-        "//libs/python/cli:params_base",
+        "//libs/python/cli:params",  # Changed from params_base to params
         "//libs/python/cli:types",
         "//libs/python/cli/providers/rabbitmq",
         "//libs/python/logging",  # Use consolidated logging


### PR DESCRIPTION
## Problem
The manman-worker was failing at runtime with:
```
ModuleNotFoundError: No module named 'libs.python.cli.params'
```

## Root Cause
- `manman/src/worker/main.py` imports `logging_params` from `libs.python.cli.params`
- But `BUILD.bazel` only depended on `//libs/python/cli:params_base`
- `params_base` doesn't include the `logging_params` decorator

## Solution
Changed dependency from:
- `//libs/python/cli:params_base` → `//libs/python/cli:params`

This provides access to all CLI parameter decorators including `logging_params`.

## Testing
```bash
bazel run //manman/src/worker:worker -- --help
```
Successfully displays help with all logging parameters.