### PR TITLE
fix: Rename ManManV2 apps and update deployment configuration

### DIFF
--- a/manman/ARCHITECTURE.md
+++ b/manman/ARCHITECTURE.md
@@ -71,9 +71,9 @@ ManManV2 is a game server management platform with a split-plane architecture:
 
 | Deployable | App Type | Deployment | Description |
 |------------|----------|------------|-------------|
-| `manmanv2-api` | external-api | K8s (Cloud) | User-facing API (gRPC + REST gateway) |
-| `manmanv2-processor` | worker | K8s (Cloud) | Event processor, health monitoring |
-| `manmanv2-migration` | job | K8s (Cloud) | Database migration runner |
+| `control-api` | external-api | K8s (Cloud) | User-facing API (gRPC + REST gateway) |
+| `event-processor` | worker | K8s (Cloud) | Event processor, health monitoring |
+| `control-migration` | job | K8s (Cloud) | Database migration runner |
 | `manmanv2-host` | worker | Bare metal (Docker) | Host server manager |
 
 ### Host Manager
@@ -249,7 +249,7 @@ service ManManAPI {
 ├── models.go                    # Database models (package manman)
 │                                # Flat structure - no nested pkg/db/
 │
-├── migrate/                     # Migration tool (manmanv2-migration)
+├── migrate/                     # Migration tool (control-migration)
 │   ├── main.go                  # CLI runner using libs/go/migrate
 │   ├── migrations/              # Embedded SQL migration files
 │   │   ├── 001_initial_schema.up.sql
@@ -260,12 +260,12 @@ service ManManAPI {
 │   ├── api.proto                # Control plane API
 │   └── messages.proto           # Shared message types
 │
-├── api/                         # manmanv2-api service (planned)
+├── api/                         # control-api service (planned)
 │   ├── main.go
 │   ├── handlers/
 │   └── BUILD.bazel
 │
-├── processor/                   # manmanv2-processor service (planned)
+├── processor/                   # event-processor service (planned)
 │   ├── main.go
 │   └── BUILD.bazel
 │
@@ -322,7 +322,7 @@ service ManManAPI {
   - Created `//manman/models.go` with all database models (package manman)
   - Created SQL migrations in `//manman/migrate/migrations/`
   - Built generic migration library at `//libs/go/migrate/`
-  - Migration tool configured as release_app: `//manman/migrate:manmanv2-migration`
+  - Migration tool configured as release_app: `//manman/migrate:control-migration`
 - [x] **Basic control plane API (CRUD for Game, GameConfig, Server)** ✓
   - Full CRUD operations for all entities
   - gRPC API with REST gateway

--- a/manman/BUILD.bazel
+++ b/manman/BUILD.bazel
@@ -165,9 +165,9 @@ MANMAN_V1_APPS = [
 
 # List of ManManV2 (Go) app metadata targets for chart composition
 MANMAN_V2_APPS = [
-    "//manman/api:manmanv2-api_metadata",
-    "//manman/migrate:manmanv2-migration_metadata",
-    "//manman/processor:manmanv2-processor_metadata",
+    "//manman/api:control-api_metadata",
+    "//manman/migrate:control-migration_metadata",
+    "//manman/processor:event-processor_metadata",
 ]
 
 # ManMan V1 Helm chart - Python-based legacy services
@@ -186,16 +186,16 @@ release_helm_chart(
 
 # ManManV2 Helm chart - Go-based control plane services
 # This is a separate chart for the V2 rewrite with distinct deployment lifecycle
-# Chart tags will use the format: helm-manmanv2.vX.Y.Z
+# Chart tags will use the format: helm-manman-control-services.vX.Y.Z
 release_helm_chart(
     name = "manmanv2_chart",
     apps = MANMAN_V2_APPS,
-    chart_name = "manmanv2",
+    chart_name = "control-services",
     domain = "manman",
     environment = "dev",
     namespace = "manmanv2",
     # chart_version omitted - uses default "0.0.0-dev" for local builds
-    # Release system auto-versions from git tags (helm-manmanv2.v*)
+    # Release system auto-versions from git tags (helm-manman-control-services.v*)
     visibility = ["//visibility:public"],
 )
 

--- a/manman/api/BUILD.bazel
+++ b/manman/api/BUILD.bazel
@@ -2,7 +2,7 @@ load("@rules_go//go:def.bzl", "go_binary")
 load("//tools/bazel:release.bzl", "release_app")
 
 go_binary(
-    name = "manmanv2-api",
+    name = "control-api",
     srcs = ["main.go"],
     deps = [
         "//libs/go/rmq",
@@ -18,11 +18,11 @@ go_binary(
 
 # Release metadata for API service
 release_app(
-    name = "manmanv2-api",
-    binary_name = ":manmanv2-api",
+    name = "control-api",
+    binary_name = ":control-api",
     language = "go",
     domain = "manman",
-    description = "ManManV2 control plane API (gRPC)",
+    description = "ManMan control plane API (gRPC)",
     app_type = "external-api",
     port = 50051,
     replicas = 2,

--- a/manman/api/S3_CONFIG.md
+++ b/manman/api/S3_CONFIG.md
@@ -76,7 +76,7 @@ When running in Kubernetes, use IAM Roles for Service Accounts (IRSA):
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: manmanv2-api
+  name: manman-control-api
   annotations:
     eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/ManManV2LogsRole
 ```
@@ -194,7 +194,7 @@ log_id | session_id | file_path                                          | start
 Run the migration to update schema comments:
 
 ```bash
-bazel run //manman/migrate:manmanv2-migration -- up
+bazel run //manman/migrate:control-migration -- up
 ```
 
 This applies migration `003_s3_logs.up.sql` which updates the `file_path` column documentation.

--- a/manman/design/CONFIGURATION_SYSTEM_IMPLEMENTATION.md
+++ b/manman/design/CONFIGURATION_SYSTEM_IMPLEMENTATION.md
@@ -33,13 +33,13 @@ Two new migrations have been added:
 
 ```bash
 # Build the migration binary
-bazel build //manman/migrate:manmanv2-migration
+bazel build //manman/migrate:control-migration
 
 # Run migrations (requires DATABASE_URL environment variable)
-./bazel-bin/manman/migrate/manmanv2-migration_/manmanv2-migration up
+./bazel-bin/manman/migrate/control-migration_/control-migration up
 
 # Or rollback if needed
-./bazel-bin/manman/migrate/manmanv2-migration_/manmanv2-migration down
+./bazel-bin/manman/migrate/control-migration_/control-migration down
 ```
 
 ## Go Models

--- a/manman/docs/PHASE_6_COMPLETE.md
+++ b/manman/docs/PHASE_6_COMPLETE.md
@@ -44,13 +44,13 @@ Phase 6 implementation is complete with all core components built, tested, and d
 **Build Commands:**
 ```bash
 # Build binary
-bazel build //manman/processor:manmanv2-processor
+bazel build //manman/processor:event-processor
 
 # Run locally
-bazel run //manman/processor:manmanv2-processor
+bazel run //manman/processor:event-processor
 
 # Build container image
-bazel build //manman/processor:manmanv2-processor_image
+bazel build //manman/processor:event-processor_image
 ```
 
 ### 2. Comprehensive Test Suite ✅

--- a/manman/docs/PHASE_6_STATUS.md
+++ b/manman/docs/PHASE_6_STATUS.md
@@ -29,9 +29,9 @@
 ## In-Scope Components (Already Implemented)
 
 ### ✅ Core Services (All Exist)
-1. **manmanv2-api** - Control plane gRPC API with REST gateway
-2. **manmanv2-processor** - Event processor (just completed)
-3. **manmanv2-migration** - Database migration runner
+1. **control-api** - Control plane gRPC API with REST gateway
+2. **event-processor** - Event processor (just completed)
+3. **control-migration** - Database migration runner
 4. **host** - Host manager with Docker integration
 5. **manmanv2-wrapper** - Sidecar for game containers
 6. **management-ui** - Admin web interface

--- a/manman/docs/PRODUCTION_DEPLOYMENT.md
+++ b/manman/docs/PRODUCTION_DEPLOYMENT.md
@@ -64,7 +64,7 @@ secrets:
 ```yaml
 # docker-compose.yml
 services:
-  manmanv2-processor:
+  manman-event-processor:
     environment:
       DB_PASSWORD: ${DB_PASSWORD}  # From .env file
       RABBITMQ_URL: ${RABBITMQ_URL}
@@ -421,14 +421,14 @@ stringData:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: manmanv2-processor
+  name: manman-event-processor
   namespace: manmanv2
 spec:
   template:
     spec:
       containers:
       - name: processor
-        image: ghcr.io/whale-net/manman-manmanv2-processor:v1.0.0
+        image: ghcr.io/whale-net/manman-event-processor:v1.0.0
         env:
         # Database
         - name: DB_HOST

--- a/manman/migrate/BUILD.bazel
+++ b/manman/migrate/BUILD.bazel
@@ -2,7 +2,7 @@ load("@rules_go//go:def.bzl", "go_binary")
 load("//tools/bazel:release.bzl", "release_app")
 
 go_binary(
-    name = "manmanv2-migration",
+    name = "control-migration",
     srcs = ["main.go"],
     embedsrcs = glob(["migrations/*.sql"]),
     deps = [
@@ -13,10 +13,10 @@ go_binary(
 
 # Release metadata for migration job
 release_app(
-    name = "manmanv2-migration",
-    binary_name = ":manmanv2-migration",
+    name = "control-migration",
+    binary_name = ":control-migration",
     language = "go",
     domain = "manman",
-    description = "ManManV2 database migration runner",
+    description = "ManMan control plane database migration runner",
     app_type = "job",
 )

--- a/manman/processor/BUILD.bazel
+++ b/manman/processor/BUILD.bazel
@@ -20,17 +20,17 @@ go_library(
 )
 
 go_binary(
-    name = "manmanv2-processor",
+    name = "event-processor",
     embed = [":processor_lib"],
     visibility = ["//visibility:public"],
 )
 
 release_app(
-    name = "manmanv2-processor",
-    binary_name = ":manmanv2-processor",
+    name = "event-processor",
+    binary_name = ":event-processor",
     language = "go",
     domain = "manman",
-    description = "ManManV2 event processor (RabbitMQ consumer, DB sync)",
+    description = "ManMan event processor (RabbitMQ consumer, DB sync)",
     app_type = "worker",
     replicas = 1,
 )

--- a/manman/processor/README.md
+++ b/manman/processor/README.md
@@ -1,6 +1,6 @@
 # ManManV2 Event Processor Service
 
-The ManManV2 Event Processor Service (`manmanv2-processor`) is a RabbitMQ consumer that processes events from host managers and updates the database to maintain data consistency.
+The ManManV2 Event Processor Service (`event-processor`) is a RabbitMQ consumer that processes events from host managers and updates the database to maintain data consistency.
 
 ## Architecture
 
@@ -143,13 +143,13 @@ Default threshold: **10 seconds** (configurable)
 
 ```bash
 # Build binary
-bazel build //manman/processor:manmanv2-processor
+bazel build //manman/processor:event-processor
 
 # Build container image
-bazel build //manman/processor:manmanv2-processor_image
+bazel build //manman/processor:event-processor_image
 
 # Run locally (requires RabbitMQ and PostgreSQL)
-bazel run //manman/processor:manmanv2-processor
+bazel run //manman/processor:event-processor
 ```
 
 ## Deployment

--- a/manman/processor/VERIFICATION.md
+++ b/manman/processor/VERIFICATION.md
@@ -47,13 +47,13 @@
 
 ```bash
 # ✅ Binary builds successfully
-bazel build //manman/processor:manmanv2-processor
+bazel build //manman/processor:event-processor
 
 # ✅ Container image builds successfully
-bazel build //manman/processor:manmanv2-processor_image
+bazel build //manman/processor:event-processor_image
 
 # Binary location
-bazel-bin/manman/processor/manmanv2-processor_/manmanv2-processor
+bazel-bin/manman/processor/event-processor_/event-processor
 ```
 
 ## Configuration Test

--- a/manman/processor/main.go
+++ b/manman/processor/main.go
@@ -48,7 +48,7 @@ func run() error {
 	}))
 	slog.SetDefault(logger)
 
-	logger.Info("starting manmanv2-processor",
+	logger.Info("starting event-processor",
 		"queue", cfg.QueueName,
 		"stale_threshold", cfg.StaleHostThreshold,
 		"external_exchange", cfg.ExternalExchange,


### PR DESCRIPTION
## Summary

Renames ManManV2 apps to distinct names without 'v2' suffix to avoid naming conflicts with v1 apps, while maintaining deployment isolation through the `manmanv2` namespace.

## Changes

### App Renames
- `manmanv2-api` → `control-api`
- `manmanv2-migration` → `control-migration`
- `manmanv2-processor` → `event-processor`

### Helm Chart Updates
- Chart name: `manmanv2` → `control-services`
- Full chart name: `manman-control-services`
- Namespace: `manmanv2` (unchanged)
- Domain: `manman` (unchanged)

### Image Names
- `ghcr.io/whale-net/manman-control-api`
- `ghcr.io/whale-net/manman-control-migration`
- `ghcr.io/whale-net/manman-event-processor`

### Documentation Updates
Updated all documentation files to reflect new naming:
- Architecture docs
- Phase 6 completion docs
- Production deployment guide
- Configuration system docs
- Service READMEs and verification docs

## Deployment

Apps to deploy:
1. **manman-control-api** (external-api, gRPC on port 50051, 2 replicas)
2. **manman-control-migration** (job, database migration runner)
3. **manman-event-processor** (worker, RabbitMQ consumer, 1 replica)

Helm chart: `helm-manman-control-services.vX.Y.Z`
Namespace: `manmanv2`

## Testing

- ✅ All builds pass
- ✅ Helm chart generates successfully
- ✅ No references to old names in documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)