### PR TITLE
docs: Update repository structure documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ This document provides comprehensive guidelines for AI agents working on the Eve
 
 ## ⚠️ CRITICAL: Cross-Compilation
 
-**MUST READ**: [`docs/BUILDING_CONTAINERS.md`](docs/BUILDING_CONTAINERS.md)
+**MUST READ**: [`docs/DOCKER.md`](docs/DOCKER.md)
 
 This repository implements true cross-compilation for Python apps using rules_pycross for platform-specific wheel resolution. **This is critical for ARM64 container deployments**. If cross-compilation breaks, ARM64 containers will crash at runtime with compiled dependencies (pydantic, numpy, pandas, etc.).
 
@@ -52,12 +52,18 @@ This repository implements true cross-compilation for Python apps using rules_py
 
 ### Repository Structure
 ```
-├── demo/                    # Example applications
-├── libs/                    # Shared libraries (python/, go/)
-├── tools/                   # Build and release tooling
-├── docs/                    # Documentation (including CROSS_COMPILATION.md)
+├── manman/                  # ManMan - Game server orchestration system (Python + Go)
+│   ├── src/                # Python services (APIs, workers)
+│   └── management-ui/      # Go-based HTMX management interface
+├── friendly_computing_machine/  # Slack bot with Temporal workflows
+├── demo/                    # Example applications (hello_python, hello_go, hello_fastapi, etc.)
+├── libs/                    # Shared libraries
+│   ├── python/             # Python libs (alembic, cli, gunicorn, logging, postgres, rmq, retry)
+│   └── go/                 # Go libs (htmxauth)
+├── generated/              # Generated OpenAPI clients (py/, go/)
+├── tools/                   # Build and release tooling (helm, release_helper, tilt, etc.)
+├── docs/                    # Documentation
 ├── .github/                 # CI/CD workflows
-├── tools/scripts/test_cross_compilation.sh # CRITICAL: Cross-compilation verification
 └── BUILD.bazel, MODULE.bazel # Bazel configuration
 ```
 

--- a/README.md
+++ b/README.md
@@ -15,11 +15,19 @@ A modern Bazel monorepo supporting both Python and Go development with automated
 
 ```
 everything/
-├── demo/                    # Example applications
-├── libs/                    # Shared libraries (python/, go/)
+├── manman/                  # ManMan - Game server orchestration system
+│   ├── src/                # Python services (APIs, workers, migrations)
+│   └── management-ui/      # Go-based HTMX management interface
+├── friendly_computing_machine/  # Slack bot with Temporal workflows
+├── demo/                    # Example applications (hello_python, hello_go, hello_fastapi, etc.)
+├── libs/                    # Shared libraries
+│   ├── python/             # Python libs (alembic, cli, gunicorn, logging, postgres, rmq, retry)
+│   └── go/                 # Go libs (htmxauth)
+├── generated/              # Generated OpenAPI clients (py/, go/)
 ├── tools/                   # Build and release tooling
 │   ├── helm/               # Helm chart generation
-│   └── release_helper/     # Release automation
+│   ├── release_helper/     # Release automation
+│   └── tilt/               # Local development with Tilt
 ├── docs/                    # Documentation
 ├── .github/workflows/      # CI/CD pipelines
 ├── BUILD.bazel             # Root build configuration
@@ -31,6 +39,13 @@ everything/
 - **True Cross-Compilation**: Platform transitions for correct ARM64 wheel selection
 - **Monorepo Structure**: Multiple apps and shared libraries in a single repository
 - **Release Automation**: Comprehensive CI/CD with intelligent change detection
+
+### Main Projects
+
+| Project | Description | Documentation |
+|---------|-------------|---------------|
+| **ManMan** | Game server orchestration with APIs, workers, and HTMX UI | [manman/README.md](manman/README.md) |
+| **Friendly Computing Machine** | Slack bot with Temporal workflow support | [friendly_computing_machine/README.md](friendly_computing_machine/README.md) |
 
 ## 🚀 Quick Start
 
@@ -150,14 +165,16 @@ See the complete guide: [docs/RELEASE.md](docs/RELEASE.md)
 
 ### Repository Structure
 ```
-├── .github/workflows/     # CI/CD workflows (ci.yml, release.yml)
+├── manman/                # ManMan - Game server orchestration
+├── friendly_computing_machine/  # Slack bot with Temporal
 ├── demo/                  # Example applications
-├── docs/                  # Documentation (guides and references)
 ├── libs/                  # Shared libraries (python/, go/)
+├── generated/            # Generated OpenAPI clients
 ├── tools/                 # Build and release tooling
+├── docs/                  # Documentation
+├── .github/workflows/     # CI/CD workflows
 ├── BUILD.bazel           # Root build configuration
-├── MODULE.bazel          # External dependencies
-└── README.md             # This file
+└── MODULE.bazel          # External dependencies
 ```
 
 ### Future Improvements


### PR DESCRIPTION
## Summary
- Update AGENTS.md and README.md to accurately reflect the actual repository layout
- Add documentation for main projects (ManMan, Friendly Computing Machine)
- Fix broken documentation link in AGENTS.md (`docs/BUILDING_CONTAINERS.md` → `docs/DOCKER.md`)

## Test plan
- [ ] Verify all documentation links work correctly
- [ ] Confirm repository structure matches actual layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)