### PR TITLE
fix: Create session data directories before container creation

### DIFF
--- a/manman-v2/docs/containerized-deployment.md
+++ b/manman-v2/docs/containerized-deployment.md
@@ -1,0 +1,238 @@
+# Containerized Host Manager Deployment
+
+This document describes how to deploy the ManManV2 host manager in a Docker container, which is the recommended approach for production deployments.
+
+## Overview
+
+The host manager can run in two modes:
+
+1. **Bare Metal Mode** (development): Run directly on the host with `bazel run //manman/host:host`
+2. **Containerized Mode** (production): Run in a Docker container with proper volume mounts
+
+## Why Containerize?
+
+Running the host manager in a container provides:
+- Consistent runtime environment
+- Easy deployment and updates
+- Isolation from host system dependencies
+- Better resource management
+
+## Requirements
+
+### Volume Mounts
+
+The containerized host manager requires two critical volume mounts:
+
+```yaml
+volumes:
+  - /var/run/docker.sock:/var/run/docker.sock  # Docker API access
+  - ./data:/data                                 # Session data persistence
+```
+
+#### Docker Socket (`/var/run/docker.sock`)
+Allows the host manager to control Docker on the host machine to create game server containers.
+
+#### Data Directory (`./data:/data`)
+**Critical for proper operation.** This mount allows the host manager to:
+1. Create session directories (`/data/session-{id}`) that persist game server data
+2. Bind mount these directories into game containers
+3. Enable data persistence across container restarts
+
+**Without this mount**, session starts will fail with:
+```
+Error: invalid mount config for type "bind": bind source path does not exist: /data/session-1
+```
+
+## Docker Compose Configuration
+
+### Minimal Configuration
+
+```yaml
+services:
+  host-manager:
+    image: ghcr.io/whale-net/manmanv2-host-manager:latest
+    container_name: manmanv2-host-manager
+    restart: always
+    network_mode: host
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./data:/data
+    environment:
+      SERVER_NAME: ${SERVER_NAME}
+      RABBITMQ_URL: ${RABBITMQ_URL}
+      API_ADDRESS: ${API_ADDRESS:-localhost:50051}
+      ENVIRONMENT: ${ENVIRONMENT:-production}
+```
+
+### Environment Variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `SERVER_NAME` | Yes | - | Unique name for this host manager instance |
+| `RABBITMQ_URL` | Yes | - | RabbitMQ connection URL |
+| `API_ADDRESS` | No | `localhost:50051` | Control plane API address |
+| `ENVIRONMENT` | No | `production` | Deployment environment (dev/staging/production) |
+| `DOCKER_SOCKET` | No | `/var/run/docker.sock` | Docker socket path |
+
+## Session Data Directory Structure
+
+When sessions are started, the host manager creates directories in the mounted `/data` volume:
+
+```
+./data/
+├── session-1/      # Session 1 game data
+├── session-2/      # Session 2 game data
+└── session-n/      # Session N game data
+```
+
+Each session directory is bind-mounted into its game container at `/data/game`, allowing:
+- Game servers to persist world data, configs, and save files
+- Backups to be created from session data
+- Session restoration from backups
+
+## Testing Containerized Deployment
+
+A comprehensive test script validates the containerized deployment:
+
+```bash
+cd manman-v2
+
+# Build host manager image
+bazel run //manman/host:host-manager_image_load
+
+# Ensure control plane is running
+tilt up
+
+# Run containerized deployment test
+./scripts/test-containerized-flow.sh
+```
+
+This test validates:
+- Host manager starts successfully in a container
+- Session data directories are created correctly
+- Game containers start with proper bind mounts
+- Full session lifecycle (start → running → stop)
+
+## Troubleshooting
+
+### Issue: "bind source path does not exist"
+
+**Symptom:**
+```
+Error: failed to create game container: Error response from daemon:
+invalid mount config for type "bind": bind source path does not exist: /data/session-1
+```
+
+**Solution:**
+Ensure the data volume is mounted in your docker-compose.yml:
+```yaml
+volumes:
+  - ./data:/data  # This line is required!
+```
+
+### Issue: Permission denied on /data
+
+**Symptom:**
+```
+Error: failed to create session data directory: permission denied
+```
+
+**Solution:**
+Ensure the data directory has appropriate permissions:
+```bash
+mkdir -p ./data
+chmod 755 ./data
+```
+
+### Issue: Game container can't write to /data/game
+
+**Symptom:**
+Game server logs show permission errors when writing to `/data/game`
+
+**Solution:**
+The session directory may have restrictive permissions. The host manager creates directories with `0755` by default, which should work for most game servers.
+
+If your game server runs as a specific UID, you may need to adjust permissions:
+```bash
+# Find the session directory
+ls -la ./data/
+
+# Adjust permissions for the specific session
+chmod 777 ./data/session-{id}
+```
+
+## Deployment Checklist
+
+Before deploying to production:
+
+- [ ] Data directory is mounted (`./data:/data`)
+- [ ] Docker socket is mounted (`/var/run/docker.sock:/var/run/docker.sock`)
+- [ ] Network mode is set to `host`
+- [ ] Environment variables are configured
+- [ ] Server name is unique across all host managers
+- [ ] RabbitMQ URL is correct and accessible
+- [ ] Control plane API is reachable
+- [ ] Host manager image is up to date
+- [ ] Test script passes: `./scripts/test-containerized-flow.sh`
+
+## Security Considerations
+
+### Docker Socket Access
+
+The host manager requires access to the Docker socket, which gives it full control over Docker on the host. This is a privileged operation. Ensure:
+
+- The host manager container is from a trusted source
+- The host system is properly secured
+- Only authorized users can modify the host manager configuration
+
+### Network Mode: Host
+
+The host manager uses `network_mode: host` to:
+- Access the host's Docker daemon
+- Allow game containers to bind to host ports
+- Communicate with RabbitMQ and the control plane
+
+This means the host manager can access any network port on the host. Ensure proper firewall rules are in place.
+
+## Migration from Bare Metal to Containerized
+
+If you're currently running the host manager with `bazel run //manman/host:host`:
+
+1. **Stop the bare metal host manager**
+   ```bash
+   # Press Ctrl+C to stop the running process
+   ```
+
+2. **Create data directory**
+   ```bash
+   mkdir -p ./data
+   ```
+
+3. **Configure docker-compose.yml** (as shown above)
+
+4. **Start containerized host manager**
+   ```bash
+   docker-compose up -d host-manager
+   ```
+
+5. **Verify registration**
+   ```bash
+   docker-compose logs -f host-manager
+   # Look for: "Successfully registered with control plane"
+   ```
+
+6. **Test with a session**
+   ```bash
+   # Use the test script or start a session via the API
+   ./scripts/test-containerized-flow.sh
+   ```
+
+## Performance Considerations
+
+The containerized host manager has minimal overhead compared to bare metal mode:
+
+- **Docker socket communication**: Negligible latency
+- **Volume mount overhead**: Minimal (native bind mounts)
+- **Network performance**: No overhead with `network_mode: host`
+
+For production workloads, containerized deployment is recommended as it provides better operational benefits with negligible performance impact.

