### PR TITLE
feat: Add log-processor to ManManV2 Helm chart

### DIFF
--- a/manman/BUILD.bazel
+++ b/manman/BUILD.bazel
@@ -174,6 +174,7 @@ MANMAN_V2_APPS = [
     "//manman/api:control-api_metadata",
     "//manman/migrate:control-migration_metadata",
     "//manman/processor:event-processor_metadata",
+    "//manman/log-processor:log-processor_metadata",
     "//manman-v2/ui:manmanv2-ui_metadata",
 ]
 

--- a/manman/log-processor/BUILD.bazel
+++ b/manman/log-processor/BUILD.bazel
@@ -32,10 +32,11 @@ go_binary(
 # Release metadata for log-processor
 release_app(
     name = "log-processor",
+    app_type = "internal-api",
     binary_name = ":log-processor",
-    language = "go",
+    description = "Real-time log streaming and S3 archival service with gRPC API",
     domain = "manmanv2",
-    description = "ManMan log processor (real-time log streaming service)",
-    app_type = "service",
+    language = "go",
+    port = 50053,
     replicas = 1,
 )


### PR DESCRIPTION
## Summary

Adds the log-processor service to the ManManV2 Helm chart so it can be deployed to production/staging environments via Helm releases.

## Changes

### 1. Updated `manman/log-processor/BUILD.bazel`
- Set `app_type` to `"internal-api"` (gRPC service)
- Configured `port: 50053` for gRPC communication
- Added complete service description
- Set `replicas: 1` for initial deployment

### 2. Updated `manman/BUILD.bazel`
- Added `//manman/log-processor:log-processor_metadata` to `MANMAN_V2_APPS` list
- Log-processor will now be included in `helm-manmanv2-control-services` chart releases

## Service Details

**Service**: log-processor  
**Type**: Internal gRPC API  
**Port**: 50053  
**Description**: Real-time log streaming and S3 archival service

**Dependencies**:
- RabbitMQ (log source)
- S3/MinIO (archival storage)
- PostgreSQL (log reference tracking)
- ManMan API (session queries)

## Helm Chart Impact

The log-processor will be deployed alongside:
- ✅ control-api (gRPC API)
- ✅ control-migration (database migrations)
- ✅ event-processor (background worker)
- ✅ manmanv2-ui (web interface)
- ✅ **log-processor (NEW)**

## Required Environment Variables

Helm values should include:
```yaml
logProcessor:
  env:
    RABBITMQ_URL: "amqp://..."
    S3_BUCKET: "manman-logs"
    S3_REGION: "us-east-1"
    S3_ENDPOINT: "https://s3.amazonaws.com"
    DATABASE_URL: "postgres://..."
    API_ADDRESS: "control-api:50051"
    TZ: "UTC"
    GRPC_PORT: "50053"
```

## Testing

To test the Helm chart generation:
```bash
bazel build //manman:manmanv2_chart
```

To release:
```bash
# Create git tag: helm-manmanv2-control-services.vX.Y.Z
# CI will build and push Helm chart
```

## Related PRs

- #342 - Original implementation of log-processor service
- This PR adds Helm chart support for production deployments

🤖 Generated with [Claude Code](https://claude.com/claude-code)