### PR TITLE
fix: Add RABBITMQ_TLS_SERVER_NAME for certificate hostname verification

### DIFF
--- a/libs/go/rmq/TLS_CONFIGURATION.md
+++ b/libs/go/rmq/TLS_CONFIGURATION.md
@@ -36,6 +36,22 @@ Path to a custom CA certificate file for verifying the RabbitMQ server's certifi
 export RABBITMQ_CA_CERT_PATH=/etc/ssl/certs/rabbitmq-ca.crt
 ```
 
+### `RABBITMQ_TLS_SERVER_NAME`
+
+Server name to use for TLS certificate verification (SNI - Server Name Indication).
+
+- **Default**: (empty) - uses hostname from connection URL
+- **Use case**: When connecting to internal hostname but certificate is for external domain
+- **Common scenario**: Kubernetes internal service names vs. external certificates
+
+```bash
+# Connect to internal k8s service but verify against external cert
+export RABBITMQ_URL="amqps://user:pass@common-rabbitmq.rabbitmq.svc.cluster.local:5671/vhost"
+export RABBITMQ_TLS_SERVER_NAME="rmq.whalenet.dev"
+```
+
+**Example**: Your RabbitMQ certificate is for `rmq.whalenet.dev`, but in Kubernetes you connect to `common-rabbitmq.rabbitmq.svc.cluster.local`. Set `RABBITMQ_TLS_SERVER_NAME=rmq.whalenet.dev` to verify the certificate correctly.
+
 ## Usage
 
 ### Basic Connection (Non-TLS)


### PR DESCRIPTION
## Summary

Fixes TLS certificate hostname mismatch errors when connecting to internal Kubernetes service names but the certificate is issued for an external domain.

Resolves the error reported in production:
```
tls: failed to verify certificate: x509: certificate is valid for rmq.whalenet.dev, 
not common-rabbitmq.rabbitmq.svc.cluster.local
```

## Problem

When using `amqps://` with Kubernetes internal service names:
- **Connection URL**: `amqps://user:pass@common-rabbitmq.rabbitmq.svc.cluster.local:5671/vhost`
- **Certificate**: Valid for `rmq.whalenet.dev`
- **Result**: TLS verification fails due to hostname mismatch

This is a common scenario in Kubernetes where you connect to an internal service name but the certificate is for the external domain.

## Solution

Added `RABBITMQ_TLS_SERVER_NAME` environment variable to specify the server name for TLS certificate verification (SNI - Server Name Indication).

### Changes

**libs/go/rmq/connection.go**:
- Add `ServerName` field to `TLSConfig` struct
- Load `RABBITMQ_TLS_SERVER_NAME` from environment in `getTLSConfigFromEnv()`
- Set `tls.Config.ServerName` in `buildTLSConfig()` to override hostname verification

**libs/go/rmq/TLS_CONFIGURATION.md**:
- Document new `RABBITMQ_TLS_SERVER_NAME` environment variable
- Add Kubernetes usage example
- Explain when and why to use it

## Usage

### Kubernetes Deployment

```yaml
env:
  - name: RABBITMQ_URL
    value: "amqps://user:pass@common-rabbitmq.rabbitmq.svc.cluster.local:5671/vhost"
  - name: RABBITMQ_TLS_SERVER_NAME
    value: "rmq.whalenet.dev"
```

### How It Works

1. **Connect** to `common-rabbitmq.rabbitmq.svc.cluster.local` (internal k8s service)
2. **Verify certificate** against `rmq.whalenet.dev` (external domain in cert)
3. **TLS handshake** succeeds because ServerName matches certificate

## Testing

- ✅ Library builds successfully with Bazel
- ✅ manmanv2-control-api builds successfully
- ✅ manmanv2-event-processor builds successfully
- ✅ Backward compatible (ServerName is optional)

## Affected Services

- manmanv2-control-api
- manmanv2-event-processor
- All services using `libs/go/rmq` with `amqps://`

## Environment Variables

| Variable | Purpose | Required |
|----------|---------|----------|
| `RABBITMQ_URL` | Connection URL with amqps:// | Yes |
| `RABBITMQ_TLS_SERVER_NAME` | Hostname for cert verification | Optional - only when cert hostname differs from URL hostname |
| `RABBITMQ_SSL_VERIFY` | Disable verification (dev only) | Optional |
| `RABBITMQ_CA_CERT_PATH` | Custom CA certificate | Optional |

## Deployment

After merging:
1. Set `RABBITMQ_TLS_SERVER_NAME=rmq.whalenet.dev` in ManManV2 deployments
2. Update `RABBITMQ_URL` to use `amqps://` with internal service name
3. Deploy updated services

## Breaking Changes

None - fully backward compatible. ServerName is only used when explicitly set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)