--- a/manman-v2/scripts/test-containerized-flow.sh
+++ b/manman-v2/scripts/test-containerized-flow.sh
@@ -1,0 +1,394 @@
+#!/bin/bash
+# End-to-end test script for ManManV2 containerized deployment
+#
+# This script tests the complete flow with the host manager running in a container:
+# 1. Start host manager in Docker container
+# 2. Create a game configuration
+# 3. Create a server game config
+# 4. Start a session
+# 5. Verify containers are running
+# 6. Stop the session
+# 7. Verify cleanup
+# 8. Stop host manager container
+#
+# Prerequisites:
+#   - Control plane running (tilt up)
+#   - Host manager image built (bazel run //manman/host:host-manager_image_load)
+#   - grpcurl installed (brew install grpcurl)
+#
+# Usage: ./scripts/test-containerized-flow.sh [OPTIONS]
+#
+# Options:
+#   --api-endpoint=HOST:PORT   API endpoint (default: localhost:50051)
+#   --server-name=NAME        Server name (default: host-test-containerized)
+#   --rabbitmq-url=URL        RabbitMQ URL (default: amqp://rabbit:password@localhost:5672/manmanv2-dev)
+#   --cleanup                 Clean up resources after test
+#   --help                    Show this help message
+
+set -e
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+# Default values
+API_ENDPOINT="localhost:50051"
+SERVER_NAME="host-test-containerized"
+RABBITMQ_URL="amqp://rabbit:password@localhost:5672/manmanv2-dev"
+CLEANUP=false
+HOST_CONTAINER_NAME="test-host-manager-$$"
+DATA_DIR="/tmp/manmanv2-test-data-$$"
+
+# Parse arguments
+for arg in "$@"; do
+  case $arg in
+    --api-endpoint=*)
+      API_ENDPOINT="${arg#*=}"
+      shift
+      ;;
+    --server-name=*)
+      SERVER_NAME="${arg#*=}"
+      shift
+      ;;
+    --rabbitmq-url=*)
+      RABBITMQ_URL="${arg#*=}"
+      shift
+      ;;
+    --cleanup)
+      CLEANUP=true
+      shift
+      ;;
+    --help)
+      head -n 23 "$0" | tail -n +2 | sed 's/^# //'
+      exit 0
+      ;;
+    *)
+      echo -e "${RED}Unknown option: $arg${NC}"
+      exit 1
+      ;;
+  esac
+done
+
+# Check for grpcurl
+if ! command -v grpcurl &> /dev/null; then
+  echo -e "${RED}Error: grpcurl is not installed${NC}"
+  echo "Install with: brew install grpcurl (macOS) or go install github.com/fullstorydev/grpcurl/cmd/grpcurl@latest"
+  exit 1
+fi
+
+# Cleanup function
+cleanup() {
+  echo ""
+  echo -e "${YELLOW}Cleaning up...${NC}"
+
+  # Stop and remove host manager container
+  if docker ps -a --format '{{.Names}}' | grep -q "^${HOST_CONTAINER_NAME}$"; then
+    echo "Stopping host manager container..."
+    docker stop "$HOST_CONTAINER_NAME" || true
+    docker rm "$HOST_CONTAINER_NAME" || true
+  fi
+
+  # Remove test data directory
+  if [ -d "$DATA_DIR" ]; then
+    echo "Removing test data directory..."
+    rm -rf "$DATA_DIR"
+  fi
+}
+
+# Set up trap to cleanup on exit
+trap cleanup EXIT
+
+echo ""
+echo -e "${GREEN}═══════════════════════════════════════════════════${NC}"
+echo -e "${GREEN}  ManManV2 Containerized Deployment Test${NC}"
+echo -e "${GREEN}═══════════════════════════════════════════════════${NC}"
+echo -e "${BLUE}API Endpoint:${NC} $API_ENDPOINT"
+echo -e "${BLUE}Server Name:${NC} $SERVER_NAME"
+echo -e "${BLUE}RabbitMQ URL:${NC} $RABBITMQ_URL"
+echo -e "${BLUE}Data Directory:${NC} $DATA_DIR"
+echo ""
+
+# Test API connectivity
+echo -e "${YELLOW}Testing API connectivity...${NC}"
+if ! grpcurl -plaintext "$API_ENDPOINT" list manman.v1.ManManAPI &> /dev/null; then
+  echo -e "${RED}✗ Cannot connect to API at $API_ENDPOINT${NC}"
+  echo "Make sure control plane is running: tilt up"
+  exit 1
+fi
+echo -e "${GREEN}✓ API is reachable${NC}"
+echo ""
+
+# Create test data directory
+echo -e "${BLUE}━━━ Setup: Creating Test Data Directory ━━━${NC}"
+mkdir -p "$DATA_DIR"
+echo -e "${GREEN}✓ Created $DATA_DIR${NC}"
+echo ""
+
+# Start host manager in container
+echo -e "${BLUE}━━━ Step 1: Start Host Manager Container ━━━${NC}"
+docker run -d \
+  --name "$HOST_CONTAINER_NAME" \
+  --network host \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -v "$DATA_DIR:/data" \
+  -e SERVER_NAME="$SERVER_NAME" \
+  -e RABBITMQ_URL="$RABBITMQ_URL" \
+  -e DOCKER_SOCKET=/var/run/docker.sock \
+  -e API_ADDRESS="$API_ENDPOINT" \
+  -e ENVIRONMENT=test \
+  manmanv2-host-manager:latest
+
+echo -e "${GREEN}✓ Host manager container started${NC}"
+echo ""
+
+# Wait for host manager to register
+echo -e "${YELLOW}Waiting for host manager to register (max 30 seconds)...${NC}"
+for i in {1..30}; do
+  # List servers and check if our server is registered
+  SERVERS=$(grpcurl -plaintext "$API_ENDPOINT" manman.v1.ManManAPI/ListServers 2>/dev/null || echo "{}")
+  if echo "$SERVERS" | grep -q "$SERVER_NAME"; then
+    echo -e "${GREEN}✓ Host manager registered${NC}"
+    break
+  fi
+
+  if [ $i -eq 30 ]; then
+    echo -e "${RED}✗ Host manager did not register within 30 seconds${NC}"
+    echo "Container logs:"
+    docker logs "$HOST_CONTAINER_NAME"
+    exit 1
+  fi
+
+  sleep 1
+done
+
+# Get server ID
+SERVER_ID=$(echo "$SERVERS" | grep -A5 "$SERVER_NAME" | grep '"serverId"' | grep -o '"[0-9]*"' | tr -d '"')
+echo -e "${BLUE}Server ID:${NC} $SERVER_ID"
+echo ""
+
+# Step 2: Create game
+echo -e "${BLUE}━━━ Step 2: Create Game ━━━${NC}"
+GAME_RESPONSE=$(grpcurl -plaintext \
+  -d '{
+    "name": "test-game-containerized",
+    "metadata": {
+      "genre": "test",
+      "publisher": "ManManV2",
+      "tags": ["test"]
+    }
+  }' \
+  "$API_ENDPOINT" \
+  manman.v1.ManManAPI/CreateGame)
+
+GAME_ID=$(echo "$GAME_RESPONSE" | grep -o '"gameId": *"[0-9]*"' | grep -o '[0-9]*')
+
+if [ -z "$GAME_ID" ]; then
+  echo -e "${RED}✗ Failed to create game${NC}"
+  echo "$GAME_RESPONSE"
+  exit 1
+fi
+
+echo -e "${GREEN}✓ Created game with ID: $GAME_ID${NC}"
+echo ""
+
+# Step 3: Create game config
+echo -e "${BLUE}━━━ Step 3: Create Game Config ━━━${NC}"
+CONFIG_RESPONSE=$(grpcurl -plaintext \
+  -d "{
+    \"game_id\": $GAME_ID,
+    \"name\": \"test-config-containerized\",
+    \"image\": \"manmanv2-test-game-server:latest\",
+    \"env_template\": {}
+  }" \
+  "$API_ENDPOINT" \
+  manman.v1.ManManAPI/CreateGameConfig)
+
+CONFIG_ID=$(echo "$CONFIG_RESPONSE" | grep -o '"configId": *"[0-9]*"' | grep -o '[0-9]*')
+
+if [ -z "$CONFIG_ID" ]; then
+  echo -e "${RED}✗ Failed to create game config${NC}"
+  echo "$CONFIG_RESPONSE"
+  exit 1
+fi
+
+echo -e "${GREEN}✓ Created game config with ID: $CONFIG_ID${NC}"
+echo ""
+
+# Step 4: Deploy game config
+echo -e "${BLUE}━━━ Step 4: Deploy Game Config ━━━${NC}"
+DEPLOY_RESPONSE=$(grpcurl -plaintext \
+  -d "{
+    \"server_id\": $SERVER_ID,
+    \"game_config_id\": $CONFIG_ID,
+    \"port_bindings\": [
+      {
+        \"container_port\": 8080,
+        \"host_port\": 18080,
+        \"protocol\": \"TCP\"
+      }
+    ]
+  }" \
+  "$API_ENDPOINT" \
+  manman.v1.ManManAPI/DeployGameConfig)
+
+SGC_ID=$(echo "$DEPLOY_RESPONSE" | grep -o '"serverGameConfigId": *"[0-9]*"' | grep -o '[0-9]*')
+
+if [ -z "$SGC_ID" ]; then
+  echo -e "${RED}✗ Failed to deploy game config${NC}"
+  echo "$DEPLOY_RESPONSE"
+  exit 1
+fi
+
+echo -e "${GREEN}✓ Deployed with server game config ID: $SGC_ID${NC}"
+echo ""
+
+# Step 5: Start session
+echo -e "${BLUE}━━━ Step 5: Start Session ━━━${NC}"
+SESSION_RESPONSE=$(grpcurl -plaintext \
+  -d "{
+    \"server_game_config_id\": $SGC_ID
+  }" \
+  "$API_ENDPOINT" \
+  manman.v1.ManManAPI/StartSession)
+
+SESSION_ID=$(echo "$SESSION_RESPONSE" | grep -o '"sessionId": *"[0-9]*"' | grep -o '[0-9]*')
+
+if [ -z "$SESSION_ID" ]; then
+  echo -e "${RED}✗ Failed to start session${NC}"
+  echo "$SESSION_RESPONSE"
+  exit 1
+fi
+
+echo -e "${GREEN}✓ Started session with ID: $SESSION_ID${NC}"
+echo ""
+
+# Wait for session to start
+echo -e "${YELLOW}Waiting for session to start (max 30 seconds)...${NC}"
+for i in {1..30}; do
+  SESSION_STATUS=$(grpcurl -plaintext \
+    -d "{\"session_id\": $SESSION_ID}" \
+    "$API_ENDPOINT" \
+    manman.v1.ManManAPI/GetSession 2>/dev/null | grep -o '"status": *"[^"]*"' | grep -o '"[^"]*"$' | tr -d '"' || echo "unknown")
+
+  echo -e "${BLUE}  Status: $SESSION_STATUS (attempt $i/30)${NC}"
+
+  if [ "$SESSION_STATUS" = "running" ]; then
+    echo -e "${GREEN}✓ Session is running${NC}"
+    break
+  elif [ "$SESSION_STATUS" = "crashed" ] || [ "$SESSION_STATUS" = "stopped" ]; then
+    echo -e "${RED}✗ Session ended unexpectedly with status: $SESSION_STATUS${NC}"
+    echo "Host manager logs:"
+    docker logs "$HOST_CONTAINER_NAME" | tail -50
+    exit 1
+  fi
+
+  sleep 1
+done
+
+if [ "$SESSION_STATUS" != "running" ]; then
+  echo -e "${RED}✗ Session did not start within 30 seconds${NC}"
+  echo "Host manager logs:"
+  docker logs "$HOST_CONTAINER_NAME" | tail -50
+  exit 1
+fi
+echo ""
+
+# Step 6: Verify data directory was created
+echo -e "${BLUE}━━━ Step 6: Verify Session Data Directory ━━━${NC}"
+SESSION_DATA_DIR="$DATA_DIR/session-$SESSION_ID"
+if [ -d "$SESSION_DATA_DIR" ]; then
+  echo -e "${GREEN}✓ Session data directory created: $SESSION_DATA_DIR${NC}"
+else
+  echo -e "${RED}✗ Session data directory not found: $SESSION_DATA_DIR${NC}"
+  exit 1
+fi
+echo ""
+
+# Step 7: Verify containers
+echo -e "${BLUE}━━━ Step 7: Verify Game Container ━━━${NC}"
+GAME_CONTAINER=$(docker ps --filter "label=manman.session_id=$SESSION_ID" --filter "label=manman.type=game" --format "{{.Names}}")
+
+if [ -z "$GAME_CONTAINER" ]; then
+  echo -e "${RED}✗ Game container not found${NC}"
+  docker ps --filter "label=manman.session_id=$SESSION_ID"
+  exit 1
+fi
+
+echo -e "${GREEN}✓ Game container: $GAME_CONTAINER${NC}"
+
+# Verify the bind mount is working
+MOUNT_INFO=$(docker inspect "$GAME_CONTAINER" | grep -A10 "Mounts" | grep "/data/game")
+if [ -n "$MOUNT_INFO" ]; then
+  echo -e "${GREEN}✓ Bind mount configured correctly${NC}"
+else
+  echo -e "${YELLOW}⚠ Could not verify bind mount (this may be okay)${NC}"
+fi
+echo ""
+
+# Step 8: Stop session
+echo -e "${BLUE}━━━ Step 8: Stop Session ━━━${NC}"
+STOP_RESPONSE=$(grpcurl -plaintext \
+  -d "{\"session_id\": $SESSION_ID}" \
+  "$API_ENDPOINT" \
+  manman.v1.ManManAPI/StopSession)
+
+echo -e "${GREEN}✓ Stop command sent${NC}"
+echo ""
+
+# Wait for session to stop
+echo -e "${YELLOW}Waiting for session to stop (max 20 seconds)...${NC}"
+for i in {1..20}; do
+  SESSION_STATUS=$(grpcurl -plaintext \
+    -d "{\"session_id\": $SESSION_ID}" \
+    "$API_ENDPOINT" \
+    manman.v1.ManManAPI/GetSession 2>/dev/null | grep -o '"status": *"[^"]*"' | grep -o '"[^"]*"$' | tr -d '"' || echo "unknown")
+
+  echo -e "${BLUE}  Status: $SESSION_STATUS (attempt $i/20)${NC}"
+
+  if [ "$SESSION_STATUS" = "stopped" ]; then
+    echo -e "${GREEN}✓ Session stopped${NC}"
+    break
+  fi
+
+  sleep 1
+done
+
+if [ "$SESSION_STATUS" != "stopped" ]; then
+  echo -e "${YELLOW}⚠ Session status is: $SESSION_STATUS (expected: stopped)${NC}"
+fi
+echo ""
+
+# Step 9: Verify cleanup
+echo -e "${BLUE}━━━ Step 9: Verify Container Cleanup ━━━${NC}"
+REMAINING_CONTAINERS=$(docker ps --filter "label=manman.session_id=$SESSION_ID" --format "{{.Names}}")
+
+if [ -z "$REMAINING_CONTAINERS" ]; then
+  echo -e "${GREEN}✓ All session containers cleaned up${NC}"
+else
+  echo -e "${YELLOW}⚠ Some containers still running:${NC}"
+  echo "$REMAINING_CONTAINERS"
+fi
+echo ""
+
+# Summary
+echo -e "${GREEN}═══════════════════════════════════════════════════${NC}"
+echo -e "${GREEN}  Test Summary${NC}"
+echo -e "${GREEN}═══════════════════════════════════════════════════${NC}"
+echo -e "${GREEN}✓ All containerized deployment tests passed!${NC}"
+echo ""
+echo -e "${BLUE}Key achievements:${NC}"
+echo "  ✓ Host manager ran successfully in container"
+echo "  ✓ Session data directory created at: $SESSION_DATA_DIR"
+echo "  ✓ Game container started with bind mount"
+echo "  ✓ Session lifecycle completed successfully"
+echo ""
+echo -e "${BLUE}Resources created:${NC}"
+echo "  Game ID: $GAME_ID"
+echo "  Config ID: $CONFIG_ID"
+echo "  Server Game Config ID: $SGC_ID"
+echo "  Session ID: $SESSION_ID"
+echo "  Server ID: $SERVER_ID"
+echo ""

