### PR TITLE
fix: Set ManManV2 apps to use manmanv2 domain/namespace

### DIFF
--- a/manman/BUILD.bazel
+++ b/manman/BUILD.bazel
@@ -191,11 +191,11 @@ release_helm_chart(
     name = "manmanv2_chart",
     apps = MANMAN_V2_APPS,
     chart_name = "control-services",
-    domain = "manman",
+    domain = "manmanv2",
     environment = "dev",
     namespace = "manmanv2",
     # chart_version omitted - uses default "0.0.0-dev" for local builds
-    # Release system auto-versions from git tags (helm-manman-control-services.v*)
+    # Release system auto-versions from git tags (helm-manmanv2-control-services.v*)
     visibility = ["//visibility:public"],
 )
 

--- a/manman/api/BUILD.bazel
+++ b/manman/api/BUILD.bazel
@@ -21,7 +21,7 @@ release_app(
     name = "control-api",
     binary_name = ":control-api",
     language = "go",
-    domain = "manman",
+    domain = "manmanv2",
     description = "ManMan control plane API (gRPC)",
     app_type = "external-api",
     port = 50051,

--- a/manman/host/BUILD.bazel
+++ b/manman/host/BUILD.bazel
@@ -31,7 +31,7 @@ release_app(
     name = "host-manager",
     binary_name = ":host-manager",
     language = "go",
-    domain = "manman",
+    domain = "manmanv2",
     description = "ManMan host manager (Docker container orchestration)",
     app_type = "worker",
     replicas = 1,

--- a/manman/migrate/BUILD.bazel
+++ b/manman/migrate/BUILD.bazel
@@ -16,7 +16,7 @@ release_app(
     name = "control-migration",
     binary_name = ":control-migration",
     language = "go",
-    domain = "manman",
+    domain = "manmanv2",
     description = "ManMan control plane database migration runner",
     app_type = "job",
 )

--- a/manman/processor/BUILD.bazel
+++ b/manman/processor/BUILD.bazel
@@ -29,7 +29,7 @@ release_app(
     name = "event-processor",
     binary_name = ":event-processor",
     language = "go",
-    domain = "manman",
+    domain = "manmanv2",
     description = "ManMan event processor (RabbitMQ consumer, DB sync)",
     app_type = "worker",
     replicas = 1,


### PR DESCRIPTION
Fixes ManManV2 apps being released under manman V1 namespace.

All apps now use `domain = "manmanv2"` instead of `domain = "manman"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)