### PR TITLE
fix: Use DB_SSL_MODE environment variable consistently in migration code

### DIFF
--- a/libs/go/migrate/cli.go
+++ b/libs/go/migrate/cli.go
@@ -34,7 +34,7 @@ func DefaultConfig() *Config {
 		User:            getEnv("DB_USER", "postgres"),
 		Password:        getEnv("DB_PASSWORD", ""),
 		Database:        getEnv("DB_NAME", "postgres"),
-		SSLMode:         getEnv("DB_SSLMODE", "disable"),
+		SSLMode:         getEnv("DB_SSL_MODE", "disable"),
 		MaxOpenConns:    25,
 		MaxIdleConns:    5,
 		ConnMaxLifetime: 5 * time.Minute,


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Fixes #323 - Application not respecting `DB_SSL_MODE` environment variable

## Problem

The migration code was using `DB_SSLMODE` instead of `DB_SSL_MODE`, which is inconsistent with the API and processor services. This caused migrations to fail when PostgreSQL requires SSL encryption, resulting in the error:

```
server error: FATAL: pg_hba.conf rejects connection for host "", user "", database "", no encryption (SQLSTATE 28000)
```

## Changes

- Updated `libs/go/migrate/cli.go` line 37 to use `DB_SSL_MODE` instead of `DB_SSLMODE`
- This brings the migration code in line with:
  - `manman/api/main.go`
  - `manman/processor/config.go`
  - All Tiltfile and documentation references

## Testing

- ✅ Build passes: `bazel build //libs/go/migrate/...`
- ✅ Verified all services now use `DB_SSL_MODE` consistently
- ✅ No other instances of `DB_SSLMODE` found in codebase

## Impact

All ManManV2 services (API, processor, migrations) will now properly respect the `DB_SSL_MODE` environment variable when connecting to PostgreSQL, allowing successful connections to SSL-required databases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)