--- a/manman/host/session/manager.go
+++ b/manman/host/session/manager.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -199,6 +200,12 @@ func (sm *SessionManager) SendInput(ctx context.Context, sessionID int64, input 
 
 // createGameContainer creates the game container directly
 func (sm *SessionManager) createGameContainer(ctx context.Context, state *State, cmd *StartSessionCommand) (string, error) {
+	// Create session data directory if it doesn't exist
+	sessionDataDir := fmt.Sprintf("/data/session-%d", state.SessionID)
+	if err := os.MkdirAll(sessionDataDir, 0755); err != nil {
+		return "", fmt.Errorf("failed to create session data directory: %w", err)
+	}
+
 	config := docker.ContainerConfig{
 		Image:     cmd.Image,
 		Name:      fmt.Sprintf("game-%d-%d", cmd.ServerID, cmd.SGCID),


### PR DESCRIPTION
## Summary

Fixes a critical bug where the host manager fails to start game sessions when running in containerized mode.

## Problem

When the host manager runs in a Docker container, it attempts to bind mount `/data/session-{id}` directories into game containers. Docker requires the source path to exist before creating bind mounts, but the host manager wasn't creating these directories first.

**Error:**
```
Error response from daemon: invalid mount config for type "bind": 
bind source path does not exist: /data/session-1
```

This issue only appeared in containerized deployments because:
- **Bare metal mode** (`bazel run //manman/host:host`): Directories created on host filesystem, worked fine
- **Containerized mode** (docker-compose): Host manager runs in container, needs explicit directory creation

## Solution

1. **Code fix**: Added `os.MkdirAll` in `createGameContainer()` to create session directories with 0755 permissions before container creation
2. **Test coverage**: Created comprehensive test script for containerized deployment
3. **Documentation**: Added deployment guide with troubleshooting and best practices

## Changes

- `manman/host/session/manager.go`: Create session data directory before mounting
- `manman-v2/scripts/test-containerized-flow.sh`: End-to-end test for containerized deployment
- `manman-v2/docs/containerized-deployment.md`: Deployment guide and troubleshooting

## Testing

### Automated Test
```bash
# Build host manager image
bazel run //manman/host:host-manager_image_load

# Ensure control plane is running
tilt up

# Run test
./manman-v2/scripts/test-containerized-flow.sh
```

The test validates:
- ✅ Host manager starts in container
- ✅ Session data directories created correctly
- ✅ Game containers start with bind mounts
- ✅ Full session lifecycle works

### Manual Verification
Tested with Minecraft server deployment on `dev-api.manmanv2.whalenet.dev`:
- Session started successfully
- `/data/session-1` created with correct permissions
- Game container running with bind mount to `/data/game`

## Deployment Impact

### Required Changes
Docker Compose configurations must include the data volume mount:
```yaml
volumes:
  - ./data:/data  # Required for session persistence
```

### Breaking Changes
None - this is a bug fix that makes containerized deployment work as intended.

## Checklist

- [x] Fix implemented and tested
- [x] Test coverage added
- [x] Documentation updated
- [x] Commit follows conventional commits format
- [x] All tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)