### PR TITLE
feat: add kraken - Go rewrite of release_helper

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -181,6 +181,7 @@ use_repo(
     "com_github_opencontainers_image_spec",
     "com_github_pkg_errors",
     "com_github_rabbitmq_amqp091_go",
+    "com_github_spf13_cobra",
     "com_github_stretchr_testify",
     "io_opentelemetry_go_contrib_instrumentation_net_http_otelhttp",
     "io_opentelemetry_go_otel_trace",

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/pkg/errors v0.9.1
 	github.com/rabbitmq/amqp091-go v1.10.0
+	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/crypto v0.47.0
 	golang.org/x/net v0.49.0
@@ -62,7 +63,9 @@ require (
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/lib/pq v1.10.9 // indirect
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
+	github.com/spf13/pflag v1.0.6 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.64.0
 	go.opentelemetry.io/otel v1.39.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -141,6 +141,7 @@ github.com/containerd/errdefs/pkg v0.3.0/go.mod h1:NJw6s9HwNuRhnjJhM7pylWwMyAkmC
 github.com/coreos/go-oidc/v3 v3.13.0/go.mod h1:HaZ3szPaZ0e4r6ebqvsLWlk2Tn+aejfmrfah6hnSYEU=
 github.com/coreos/go-oidc/v3 v3.17.0 h1:hWBGaQfbi0iVviX4ibC7bk8OKT5qNr4klBaCHVNvehc=
 github.com/coreos/go-oidc/v3 v3.17.0/go.mod h1:wqPbKFrVnE90vty060SB40FCJ8fTHTxSwyXJqZH+sI8=
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/cznic/mathutil v0.0.0-20180504122225-ca4c9f2c1369 h1:XNT/Zf5l++1Pyg08/HV04ppB0gKxAqtZQBRYiYrUuYk=
 github.com/cznic/mathutil v0.0.0-20180504122225-ca4c9f2c1369/go.mod h1:e6NPNENfs9mPDVNRekM7lKScauxd5kXTr1Mfyig6TDM=
 github.com/danieljoos/wincred v1.1.2 h1:QLdCxFs1/Yl4zduvBdcHB8goaYk9RARS2SgLLRuAyr0=
@@ -255,6 +256,8 @@ github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jackc/chunkreader/v2 v2.0.1 h1:i+RDz65UE+mmpjTfyz0MoVTnzeYxroil2G82ki7MGG8=
 github.com/jackc/chunkreader/v2 v2.0.1/go.mod h1:odVSm741yZoC3dpHEUXIqA9tQRhFrgOHwnPIn9lDKlk=
 github.com/jackc/pgconn v1.14.3 h1:bVoTr12EGANZz66nZPkMInAV/KHD2TxH9npjXXgiB3w=
@@ -358,6 +361,7 @@ github.com/rqlite/gorqlite v0.0.0-20230708021416-2acd02b70b79 h1:V7x0hCAgL8lNGez
 github.com/rqlite/gorqlite v0.0.0-20230708021416-2acd02b70b79/go.mod h1:xF/KoXmrRyahPfo5L7Szb5cAAUl53dMWBh9cMruGEZg=
 github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3VRLtww=
 github.com/russross/blackfriday v1.6.0/go.mod h1:ti0ldHuxg49ri4ksnFxlkCfN+hvslNlmVHqNRXXJNAY=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6NgVqpn3+iol9aGu4=
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=
 github.com/shopspring/decimal v1.2.0 h1:abSATXmQEYyShuxI4/vyW3tV1MrKAJzCZ/0zLUXYbsQ=
@@ -366,6 +370,10 @@ github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/snowflakedb/gosnowflake v1.6.19 h1:KSHXrQ5o7uso25hNIzi/RObXtnSGkFgie91X82KcvMY=
 github.com/snowflakedb/gosnowflake v1.6.19/go.mod h1:FM1+PWUdwB9udFDsXdfD58NONC0m+MlOSmQRvimobSM=
+github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
+github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
+github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
+github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spiffe/go-spiffe/v2 v2.6.0 h1:l+DolpxNWYgruGQVV0xsfeya3CsC7m8iBzDnMpsbLuo=
 github.com/spiffe/go-spiffe/v2 v2.6.0/go.mod h1:gm2SeUoMZEtpnzPNs2Csc0D/gX33k1xIx7lEzqblHEs=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -59,6 +59,13 @@ alias(
     visibility = ["//visibility:public"],
 )
 
+# Kraken - Go rewrite of the release helper
+alias(
+    name = "kraken",
+    actual = "//tools/kraken/cmd/kraken",
+    visibility = ["//visibility:public"],
+)
+
 # Test suite for cross-compilation (now in scripts/)
 # Use test_suite instead of alias so 'bazel test' works correctly
 # Has 'manual' tag to prevent running with //... in regular test job

--- a/tools/kraken/BUILD.bazel
+++ b/tools/kraken/BUILD.bazel
@@ -1,0 +1,39 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+package(default_visibility = ["//visibility:public"])
+
+go_library(
+    name = "kraken_lib",
+    srcs = [
+        "changes.go",
+        "cleanup.go",
+        "core.go",
+        "ghcr.go",
+        "git.go",
+        "github_release.go",
+        "images.go",
+        "metadata.go",
+        "release.go",
+        "release_notes.go",
+        "summary.go",
+        "validation.go",
+    ],
+    importpath = "github.com/whale-net/everything/tools/kraken",
+)
+
+go_test(
+    name = "kraken_test",
+    srcs = [
+        "changes_test.go",
+        "cleanup_test.go",
+        "core_test.go",
+        "ghcr_test.go",
+        "git_test.go",
+        "metadata_test.go",
+        "release_notes_test.go",
+        "release_test.go",
+        "summary_test.go",
+        "validation_test.go",
+    ],
+    embed = [":kraken_lib"],
+)

--- a/tools/kraken/BUILD.bazel
+++ b/tools/kraken/BUILD.bazel
@@ -2,6 +2,23 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 package(default_visibility = ["//visibility:public"])
 
+# Integration test comparing kraken output against release_helper.
+# Requires both tools to be buildable and invokes bazel internally,
+# so it is tagged "integration" and excluded from normal test runs.
+sh_test(
+    name = "integration_test",
+    srcs = ["integration_test.sh"],
+    data = [
+        "//tools/kraken/cmd/kraken",
+        "//tools/release_helper:release_helper",
+    ],
+    tags = [
+        "integration",
+        "no-sandbox",
+    ],
+    size = "large",
+)
+
 go_library(
     name = "kraken_lib",
     srcs = [

--- a/tools/kraken/changes.go
+++ b/tools/kraken/changes.go
@@ -1,0 +1,246 @@
+package kraken
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// GetChangedFiles returns the list of changed files compared to a base commit.
+func GetChangedFiles(baseCommit string) ([]string, error) {
+	cmd := exec.Command("git", "diff", "--name-only", fmt.Sprintf("%s..HEAD", baseCommit))
+	out, err := cmd.Output()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error getting changed files against %s: %v\n", baseCommit, err)
+		return nil, nil
+	}
+	raw := strings.TrimSpace(string(out))
+	if raw == "" {
+		return nil, nil
+	}
+	var files []string
+	for _, f := range strings.Split(raw, "\n") {
+		f = strings.TrimSpace(f)
+		if f != "" {
+			files = append(files, f)
+		}
+	}
+	return files, nil
+}
+
+// ShouldIgnoreFile checks if a file should be ignored for build impact analysis.
+func ShouldIgnoreFile(filePath string) bool {
+	if strings.HasPrefix(filePath, ".github/workflows/") || strings.HasPrefix(filePath, ".github/actions/") {
+		return true
+	}
+	if strings.HasPrefix(filePath, "docs/") || strings.HasSuffix(filePath, ".md") {
+		return true
+	}
+	if strings.HasSuffix(filePath, "copilot-instructions.md") {
+		return true
+	}
+	return false
+}
+
+// DetectChangedApps detects which apps have changed compared to a base commit.
+// If baseCommit is empty, returns all apps.
+func DetectChangedApps(baseCommit string) ([]AppInfo, error) {
+	allApps, err := ListAllApps()
+	if err != nil {
+		return nil, err
+	}
+
+	if baseCommit == "" {
+		fmt.Fprintln(os.Stderr, "No base commit specified, considering all apps as changed")
+		return allApps, nil
+	}
+
+	changedFiles, err := GetChangedFiles(baseCommit)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(changedFiles) == 0 {
+		fmt.Fprintln(os.Stderr, "No files changed, no apps need to be built")
+		return nil, nil
+	}
+
+	preview := changedFiles
+	if len(preview) > 10 {
+		preview = preview[:10]
+	}
+	suffix := ""
+	if len(changedFiles) > 10 {
+		suffix = fmt.Sprintf(" (and %d more)", len(changedFiles)-10)
+	}
+	fmt.Fprintf(os.Stderr, "Changed files: %s%s\n", strings.Join(preview, ", "), suffix)
+
+	// Filter out non-build files
+	var relevantFiles []string
+	for _, f := range changedFiles {
+		if !ShouldIgnoreFile(f) {
+			relevantFiles = append(relevantFiles, f)
+		}
+	}
+
+	if len(relevantFiles) == 0 {
+		fmt.Fprintln(os.Stderr, "All changed files are non-build artifacts (workflows, docs, etc.). No apps need to be built.")
+		return nil, nil
+	}
+
+	if len(relevantFiles) < len(changedFiles) {
+		fmt.Fprintf(os.Stderr, "Filtered out %d non-build files (workflows, docs, etc.)\n", len(changedFiles)-len(relevantFiles))
+	}
+
+	fmt.Fprintf(os.Stderr, "Analyzing %d changed files using Bazel query...\n", len(relevantFiles))
+
+	// Convert git file paths to Bazel labels
+	var fileLabels []string
+	changedPackages := make(map[string]bool)
+
+	for _, f := range relevantFiles {
+		if strings.HasSuffix(f, ".bzl") {
+			continue
+		}
+
+		base := filepath.Base(f)
+		if base == "BUILD" || base == "BUILD.bazel" {
+			dir := filepath.Dir(f)
+			if dir == "." {
+				changedPackages["//"] = true
+			} else {
+				changedPackages[fmt.Sprintf("//%s", dir)] = true
+			}
+			continue
+		}
+
+		parts := strings.Split(f, "/")
+		if len(parts) < 2 {
+			fileLabels = append(fileLabels, fmt.Sprintf("//:%s", f))
+		} else {
+			pkg := strings.Join(parts[:len(parts)-1], "/")
+			filename := parts[len(parts)-1]
+			fileLabels = append(fileLabels, fmt.Sprintf("//%s:%s", pkg, filename))
+		}
+	}
+
+	if len(fileLabels) == 0 && len(changedPackages) == 0 {
+		fmt.Fprintln(os.Stderr, "No file labels to analyze")
+		return nil, nil
+	}
+
+	// Validate labels in batch
+	var validLabels []string
+	if len(fileLabels) > 0 {
+		labelsExpr := strings.Join(fileLabels, " + ")
+		result, err := RunBazel([]string{"query", labelsExpr, "--output=label"}, true, nil)
+		if err != nil {
+			// Fall back to individual validation
+			for _, label := range fileLabels {
+				result, err := RunBazel([]string{"query", label, "--output=label"}, true, nil)
+				if err == nil && strings.TrimSpace(result.Stdout) != "" {
+					validLabels = append(validLabels, label)
+				}
+			}
+		} else if strings.TrimSpace(result.Stdout) != "" {
+			validLabels = strings.Split(strings.TrimSpace(result.Stdout), "\n")
+		}
+	}
+
+	if len(validLabels) == 0 && len(changedPackages) == 0 {
+		fmt.Fprintln(os.Stderr, "No valid Bazel targets in changed files")
+		return nil, nil
+	}
+
+	// Query rdeps for all valid labels and changed packages
+	var queryParts []string
+	if len(validLabels) > 0 {
+		queryParts = append(queryParts, strings.Join(validLabels, " + "))
+	}
+	for pkg := range changedPackages {
+		queryParts = append(queryParts, pkg+"/...")
+	}
+
+	if len(queryParts) == 0 {
+		fmt.Fprintln(os.Stderr, "No query parts to analyze")
+		return nil, nil
+	}
+
+	labelsExpr := strings.Join(queryParts, " + ")
+	result, err := RunBazel([]string{"query", fmt.Sprintf("rdeps(//..., %s)", labelsExpr), "--output=label"}, true, nil)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error querying reverse dependencies: %v\n", err)
+		return nil, nil
+	}
+
+	allAffectedTargets := make(map[string]bool)
+	if strings.TrimSpace(result.Stdout) != "" {
+		for _, t := range strings.Split(strings.TrimSpace(result.Stdout), "\n") {
+			allAffectedTargets[t] = true
+		}
+	}
+
+	if len(allAffectedTargets) == 0 {
+		fmt.Fprintln(os.Stderr, "No targets affected by changed files")
+		return nil, nil
+	}
+
+	// Find app_metadata targets that depend on affected targets
+	metaResult, err := RunBazel([]string{"query", "kind('app_metadata', //...)", "--output=label"}, true, nil)
+	if err != nil {
+		return nil, nil
+	}
+
+	allMetadataTargets := make(map[string]bool)
+	if strings.TrimSpace(metaResult.Stdout) != "" {
+		for _, t := range strings.Split(strings.TrimSpace(metaResult.Stdout), "\n") {
+			allMetadataTargets[t] = true
+		}
+	}
+
+	if len(allMetadataTargets) == 0 {
+		fmt.Fprintln(os.Stderr, "No app_metadata targets found")
+		return nil, nil
+	}
+
+	var metaTargetList []string
+	for t := range allMetadataTargets {
+		metaTargetList = append(metaTargetList, t)
+	}
+	var affectedTargetList []string
+	for t := range allAffectedTargets {
+		affectedTargetList = append(affectedTargetList, t)
+	}
+
+	metadataExpr := strings.Join(metaTargetList, " + ")
+	affectedExpr := strings.Join(affectedTargetList, " + ")
+
+	rdepsResult, err := RunBazel([]string{"query", fmt.Sprintf("rdeps(%s, %s)", metadataExpr, affectedExpr), "--output=label"}, true, nil)
+	if err != nil {
+		return nil, nil
+	}
+
+	allAffectedMetadata := make(map[string]bool)
+	if strings.TrimSpace(rdepsResult.Stdout) != "" {
+		for _, t := range strings.Split(strings.TrimSpace(rdepsResult.Stdout), "\n") {
+			allAffectedMetadata[t] = true
+		}
+	}
+
+	if len(allAffectedMetadata) == 0 {
+		fmt.Fprintln(os.Stderr, "No apps affected by changed files")
+		return nil, nil
+	}
+
+	var affectedApps []AppInfo
+	for _, app := range allApps {
+		if allAffectedMetadata[app.BazelTarget] {
+			affectedApps = append(affectedApps, app)
+			fmt.Fprintf(os.Stderr, "  %s: affected by changes\n", app.Name)
+		}
+	}
+
+	return affectedApps, nil
+}

--- a/tools/kraken/changes_test.go
+++ b/tools/kraken/changes_test.go
@@ -1,0 +1,45 @@
+package kraken
+
+import (
+	"testing"
+)
+
+func TestShouldIgnoreFileGitHubWorkflows(t *testing.T) {
+	if !ShouldIgnoreFile(".github/workflows/ci.yml") {
+		t.Error("expected .github/workflows/ci.yml to be ignored")
+	}
+	if !ShouldIgnoreFile(".github/actions/setup/action.yml") {
+		t.Error("expected .github/actions/setup/action.yml to be ignored")
+	}
+}
+
+func TestShouldIgnoreFileDocs(t *testing.T) {
+	if !ShouldIgnoreFile("docs/README.md") {
+		t.Error("expected docs/README.md to be ignored")
+	}
+	if !ShouldIgnoreFile("CHANGELOG.md") {
+		t.Error("expected CHANGELOG.md to be ignored")
+	}
+}
+
+func TestShouldIgnoreFileCopilotInstructions(t *testing.T) {
+	if !ShouldIgnoreFile("copilot-instructions.md") {
+		t.Error("expected copilot-instructions.md to be ignored")
+	}
+}
+
+func TestShouldNotIgnoreSourceFiles(t *testing.T) {
+	files := []string{
+		"main.py",
+		"tools/release_helper/core.py",
+		"demo/hello_python/main.py",
+		"BUILD.bazel",
+		"go.mod",
+	}
+
+	for _, f := range files {
+		if ShouldIgnoreFile(f) {
+			t.Errorf("expected %s to NOT be ignored", f)
+		}
+	}
+}

--- a/tools/kraken/cleanup.go
+++ b/tools/kraken/cleanup.go
@@ -1,0 +1,416 @@
+package kraken
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+// CleanupPlan holds the plan for cleaning up tags and packages.
+type CleanupPlan struct {
+	TagsToDelete     []string
+	TagsToKeep       []string
+	PackagesToDelete map[string][]int    // package name -> version IDs
+	ReleasesToDelete map[string]int      // tag name -> release ID
+	RetentionPolicy  map[string]int
+}
+
+// TotalTagDeletions returns the total number of tags to delete.
+func (p *CleanupPlan) TotalTagDeletions() int {
+	return len(p.TagsToDelete)
+}
+
+// TotalPackageDeletions returns the total number of package versions to delete.
+func (p *CleanupPlan) TotalPackageDeletions() int {
+	total := 0
+	for _, versions := range p.PackagesToDelete {
+		total += len(versions)
+	}
+	return total
+}
+
+// TotalReleaseDeletions returns the total number of releases to delete.
+func (p *CleanupPlan) TotalReleaseDeletions() int {
+	return len(p.ReleasesToDelete)
+}
+
+// IsEmpty checks if the cleanup plan is empty.
+func (p *CleanupPlan) IsEmpty() bool {
+	return len(p.TagsToDelete) == 0 && len(p.PackagesToDelete) == 0 && len(p.ReleasesToDelete) == 0
+}
+
+// CleanupResult holds the result of cleanup execution.
+type CleanupResult struct {
+	TagsDeleted     []string
+	PackagesDeleted map[string][]int
+	ReleasesDeleted []string
+	Errors          []string
+	DryRun          bool
+}
+
+// IsSuccessful checks if cleanup was successful (no errors).
+func (r *CleanupResult) IsSuccessful() bool {
+	return len(r.Errors) == 0
+}
+
+// Summary generates a summary of the cleanup result.
+func (r *CleanupResult) Summary() string {
+	var lines []string
+	lines = append(lines, fmt.Sprintf("Tags deleted: %d", len(r.TagsDeleted)))
+	lines = append(lines, fmt.Sprintf("Releases deleted: %d", len(r.ReleasesDeleted)))
+
+	totalPackages := 0
+	for _, versions := range r.PackagesDeleted {
+		totalPackages += len(versions)
+	}
+	lines = append(lines, fmt.Sprintf("Package versions deleted: %d", totalPackages))
+
+	if len(r.Errors) > 0 {
+		lines = append(lines, fmt.Sprintf("Errors encountered: %d", len(r.Errors)))
+	}
+
+	if r.DryRun {
+		lines = append(lines, "(Dry run - no actual deletions)")
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+// ReleaseCleanup orchestrates cleanup of Git tags, GitHub Releases, and GHCR packages.
+type ReleaseCleanup struct {
+	Owner         string
+	Repo          string
+	GHCRClient    *GHCRClient
+	ReleaseClient *GitHubReleaseClient
+}
+
+// NewReleaseCleanup creates a new cleanup orchestrator.
+func NewReleaseCleanup(owner, repo, token string) (*ReleaseCleanup, error) {
+	ghcrClient, err := NewGHCRClient(owner, token)
+	if err != nil {
+		return nil, err
+	}
+
+	releaseClient, err := NewGitHubReleaseClient(owner, repo, token)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ReleaseCleanup{
+		Owner:         owner,
+		Repo:          repo,
+		GHCRClient:    ghcrClient,
+		ReleaseClient: releaseClient,
+	}, nil
+}
+
+// PlanCleanup plans what tags, releases, and packages to delete.
+func (rc *ReleaseCleanup) PlanCleanup(keepMinorVersions, minAgeDays int) (*CleanupPlan, error) {
+	allTags, err := GetAllTags()
+	if err != nil {
+		return nil, err
+	}
+
+	tagsToDelete, tagsToKeep := IdentifyTagsToPrune(allTags, keepMinorVersions, minAgeDays)
+
+	// Find corresponding GitHub Releases
+	releasesToDelete := make(map[string]int)
+	releasesMap, err := rc.ReleaseClient.FindReleasesByTags(tagsToDelete)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "⚠️  Error finding GitHub releases: %v\n", err)
+	} else {
+		for tagName, releaseData := range releasesMap {
+			if releaseData == nil {
+				continue
+			}
+			id, ok := releaseData["id"]
+			if !ok {
+				continue
+			}
+			if idFloat, ok := id.(float64); ok {
+				releasesToDelete[tagName] = int(idFloat)
+				fmt.Printf("  Found GitHub release %d for tag %s\n", int(idFloat), tagName)
+			}
+		}
+	}
+
+	// Map tags to GHCR packages
+	packagesToDelete := make(map[string][]int)
+	tagPackageRegex := regexp.MustCompile(`^([^.]+)\.v\d+\.\d+\.\d+`)
+	tagVersionRegex := regexp.MustCompile(`(v\d+\.\d+\.\d+(?:-[a-zA-Z0-9\-\.]+)?)`)
+
+	for _, tag := range tagsToDelete {
+		match := tagPackageRegex.FindStringSubmatch(tag)
+		if match == nil {
+			fmt.Fprintf(os.Stderr, "⚠️  Could not parse package name from tag: %s\n", tag)
+			continue
+		}
+		packageName := match[1]
+
+		vMatch := tagVersionRegex.FindStringSubmatch(tag)
+		if vMatch == nil {
+			fmt.Fprintf(os.Stderr, "⚠️  Could not extract version from tag: %s\n", tag)
+			continue
+		}
+		version := vMatch[1]
+
+		allVersions, err := rc.GHCRClient.ListPackageVersions(packageName)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "⚠️  Error finding GHCR versions for %s: %v\n", packageName, err)
+			continue
+		}
+
+		for _, pkgVersion := range allVersions {
+			if pkgVersion.HasTag(version) {
+				packagesToDelete[packageName] = append(packagesToDelete[packageName], pkgVersion.VersionID)
+				fmt.Printf("  Found GHCR version %d for %s:%s\n", pkgVersion.VersionID, packageName, version)
+			}
+		}
+	}
+
+	return &CleanupPlan{
+		TagsToDelete:     tagsToDelete,
+		TagsToKeep:       tagsToKeep,
+		PackagesToDelete: packagesToDelete,
+		ReleasesToDelete: releasesToDelete,
+		RetentionPolicy: map[string]int{
+			"keep_minor_versions": keepMinorVersions,
+			"min_age_days":        minAgeDays,
+		},
+	}, nil
+}
+
+// ExecuteCleanup executes the cleanup plan.
+func (rc *ReleaseCleanup) ExecuteCleanup(plan *CleanupPlan, dryRun bool) *CleanupResult {
+	result := &CleanupResult{
+		DryRun:          dryRun,
+		PackagesDeleted: make(map[string][]int),
+	}
+
+	if dryRun {
+		fmt.Println("🧪 DRY RUN MODE - No actual deletions will occur")
+		fmt.Println()
+	}
+
+	// Phase 1: Delete GitHub Releases
+	if len(plan.ReleasesToDelete) > 0 {
+		fmt.Printf("🗑 Deleting %d GitHub releases...\n", len(plan.ReleasesToDelete))
+		for tagName, releaseID := range plan.ReleasesToDelete {
+			if dryRun {
+				fmt.Printf("  [DRY RUN] Would delete release %d for tag: %s\n", releaseID, tagName)
+				result.ReleasesDeleted = append(result.ReleasesDeleted, tagName)
+			} else {
+				success := rc.ReleaseClient.DeleteRelease(releaseID)
+				if success {
+					result.ReleasesDeleted = append(result.ReleasesDeleted, tagName)
+					fmt.Printf("  ✅ Deleted release %d for tag: %s\n", releaseID, tagName)
+				} else {
+					errMsg := fmt.Sprintf("Failed to delete release %d for tag: %s", releaseID, tagName)
+					result.Errors = append(result.Errors, errMsg)
+					fmt.Fprintf(os.Stderr, "  ❌ %s\n", errMsg)
+				}
+			}
+		}
+		fmt.Println()
+	}
+
+	// Phase 2: Delete Git tags
+	fmt.Printf("🏷️  Deleting %d Git tags...\n", len(plan.TagsToDelete))
+	for _, tag := range plan.TagsToDelete {
+		if dryRun {
+			fmt.Printf("  [DRY RUN] Would delete tag: %s\n", tag)
+			result.TagsDeleted = append(result.TagsDeleted, tag)
+		} else {
+			success := DeleteRemoteTag(tag, rc.Owner, rc.Repo)
+			if success {
+				result.TagsDeleted = append(result.TagsDeleted, tag)
+				fmt.Printf("  ✅ Deleted tag: %s\n", tag)
+			} else {
+				errMsg := fmt.Sprintf("Failed to delete tag: %s", tag)
+				result.Errors = append(result.Errors, errMsg)
+				fmt.Fprintf(os.Stderr, "  ❌ %s\n", errMsg)
+			}
+		}
+	}
+
+	// Phase 3: Delete GHCR packages
+	totalPackages := plan.TotalPackageDeletions()
+	if totalPackages > 0 {
+		fmt.Printf("\n📦 Deleting %d GHCR package versions...\n", totalPackages)
+		for packageName, versionIDs := range plan.PackagesToDelete {
+			for _, versionID := range versionIDs {
+				if dryRun {
+					fmt.Printf("  [DRY RUN] Would delete %s version %d\n", packageName, versionID)
+					result.PackagesDeleted[packageName] = append(result.PackagesDeleted[packageName], versionID)
+				} else {
+					success, err := rc.GHCRClient.DeletePackageVersion(packageName, versionID)
+					if err != nil || !success {
+						errMsg := fmt.Sprintf("Error deleting %s version %d", packageName, versionID)
+						result.Errors = append(result.Errors, errMsg)
+						fmt.Fprintf(os.Stderr, "  ❌ %s\n", errMsg)
+					} else {
+						result.PackagesDeleted[packageName] = append(result.PackagesDeleted[packageName], versionID)
+						fmt.Printf("  ✅ Deleted %s version %d\n", packageName, versionID)
+					}
+				}
+			}
+		}
+	}
+
+	return result
+}
+
+// GetTagCreationDate gets the creation date of a Git tag.
+func GetTagCreationDate(tag string) *time.Time {
+	cmd := exec.Command("git", "log", "-1", "--format=%ai", tag)
+	out, err := cmd.Output()
+	if err != nil {
+		return nil
+	}
+	dateStr := strings.TrimSpace(string(out))
+	if dateStr == "" {
+		return nil
+	}
+	// Parse format: 2025-01-15 10:30:45 -0800
+	if len(dateStr) >= 19 {
+		t, err := time.Parse("2006-01-02 15:04:05", dateStr[:19])
+		if err != nil {
+			return nil
+		}
+		return &t
+	}
+	return nil
+}
+
+// DeleteRemoteTag deletes a Git tag from the remote repository.
+func DeleteRemoteTag(tagName, owner, repo string) bool {
+	cmd := exec.Command("git", "push", "--delete", "origin", tagName)
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "❌ Failed to delete remote tag %s: %v\n", tagName, err)
+		return false
+	}
+	return true
+}
+
+type tagVersion struct {
+	tag   string
+	major int
+	minor int
+	patch int
+}
+
+// IdentifyTagsToPrune identifies which tags should be pruned based on retention policy.
+func IdentifyTagsToPrune(allTags []string, keepMinorVersions, minAgeDays int) (tagsToDelete, tagsToKeep []string) {
+	tagRegex := regexp.MustCompile(`^([^.]+)\.(v\d+\.\d+\.\d+)`)
+
+	// Group tags by app/chart
+	tagsByApp := make(map[string][]tagVersion)
+
+	for _, tag := range allTags {
+		match := tagRegex.FindStringSubmatch(tag)
+		if match == nil {
+			continue
+		}
+		appName := match[1]
+		versionStr := match[2]
+
+		sv, err := ParseSemanticVersion(versionStr)
+		if err != nil {
+			continue
+		}
+
+		tagsByApp[appName] = append(tagsByApp[appName], tagVersion{
+			tag:   tag,
+			major: sv.Major,
+			minor: sv.Minor,
+			patch: sv.Patch,
+		})
+	}
+
+	// Process each app independently
+	for _, appTags := range tagsByApp {
+		// Step 1: Group by minor version and keep only latest patch
+		type minorKey struct{ major, minor int }
+		minorVersions := make(map[minorKey]tagVersion)
+
+		for _, tv := range appTags {
+			mk := minorKey{tv.major, tv.minor}
+			if existing, ok := minorVersions[mk]; !ok || tv.patch > existing.patch {
+				minorVersions[mk] = tv
+			}
+		}
+
+		// Step 2: Separate latest patches from old patches
+		var keptLatestPatches []tagVersion
+		for _, tv := range appTags {
+			mk := minorKey{tv.major, tv.minor}
+			latestTV := minorVersions[mk]
+
+			if tv.tag == latestTV.tag {
+				keptLatestPatches = append(keptLatestPatches, tv)
+			} else {
+				// Old patch - check age
+				tagDate := GetTagCreationDate(tv.tag)
+				if tagDate != nil {
+					ageDays := int(time.Since(*tagDate).Hours() / 24)
+					if ageDays >= minAgeDays {
+						tagsToDelete = append(tagsToDelete, tv.tag)
+						continue
+					}
+				}
+				tagsToKeep = append(tagsToKeep, tv.tag)
+			}
+		}
+
+		// Step 3: Sort latest patches by version (newest first)
+		sort.Slice(keptLatestPatches, func(i, j int) bool {
+			if keptLatestPatches[i].major != keptLatestPatches[j].major {
+				return keptLatestPatches[i].major > keptLatestPatches[j].major
+			}
+			return keptLatestPatches[i].minor > keptLatestPatches[j].minor
+		})
+
+		// Step 4: Find latest minor per major (for protection)
+		latestPerMajor := make(map[int]tagVersion)
+		for _, tv := range keptLatestPatches {
+			if existing, ok := latestPerMajor[tv.major]; !ok || tv.minor > existing.minor {
+				latestPerMajor[tv.major] = tv
+			}
+		}
+
+		protectedTags := make(map[string]bool)
+		if len(latestPerMajor) > 1 {
+			for _, tv := range latestPerMajor {
+				protectedTags[tv.tag] = true
+			}
+		}
+
+		// Step 5: Apply retention policy
+		hasEnoughVersions := len(keptLatestPatches) >= keepMinorVersions
+
+		for idx, tv := range keptLatestPatches {
+			tagDate := GetTagCreationDate(tv.tag)
+			if tagDate != nil {
+				ageDays := int(time.Since(*tagDate).Hours() / 24)
+				if ageDays < minAgeDays {
+					tagsToKeep = append(tagsToKeep, tv.tag)
+					continue
+				}
+			}
+
+			if hasEnoughVersions && idx < keepMinorVersions {
+				tagsToKeep = append(tagsToKeep, tv.tag)
+			} else if protectedTags[tv.tag] {
+				tagsToKeep = append(tagsToKeep, tv.tag)
+			} else {
+				tagsToDelete = append(tagsToDelete, tv.tag)
+			}
+		}
+	}
+
+	return tagsToDelete, tagsToKeep
+}

--- a/tools/kraken/cleanup_test.go
+++ b/tools/kraken/cleanup_test.go
@@ -1,0 +1,146 @@
+package kraken
+
+import (
+	"testing"
+)
+
+func TestCleanupPlanTotalTagDeletions(t *testing.T) {
+	plan := &CleanupPlan{
+		TagsToDelete: []string{"tag1", "tag2", "tag3"},
+	}
+	if plan.TotalTagDeletions() != 3 {
+		t.Errorf("expected 3, got %d", plan.TotalTagDeletions())
+	}
+}
+
+func TestCleanupPlanTotalPackageDeletions(t *testing.T) {
+	plan := &CleanupPlan{
+		PackagesToDelete: map[string][]int{
+			"pkg1": {1, 2},
+			"pkg2": {3},
+		},
+	}
+	if plan.TotalPackageDeletions() != 3 {
+		t.Errorf("expected 3, got %d", plan.TotalPackageDeletions())
+	}
+}
+
+func TestCleanupPlanTotalReleaseDeletions(t *testing.T) {
+	plan := &CleanupPlan{
+		ReleasesToDelete: map[string]int{
+			"tag1": 100,
+			"tag2": 200,
+		},
+	}
+	if plan.TotalReleaseDeletions() != 2 {
+		t.Errorf("expected 2, got %d", plan.TotalReleaseDeletions())
+	}
+}
+
+func TestCleanupPlanIsEmpty(t *testing.T) {
+	emptyPlan := &CleanupPlan{
+		PackagesToDelete: make(map[string][]int),
+		ReleasesToDelete: make(map[string]int),
+	}
+	if !emptyPlan.IsEmpty() {
+		t.Error("expected empty plan")
+	}
+
+	nonEmptyPlan := &CleanupPlan{
+		TagsToDelete:     []string{"tag1"},
+		PackagesToDelete: make(map[string][]int),
+		ReleasesToDelete: make(map[string]int),
+	}
+	if nonEmptyPlan.IsEmpty() {
+		t.Error("expected non-empty plan")
+	}
+}
+
+func TestCleanupResultIsSuccessful(t *testing.T) {
+	successResult := &CleanupResult{}
+	if !successResult.IsSuccessful() {
+		t.Error("expected successful result")
+	}
+
+	failResult := &CleanupResult{
+		Errors: []string{"some error"},
+	}
+	if failResult.IsSuccessful() {
+		t.Error("expected unsuccessful result")
+	}
+}
+
+func TestCleanupResultSummary(t *testing.T) {
+	result := &CleanupResult{
+		TagsDeleted:     []string{"tag1", "tag2"},
+		ReleasesDeleted: []string{"tag1"},
+		PackagesDeleted: map[string][]int{
+			"pkg1": {1, 2},
+		},
+		DryRun: true,
+	}
+
+	summary := result.Summary()
+	if summary == "" {
+		t.Error("expected non-empty summary")
+	}
+	// Check key parts of summary
+	if !containsStr(summary, "Tags deleted: 2") {
+		t.Error("expected tags deleted count in summary")
+	}
+	if !containsStr(summary, "Releases deleted: 1") {
+		t.Error("expected releases deleted count in summary")
+	}
+	if !containsStr(summary, "Package versions deleted: 2") {
+		t.Error("expected package versions deleted count in summary")
+	}
+	if !containsStr(summary, "Dry run") {
+		t.Error("expected dry run indicator in summary")
+	}
+}
+
+func TestCleanupResultSummaryWithErrors(t *testing.T) {
+	result := &CleanupResult{
+		Errors:          []string{"error1", "error2"},
+		PackagesDeleted: make(map[string][]int),
+	}
+
+	summary := result.Summary()
+	if !containsStr(summary, "Errors encountered: 2") {
+		t.Error("expected errors count in summary")
+	}
+}
+
+func TestIdentifyTagsToPruneEmptyTags(t *testing.T) {
+	toDelete, toKeep := IdentifyTagsToPrune(nil, 2, 14)
+	if len(toDelete) != 0 {
+		t.Errorf("expected 0 deletions, got %d", len(toDelete))
+	}
+	if len(toKeep) != 0 {
+		t.Errorf("expected 0 keeps, got %d", len(toKeep))
+	}
+}
+
+func TestIdentifyTagsToPruneInvalidTags(t *testing.T) {
+	tags := []string{"not-a-valid-tag", "another-invalid"}
+	toDelete, toKeep := IdentifyTagsToPrune(tags, 2, 14)
+	if len(toDelete) != 0 {
+		t.Errorf("expected 0 deletions for invalid tags, got %d", len(toDelete))
+	}
+	if len(toKeep) != 0 {
+		t.Errorf("expected 0 keeps for invalid tags, got %d", len(toKeep))
+	}
+}
+
+func containsStr(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsSubstring(s, substr))
+}
+
+func containsSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/tools/kraken/cmd/kraken/BUILD.bazel
+++ b/tools/kraken/cmd/kraken/BUILD.bazel
@@ -1,0 +1,11 @@
+load("@rules_go//go:def.bzl", "go_binary")
+
+go_binary(
+    name = "kraken",
+    srcs = ["main.go"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//tools/kraken:kraken_lib",
+        "@com_github_spf13_cobra//:cobra",
+    ],
+)

--- a/tools/kraken/cmd/kraken/main.go
+++ b/tools/kraken/cmd/kraken/main.go
@@ -1,0 +1,328 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/whale-net/everything/tools/kraken"
+)
+
+func main() {
+	root := &cobra.Command{
+		Use:   "kraken",
+		Short: "Release management tool for the Everything monorepo",
+	}
+
+	root.AddCommand(
+		newListCmd(),
+		newChangesCmd(),
+		newBuildCmd(),
+		newPlanCmd(),
+		newReleaseCmd(),
+		newReleaseMultiarchCmd(),
+		newReleaseNotesCmd(),
+		newSummaryCmd(),
+		newCreateReleaseCmd(),
+	)
+
+	if err := root.Execute(); err != nil {
+		os.Exit(1)
+	}
+}
+
+func newListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List all discoverable apps",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			apps, err := kraken.ListAllApps()
+			if err != nil {
+				return err
+			}
+
+			fmt.Printf("%-30s %-15s %-10s %s\n", "APP", "DOMAIN", "LANGUAGE", "BAZEL TARGET")
+			fmt.Println(strings.Repeat("-", 90))
+			for _, app := range apps {
+				fmt.Printf("%-30s %-15s %-10s %s\n", app.Name, app.Domain, app.Language, app.BazelTarget)
+			}
+			fmt.Printf("\nTotal: %d apps\n", len(apps))
+			return nil
+		},
+	}
+}
+
+func newChangesCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "changes [base-commit]",
+		Short: "Detect apps with changes since a base commit",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var baseCommit string
+			if len(args) > 0 {
+				baseCommit = args[0]
+			}
+
+			apps, err := kraken.DetectChangedApps(baseCommit)
+			if err != nil {
+				return err
+			}
+
+			if len(apps) == 0 {
+				fmt.Println("No apps with changes detected")
+				return nil
+			}
+
+			fmt.Printf("Changed apps (%d):\n", len(apps))
+			for _, app := range apps {
+				fmt.Printf("  %s-%s\n", app.Domain, app.Name)
+			}
+			return nil
+		},
+	}
+}
+
+func newBuildCmd() *cobra.Command {
+	var platform string
+
+	cmd := &cobra.Command{
+		Use:   "build <app>",
+		Short: "Build and load a container image",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			bazelTarget, err := kraken.FindAppBazelTarget(args[0])
+			if err != nil {
+				return err
+			}
+
+			imageName, err := kraken.BuildImage(bazelTarget, platform)
+			if err != nil {
+				return err
+			}
+
+			fmt.Printf("Successfully built: %s\n", imageName)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&platform, "platform", "", "Target platform (amd64 or arm64)")
+	return cmd
+}
+
+func newPlanCmd() *cobra.Command {
+	var (
+		eventType   string
+		apps        string
+		version     string
+		versionMode string
+		baseCommit  string
+		includeDemo bool
+		outputJSON  bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "plan",
+		Short: "Plan a release and output the build matrix",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			plan, err := kraken.PlanRelease(eventType, apps, version, versionMode, baseCommit, includeDemo)
+			if err != nil {
+				return err
+			}
+
+			if outputJSON {
+				data, err := json.MarshalIndent(plan, "", "  ")
+				if err != nil {
+					return err
+				}
+				fmt.Println(string(data))
+				return nil
+			}
+
+			if len(plan.Matrix.Include) == 0 {
+				fmt.Println("No apps to release")
+			} else {
+				fmt.Printf("Release plan (%d apps):\n", len(plan.Matrix.Include))
+				for _, entry := range plan.Matrix.Include {
+					fmt.Printf("  %s-%s: %s\n", entry.Domain, entry.App, entry.Version)
+				}
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&eventType, "event-type", "workflow_dispatch", "Event type (workflow_dispatch, tag_push, pull_request, push)")
+	cmd.Flags().StringVar(&apps, "apps", "", "Comma-separated app list or 'all'")
+	cmd.Flags().StringVar(&version, "version", "", "Release version (e.g. v1.0.0)")
+	cmd.Flags().StringVar(&versionMode, "version-mode", "", "Version mode (specific, increment_minor, increment_patch)")
+	cmd.Flags().StringVar(&baseCommit, "base-commit", "", "Base commit for change detection")
+	cmd.Flags().BoolVar(&includeDemo, "include-demo", false, "Include demo domain when using 'all'")
+	cmd.Flags().BoolVar(&outputJSON, "json", false, "Output as JSON")
+	return cmd
+}
+
+func newReleaseCmd() *cobra.Command {
+	var (
+		version        string
+		commitSHA      string
+		dryRun         bool
+		allowOverwrite bool
+		createGitTag   bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "release <app>",
+		Short: "Tag and push a container image to registry",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return kraken.TagAndPushImage(args[0], version, commitSHA, dryRun, allowOverwrite, createGitTag)
+		},
+	}
+
+	cmd.Flags().StringVar(&version, "version", "", "Release version (required)")
+	cmd.Flags().StringVar(&commitSHA, "commit-sha", "", "Commit SHA for tagging")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Print actions without executing")
+	cmd.Flags().BoolVar(&allowOverwrite, "allow-overwrite", false, "Allow overwriting existing versions")
+	cmd.Flags().BoolVar(&createGitTag, "create-git-tag", false, "Create and push a Git tag")
+	cmd.MarkFlagRequired("version")
+	return cmd
+}
+
+func newReleaseMultiarchCmd() *cobra.Command {
+	var (
+		version   string
+		registry  string
+		commitSHA string
+		dryRun    bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "release-multiarch <app>",
+		Short: "Release a multi-architecture OCI image",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			bazelTarget, err := kraken.FindAppBazelTarget(args[0])
+			if err != nil {
+				return err
+			}
+
+			if dryRun {
+				fmt.Printf("DRY RUN: Would release multi-arch image for %s version %s\n", args[0], version)
+				return nil
+			}
+
+			return kraken.ReleaseMultiarchImage(bazelTarget, version, registry, nil, commitSHA)
+		},
+	}
+
+	cmd.Flags().StringVar(&version, "version", "", "Release version (required)")
+	cmd.Flags().StringVar(&registry, "registry", "ghcr.io", "Container registry")
+	cmd.Flags().StringVar(&commitSHA, "commit-sha", "", "Commit SHA for tagging")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Print actions without executing")
+	cmd.MarkFlagRequired("version")
+	return cmd
+}
+
+func newReleaseNotesCmd() *cobra.Command {
+	var (
+		tag         string
+		previousTag string
+		formatType  string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "release-notes <app>",
+		Short: "Generate release notes for an app",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			notes, err := kraken.GenerateReleaseNotes(args[0], tag, previousTag, formatType)
+			if err != nil {
+				return err
+			}
+			fmt.Println(notes)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&tag, "tag", "", "Current release tag (required)")
+	cmd.Flags().StringVar(&previousTag, "previous-tag", "", "Previous release tag")
+	cmd.Flags().StringVar(&formatType, "format", "markdown", "Output format (markdown, plain, json)")
+	cmd.MarkFlagRequired("tag")
+	return cmd
+}
+
+func newSummaryCmd() *cobra.Command {
+	var (
+		matrixJSON      string
+		version         string
+		eventType       string
+		dryRun          bool
+		repositoryOwner string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "summary",
+		Short: "Generate a release summary for GitHub Actions",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			summary := kraken.GenerateReleaseSummary(matrixJSON, version, eventType, dryRun, repositoryOwner)
+			fmt.Println(summary)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&matrixJSON, "matrix", "", "Release matrix JSON")
+	cmd.Flags().StringVar(&version, "version", "", "Release version")
+	cmd.Flags().StringVar(&eventType, "event-type", "", "Event type")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Dry run mode")
+	cmd.Flags().StringVar(&repositoryOwner, "repository-owner", "", "GitHub repository owner")
+	return cmd
+}
+
+func newCreateReleaseCmd() *cobra.Command {
+	var (
+		version      string
+		owner        string
+		repo         string
+		commitSHA    string
+		artifactsDir string
+		dryRun       bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "create-release <app>",
+		Short: "Create a GitHub release for an app",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if owner == "" {
+				owner = os.Getenv("GITHUB_REPOSITORY_OWNER")
+				if owner == "" {
+					return fmt.Errorf("--owner is required (or set GITHUB_REPOSITORY_OWNER)")
+				}
+			}
+			if repo == "" {
+				if ghRepo := os.Getenv("GITHUB_REPOSITORY"); ghRepo != "" {
+					parts := strings.SplitN(ghRepo, "/", 2)
+					if len(parts) == 2 {
+						repo = parts[1]
+					}
+				}
+				if repo == "" {
+					return fmt.Errorf("--repo is required (or set GITHUB_REPOSITORY)")
+				}
+			}
+
+			_, err := kraken.CreateReleaseForApp(owner, repo, args[0], version, commitSHA, artifactsDir, dryRun)
+			return err
+		},
+	}
+
+	cmd.Flags().StringVar(&version, "version", "", "Release version (required)")
+	cmd.Flags().StringVar(&owner, "owner", "", "GitHub repository owner")
+	cmd.Flags().StringVar(&repo, "repo", "", "GitHub repository name")
+	cmd.Flags().StringVar(&commitSHA, "commit-sha", "", "Commit SHA")
+	cmd.Flags().StringVar(&artifactsDir, "artifacts-dir", "", "Directory containing build artifacts")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Print actions without executing")
+	cmd.MarkFlagRequired("version")
+	return cmd
+}

--- a/tools/kraken/core.go
+++ b/tools/kraken/core.go
@@ -1,0 +1,99 @@
+package kraken
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// FindWorkspaceRoot locates the Bazel workspace root directory.
+// It checks BUILD_WORKSPACE_DIRECTORY env var first, then walks up
+// looking for WORKSPACE or MODULE.bazel markers.
+func FindWorkspaceRoot() (string, error) {
+	if dir := os.Getenv("BUILD_WORKSPACE_DIRECTORY"); dir != "" {
+		return dir, nil
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("getting working directory: %w", err)
+	}
+
+	dir := cwd
+	for {
+		for _, marker := range []string{"WORKSPACE", "MODULE.bazel"} {
+			if _, err := os.Stat(filepath.Join(dir, marker)); err == nil {
+				return dir, nil
+			}
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+
+	// Fallback to current directory
+	return cwd, nil
+}
+
+// BazelResult holds the output of a bazel command.
+type BazelResult struct {
+	Stdout string
+	Stderr string
+}
+
+// RunBazel executes a bazel command with the given arguments.
+// It runs from the workspace root directory.
+func RunBazel(args []string, captureOutput bool, env []string) (*BazelResult, error) {
+	workspaceRoot, err := FindWorkspaceRoot()
+	if err != nil {
+		return nil, fmt.Errorf("finding workspace root: %w", err)
+	}
+
+	cmdArgs := append([]string{}, args...)
+	cmd := exec.Command("bazel", cmdArgs...)
+	cmd.Dir = workspaceRoot
+
+	if env != nil {
+		cmd.Env = env
+	} else {
+		cmd.Env = os.Environ()
+	}
+
+	if captureOutput {
+		var stdout, stderr strings.Builder
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
+
+		if err := cmd.Run(); err != nil {
+			return nil, fmt.Errorf("bazel command failed: %s\nWorking directory: %s\nstderr: %s\nstdout: %s\n%w",
+				strings.Join(append([]string{"bazel"}, args...), " "),
+				workspaceRoot,
+				stderr.String(),
+				stdout.String(),
+				err,
+			)
+		}
+
+		return &BazelResult{
+			Stdout: stdout.String(),
+			Stderr: stderr.String(),
+		}, nil
+	}
+
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("bazel command failed: %s\nWorking directory: %s\n%w",
+			strings.Join(append([]string{"bazel"}, args...), " "),
+			workspaceRoot,
+			err,
+		)
+	}
+
+	return &BazelResult{}, nil
+}

--- a/tools/kraken/core_test.go
+++ b/tools/kraken/core_test.go
@@ -1,0 +1,123 @@
+package kraken
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFindWorkspaceRootWithBuildWorkspaceDirectory(t *testing.T) {
+	testPath := "/workspace/build/dir"
+	os.Setenv("BUILD_WORKSPACE_DIRECTORY", testPath)
+	defer os.Unsetenv("BUILD_WORKSPACE_DIRECTORY")
+
+	result, err := FindWorkspaceRoot()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != testPath {
+		t.Errorf("expected %s, got %s", testPath, result)
+	}
+}
+
+func TestFindWorkspaceRootWithWorkspaceFile(t *testing.T) {
+	os.Unsetenv("BUILD_WORKSPACE_DIRECTORY")
+
+	// Create a temp directory with a WORKSPACE file
+	tmpDir := t.TempDir()
+	subDir := filepath.Join(tmpDir, "subdir")
+	os.MkdirAll(subDir, 0755)
+	os.WriteFile(filepath.Join(tmpDir, "WORKSPACE"), []byte(""), 0644)
+
+	// Change to subdir
+	origDir, _ := os.Getwd()
+	os.Chdir(subDir)
+	defer os.Chdir(origDir)
+
+	result, err := FindWorkspaceRoot()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != tmpDir {
+		t.Errorf("expected %s, got %s", tmpDir, result)
+	}
+}
+
+func TestFindWorkspaceRootWithModuleBazelFile(t *testing.T) {
+	os.Unsetenv("BUILD_WORKSPACE_DIRECTORY")
+
+	tmpDir := t.TempDir()
+	subDir := filepath.Join(tmpDir, "subdir")
+	os.MkdirAll(subDir, 0755)
+	os.WriteFile(filepath.Join(tmpDir, "MODULE.bazel"), []byte(""), 0644)
+
+	origDir, _ := os.Getwd()
+	os.Chdir(subDir)
+	defer os.Chdir(origDir)
+
+	result, err := FindWorkspaceRoot()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != tmpDir {
+		t.Errorf("expected %s, got %s", tmpDir, result)
+	}
+}
+
+func TestFindWorkspaceRootNoMarkersFound(t *testing.T) {
+	os.Unsetenv("BUILD_WORKSPACE_DIRECTORY")
+
+	tmpDir := t.TempDir()
+	origDir, _ := os.Getwd()
+	os.Chdir(tmpDir)
+	defer os.Chdir(origDir)
+
+	result, err := FindWorkspaceRoot()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Should fall back to current directory
+	if result != tmpDir {
+		t.Errorf("expected %s, got %s", tmpDir, result)
+	}
+}
+
+func TestFindWorkspaceRootCurrentDirectoryHasMarker(t *testing.T) {
+	os.Unsetenv("BUILD_WORKSPACE_DIRECTORY")
+
+	tmpDir := t.TempDir()
+	os.WriteFile(filepath.Join(tmpDir, "MODULE.bazel"), []byte(""), 0644)
+
+	origDir, _ := os.Getwd()
+	os.Chdir(tmpDir)
+	defer os.Chdir(origDir)
+
+	result, err := FindWorkspaceRoot()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != tmpDir {
+		t.Errorf("expected %s, got %s", tmpDir, result)
+	}
+}
+
+func TestFindWorkspaceRootDeepNestedStructure(t *testing.T) {
+	os.Unsetenv("BUILD_WORKSPACE_DIRECTORY")
+
+	tmpDir := t.TempDir()
+	deepDir := filepath.Join(tmpDir, "a", "b", "c", "d")
+	os.MkdirAll(deepDir, 0755)
+	os.WriteFile(filepath.Join(tmpDir, "WORKSPACE"), []byte(""), 0644)
+
+	origDir, _ := os.Getwd()
+	os.Chdir(deepDir)
+	defer os.Chdir(origDir)
+
+	result, err := FindWorkspaceRoot()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != tmpDir {
+		t.Errorf("expected %s, got %s", tmpDir, result)
+	}
+}

--- a/tools/kraken/ghcr.go
+++ b/tools/kraken/ghcr.go
@@ -1,0 +1,291 @@
+package kraken
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+const defaultTimeout = 30 * time.Second
+
+// GHCRPackageVersion represents a GHCR package version.
+type GHCRPackageVersion struct {
+	VersionID int      `json:"id"`
+	Tags      []string `json:"tags"`
+	CreatedAt string   `json:"created_at,omitempty"`
+	UpdatedAt string   `json:"updated_at,omitempty"`
+}
+
+// HasTag checks if this version has a specific tag.
+func (v *GHCRPackageVersion) HasTag(tag string) bool {
+	for _, t := range v.Tags {
+		if t == tag {
+			return true
+		}
+	}
+	return false
+}
+
+// IsUntagged checks if this version has no tags.
+func (v *GHCRPackageVersion) IsUntagged() bool {
+	return len(v.Tags) == 0
+}
+
+// String returns a string representation of the version.
+func (v *GHCRPackageVersion) String() string {
+	tagsStr := "untagged"
+	if len(v.Tags) > 0 {
+		tagsStr = strings.Join(v.Tags, ", ")
+	}
+	return fmt.Sprintf("GHCRPackageVersion(id=%d, tags=[%s])", v.VersionID, tagsStr)
+}
+
+// GHCRClient is a client for interacting with GitHub Container Registry API.
+type GHCRClient struct {
+	Owner          string
+	Token          string
+	BaseURL        string
+	ownerTypeCache string
+	httpClient     *http.Client
+}
+
+// NewGHCRClient creates a new GHCR client.
+func NewGHCRClient(owner, token string) (*GHCRClient, error) {
+	if token == "" {
+		token = os.Getenv("GITHUB_TOKEN")
+	}
+	if token == "" {
+		return nil, fmt.Errorf("GitHub token is required. Set GITHUB_TOKEN environment variable")
+	}
+
+	return &GHCRClient{
+		Owner:   owner,
+		Token:   token,
+		BaseURL: "https://api.github.com",
+		httpClient: &http.Client{
+			Timeout: defaultTimeout,
+		},
+	}, nil
+}
+
+func (c *GHCRClient) doRequest(method, url string) (*http.Response, error) {
+	req, err := http.NewRequest(method, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.Token)
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+	req.Header.Set("Content-Type", "application/json")
+	return c.httpClient.Do(req)
+}
+
+func (c *GHCRClient) detectOwnerType() string {
+	if c.ownerTypeCache != "" {
+		return c.ownerTypeCache
+	}
+
+	url := fmt.Sprintf("%s/users/%s", c.BaseURL, c.Owner)
+	resp, err := c.doRequest("GET", url)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "⚠️  Error detecting owner type: %v, defaulting to 'orgs'\n", err)
+		c.ownerTypeCache = "orgs"
+		return "orgs"
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == 200 {
+		var data map[string]interface{}
+		if err := json.NewDecoder(resp.Body).Decode(&data); err == nil {
+			if data["type"] == "Organization" {
+				c.ownerTypeCache = "orgs"
+			} else {
+				c.ownerTypeCache = "users"
+			}
+			return c.ownerTypeCache
+		}
+	}
+
+	fmt.Fprintf(os.Stderr, "⚠️  Could not determine owner type, defaulting to 'orgs'\n")
+	c.ownerTypeCache = "orgs"
+	return "orgs"
+}
+
+// ListPackageVersions lists all versions of a package.
+func (c *GHCRClient) ListPackageVersions(packageName string) ([]GHCRPackageVersion, error) {
+	ownerType := c.detectOwnerType()
+	url := fmt.Sprintf("%s/%s/%s/packages/container/%s/versions?per_page=100", c.BaseURL, ownerType, c.Owner, packageName)
+
+	var allVersions []GHCRPackageVersion
+
+	for url != "" {
+		resp, err := c.doRequest("GET", url)
+		if err != nil {
+			return nil, fmt.Errorf("error listing package versions: %w", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode == 404 {
+			fmt.Fprintf(os.Stderr, "ℹ️  Package %s not found or has no versions\n", packageName)
+			return nil, nil
+		}
+
+		if resp.StatusCode != 200 {
+			body, _ := io.ReadAll(resp.Body)
+			return nil, fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(body))
+		}
+
+		var versionsData []struct {
+			ID        int    `json:"id"`
+			CreatedAt string `json:"created_at"`
+			UpdatedAt string `json:"updated_at"`
+			Metadata  *struct {
+				Container *struct {
+					Tags []string `json:"tags"`
+				} `json:"container"`
+			} `json:"metadata"`
+		}
+
+		if err := json.NewDecoder(resp.Body).Decode(&versionsData); err != nil {
+			return nil, fmt.Errorf("decoding response: %w", err)
+		}
+
+		for _, vd := range versionsData {
+			var tags []string
+			if vd.Metadata != nil && vd.Metadata.Container != nil {
+				tags = vd.Metadata.Container.Tags
+			}
+			allVersions = append(allVersions, GHCRPackageVersion{
+				VersionID: vd.ID,
+				Tags:      tags,
+				CreatedAt: vd.CreatedAt,
+				UpdatedAt: vd.UpdatedAt,
+			})
+		}
+
+		// Check for pagination
+		linkHeader := resp.Header.Get("Link")
+		url = ""
+		if strings.Contains(linkHeader, `rel="next"`) {
+			for _, link := range strings.Split(linkHeader, ",") {
+				if strings.Contains(link, `rel="next"`) {
+					start := strings.Index(link, "<")
+					end := strings.Index(link, ">")
+					if start >= 0 && end > start {
+						url = link[start+1 : end]
+					}
+					break
+				}
+			}
+		}
+	}
+
+	return allVersions, nil
+}
+
+// DeletePackageVersion deletes a specific package version.
+func (c *GHCRClient) DeletePackageVersion(packageName string, versionID int) (bool, error) {
+	ownerType := c.detectOwnerType()
+	url := fmt.Sprintf("%s/%s/%s/packages/container/%s/versions/%d", c.BaseURL, ownerType, c.Owner, packageName, versionID)
+
+	resp, err := c.doRequest("DELETE", url)
+	if err != nil {
+		return false, fmt.Errorf("error deleting package version %d: %w", versionID, err)
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case 204:
+		return true, nil
+	case 404:
+		fmt.Fprintf(os.Stderr, "⚠️  Package version %d not found\n", versionID)
+		return false, nil
+	default:
+		body, _ := io.ReadAll(resp.Body)
+		return false, fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(body))
+	}
+}
+
+// FindVersionsByTags finds package versions matching specific tags.
+func (c *GHCRClient) FindVersionsByTags(packageName string, tags []string) ([]GHCRPackageVersion, error) {
+	allVersions, err := c.ListPackageVersions(packageName)
+	if err != nil {
+		return nil, err
+	}
+
+	var matching []GHCRPackageVersion
+	for _, version := range allVersions {
+		for _, tag := range tags {
+			if version.HasTag(tag) {
+				matching = append(matching, version)
+				break
+			}
+		}
+	}
+
+	return matching, nil
+}
+
+// ValidatePermissions validates that the GitHub token has the necessary permissions.
+func (c *GHCRClient) ValidatePermissions() bool {
+	ownerType := c.detectOwnerType()
+	url := fmt.Sprintf("%s/%s/%s", c.BaseURL, ownerType, c.Owner)
+
+	resp, err := c.doRequest("GET", url)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "❌ Error validating permissions: %v\n", err)
+		return false
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == 200 {
+		scopes := resp.Header.Get("X-OAuth-Scopes")
+		hasWrite := strings.Contains(scopes, "write:packages")
+		hasRead := strings.Contains(scopes, "read:packages") || hasWrite
+		if hasWrite && hasRead {
+			return true
+		}
+		fmt.Fprintf(os.Stderr, "⚠️  Missing required scopes. Current: %s\n", scopes)
+		fmt.Fprintln(os.Stderr, "   Required: write:packages, read:packages")
+		return false
+	}
+
+	if resp.StatusCode == 403 {
+		fmt.Fprintln(os.Stderr, "❌ Access forbidden. Check token permissions.")
+		return false
+	}
+
+	fmt.Fprintf(os.Stderr, "⚠️  Could not validate permissions: %d\n", resp.StatusCode)
+	return false
+}
+
+// GetPackageInfo gets package metadata from GHCR.
+func (c *GHCRClient) GetPackageInfo(packageName string) (map[string]interface{}, error) {
+	ownerType := c.detectOwnerType()
+	url := fmt.Sprintf("%s/%s/%s/packages/container/%s", c.BaseURL, ownerType, c.Owner, packageName)
+
+	resp, err := c.doRequest("GET", url)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "⚠️  Error getting package info: %v\n", err)
+		return nil, nil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == 200 {
+		var data map[string]interface{}
+		if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+			return nil, err
+		}
+		return data, nil
+	}
+
+	if resp.StatusCode == 404 {
+		return nil, nil
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	return nil, fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(body))
+}

--- a/tools/kraken/ghcr_test.go
+++ b/tools/kraken/ghcr_test.go
@@ -1,0 +1,107 @@
+package kraken
+
+import (
+	"testing"
+)
+
+func TestGHCRPackageVersionHasTag(t *testing.T) {
+	v := GHCRPackageVersion{
+		VersionID: 123,
+		Tags:      []string{"v1.0.0", "latest"},
+	}
+
+	if !v.HasTag("v1.0.0") {
+		t.Error("expected HasTag to return true for v1.0.0")
+	}
+	if !v.HasTag("latest") {
+		t.Error("expected HasTag to return true for latest")
+	}
+	if v.HasTag("v2.0.0") {
+		t.Error("expected HasTag to return false for v2.0.0")
+	}
+}
+
+func TestGHCRPackageVersionIsUntagged(t *testing.T) {
+	untagged := GHCRPackageVersion{
+		VersionID: 123,
+		Tags:      nil,
+	}
+	if !untagged.IsUntagged() {
+		t.Error("expected IsUntagged to return true for nil tags")
+	}
+
+	emptyTags := GHCRPackageVersion{
+		VersionID: 123,
+		Tags:      []string{},
+	}
+	if !emptyTags.IsUntagged() {
+		t.Error("expected IsUntagged to return true for empty tags")
+	}
+
+	tagged := GHCRPackageVersion{
+		VersionID: 123,
+		Tags:      []string{"v1.0.0"},
+	}
+	if tagged.IsUntagged() {
+		t.Error("expected IsUntagged to return false for tagged version")
+	}
+}
+
+func TestGHCRPackageVersionString(t *testing.T) {
+	v := GHCRPackageVersion{
+		VersionID: 12345,
+		Tags:      []string{"v1.0.0", "latest"},
+	}
+
+	str := v.String()
+	if str != "GHCRPackageVersion(id=12345, tags=[v1.0.0, latest])" {
+		t.Errorf("unexpected string representation: %s", str)
+	}
+}
+
+func TestGHCRPackageVersionStringUntagged(t *testing.T) {
+	v := GHCRPackageVersion{
+		VersionID: 12345,
+		Tags:      nil,
+	}
+
+	str := v.String()
+	if str != "GHCRPackageVersion(id=12345, tags=[untagged])" {
+		t.Errorf("unexpected string representation: %s", str)
+	}
+}
+
+func TestNewGHCRClientNoToken(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "")
+	_, err := NewGHCRClient("owner", "")
+	if err == nil {
+		t.Error("expected error when no token provided")
+	}
+}
+
+func TestNewGHCRClientWithToken(t *testing.T) {
+	client, err := NewGHCRClient("owner", "ghp_test_token")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if client.Owner != "owner" {
+		t.Errorf("expected owner 'owner', got '%s'", client.Owner)
+	}
+	if client.Token != "ghp_test_token" {
+		t.Errorf("expected token 'ghp_test_token', got '%s'", client.Token)
+	}
+	if client.BaseURL != "https://api.github.com" {
+		t.Errorf("unexpected base URL: %s", client.BaseURL)
+	}
+}
+
+func TestNewGHCRClientFromEnv(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "ghp_env_token")
+	client, err := NewGHCRClient("owner", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if client.Token != "ghp_env_token" {
+		t.Errorf("expected token from env, got '%s'", client.Token)
+	}
+}

--- a/tools/kraken/git.go
+++ b/tools/kraken/git.go
@@ -1,0 +1,312 @@
+package kraken
+
+import (
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// FormatGitTag formats a Git tag in the domain-appname.version format.
+func FormatGitTag(domain, appName, version string) string {
+	return fmt.Sprintf("%s-%s.%s", domain, appName, version)
+}
+
+// FormatHelmChartTag formats a Git tag for a Helm chart.
+// Chart names already include the helm- prefix and namespace.
+func FormatHelmChartTag(chartName, version string) string {
+	return fmt.Sprintf("%s.%s", chartName, version)
+}
+
+// CheckTagExists checks if a Git tag exists.
+func CheckTagExists(tagName string) bool {
+	cmd := exec.Command("git", "tag", "-l", tagName)
+	out, err := cmd.Output()
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(out)) != ""
+}
+
+// CreateGitTag creates a Git tag on the specified commit.
+// If force is true, it overwrites an existing tag.
+func CreateGitTag(tagName string, commitSHA string, message string, force bool) error {
+	if CheckTagExists(tagName) {
+		if force {
+			fmt.Printf("Tag %s already exists, forcing overwrite...\n", tagName)
+		} else {
+			fmt.Printf("Tag %s already exists, skipping creation\n", tagName)
+			return nil
+		}
+	}
+
+	args := []string{"tag"}
+	if force {
+		args = append(args, "-f")
+	}
+	if message != "" {
+		args = append(args, "-a", tagName, "-m", message)
+	} else {
+		args = append(args, tagName)
+	}
+	if commitSHA != "" {
+		args = append(args, commitSHA)
+	}
+
+	fmt.Printf("Creating Git tag: %s\n", tagName)
+	cmd := exec.Command("git", args...)
+	return cmd.Run()
+}
+
+// PushGitTag pushes a Git tag to the remote repository.
+func PushGitTag(tagName string, force bool) error {
+	args := []string{"push"}
+	if force {
+		args = append(args, "--force")
+	}
+	args = append(args, "origin", tagName)
+
+	if force {
+		fmt.Printf("Pushing Git tag: %s (force)\n", tagName)
+	} else {
+		fmt.Printf("Pushing Git tag: %s\n", tagName)
+	}
+	cmd := exec.Command("git", args...)
+	return cmd.Run()
+}
+
+// GetPreviousTag gets the previous Git tag.
+func GetPreviousTag() (string, error) {
+	cmd := exec.Command("git", "describe", "--tags", "--abbrev=0", "HEAD^")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// GetAllTags gets all Git tags sorted by version (newest first).
+func GetAllTags() ([]string, error) {
+	cmd := exec.Command("git", "tag", "--sort=-version:refname")
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+	raw := strings.TrimSpace(string(out))
+	if raw == "" {
+		return nil, nil
+	}
+	var tags []string
+	for _, t := range strings.Split(raw, "\n") {
+		t = strings.TrimSpace(t)
+		if t != "" {
+			tags = append(tags, t)
+		}
+	}
+	return tags, nil
+}
+
+// GetAppTags gets all tags for a specific app, sorted by version (newest first).
+func GetAppTags(domain, appName string) ([]string, error) {
+	allTags, err := GetAllTags()
+	if err != nil {
+		return nil, err
+	}
+	prefix := fmt.Sprintf("%s-%s.", domain, appName)
+	var appTags []string
+	for _, tag := range allTags {
+		if strings.HasPrefix(tag, prefix) {
+			appTags = append(appTags, tag)
+		}
+	}
+	return appTags, nil
+}
+
+// GetHelmChartTags gets all tags for a specific helm chart.
+func GetHelmChartTags(chartName string) ([]string, error) {
+	allTags, err := GetAllTags()
+	if err != nil {
+		return nil, err
+	}
+	prefix := fmt.Sprintf("%s.", chartName)
+	var chartTags []string
+	for _, tag := range allTags {
+		if strings.HasPrefix(tag, prefix) {
+			chartTags = append(chartTags, tag)
+		}
+	}
+	return chartTags, nil
+}
+
+var semverRegex = regexp.MustCompile(`^v(\d+)\.(\d+)\.(\d+)(?:-[a-zA-Z0-9\-\.]+)?$`)
+
+// ParseVersionFromTag parses version from an app tag.
+func ParseVersionFromTag(tag, domain, appName string) string {
+	prefix := fmt.Sprintf("%s-%s.", domain, appName)
+	if !strings.HasPrefix(tag, prefix) {
+		return ""
+	}
+	version := tag[len(prefix):]
+	if semverRegex.MatchString(version) {
+		return version
+	}
+	return ""
+}
+
+// ParseVersionFromHelmChartTag parses version from a helm chart tag.
+func ParseVersionFromHelmChartTag(tag, chartName string) string {
+	prefix := fmt.Sprintf("%s.", chartName)
+	if !strings.HasPrefix(tag, prefix) {
+		return ""
+	}
+	version := tag[len(prefix):]
+	if semverRegex.MatchString(version) {
+		return version
+	}
+	return ""
+}
+
+// SemanticVersion represents a parsed semantic version.
+type SemanticVersion struct {
+	Major      int
+	Minor      int
+	Patch      int
+	Prerelease string
+}
+
+// ParseSemanticVersion parses a semantic version string into components.
+func ParseSemanticVersion(version string) (*SemanticVersion, error) {
+	v := version
+	if strings.HasPrefix(v, "v") {
+		v = v[1:]
+	}
+
+	parts := strings.SplitN(v, "-", 2)
+	versionPart := parts[0]
+	prerelease := ""
+	if len(parts) > 1 {
+		prerelease = parts[1]
+	}
+
+	components := strings.Split(versionPart, ".")
+	if len(components) != 3 {
+		return nil, fmt.Errorf("invalid semantic version format: %s", version)
+	}
+
+	major, err := strconv.Atoi(components[0])
+	if err != nil {
+		return nil, fmt.Errorf("invalid semantic version format: %s", version)
+	}
+	minor, err := strconv.Atoi(components[1])
+	if err != nil {
+		return nil, fmt.Errorf("invalid semantic version format: %s", version)
+	}
+	patch, err := strconv.Atoi(components[2])
+	if err != nil {
+		return nil, fmt.Errorf("invalid semantic version format: %s", version)
+	}
+
+	return &SemanticVersion{
+		Major:      major,
+		Minor:      minor,
+		Patch:      patch,
+		Prerelease: prerelease,
+	}, nil
+}
+
+// IncrementMinorVersion increments the minor version and resets patch to 0.
+func IncrementMinorVersion(currentVersion string) (string, error) {
+	sv, err := ParseSemanticVersion(currentVersion)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("v%d.%d.0", sv.Major, sv.Minor+1), nil
+}
+
+// IncrementPatchVersion increments the patch version.
+func IncrementPatchVersion(currentVersion string) (string, error) {
+	sv, err := ParseSemanticVersion(currentVersion)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("v%d.%d.%d", sv.Major, sv.Minor, sv.Patch+1), nil
+}
+
+// GetLatestAppVersion gets the latest version for a specific app.
+func GetLatestAppVersion(domain, appName string) (string, error) {
+	appTags, err := GetAppTags(domain, appName)
+	if err != nil {
+		return "", err
+	}
+	for _, tag := range appTags {
+		version := ParseVersionFromTag(tag, domain, appName)
+		if version != "" {
+			return version, nil
+		}
+	}
+	return "", nil
+}
+
+// GetLatestHelmChartVersion gets the latest version for a specific helm chart.
+func GetLatestHelmChartVersion(chartName string) (string, error) {
+	chartTags, err := GetHelmChartTags(chartName)
+	if err != nil {
+		return "", err
+	}
+	for _, tag := range chartTags {
+		version := ParseVersionFromHelmChartTag(tag, chartName)
+		if version != "" {
+			return version, nil
+		}
+	}
+	return "", nil
+}
+
+// AutoIncrementVersion auto-increments version for an app based on the latest tag.
+func AutoIncrementVersion(domain, appName, incrementType string) (string, error) {
+	if incrementType != "minor" && incrementType != "patch" {
+		return "", fmt.Errorf("invalid increment type: %s. Must be 'minor' or 'patch'", incrementType)
+	}
+
+	latestVersion, err := GetLatestAppVersion(domain, appName)
+	if err != nil {
+		return "", err
+	}
+
+	if latestVersion == "" {
+		if incrementType == "minor" {
+			return "v0.1.0", nil
+		}
+		return "v0.0.1", nil
+	}
+
+	if incrementType == "minor" {
+		return IncrementMinorVersion(latestVersion)
+	}
+	return IncrementPatchVersion(latestVersion)
+}
+
+// AutoIncrementHelmChartVersion auto-increments version for a helm chart.
+func AutoIncrementHelmChartVersion(chartName, incrementType string) (string, error) {
+	if incrementType != "minor" && incrementType != "patch" {
+		return "", fmt.Errorf("invalid increment type: %s. Must be 'minor' or 'patch'", incrementType)
+	}
+
+	latestVersion, err := GetLatestHelmChartVersion(chartName)
+	if err != nil {
+		return "", err
+	}
+
+	if latestVersion == "" {
+		if incrementType == "minor" {
+			return "v0.1.0", nil
+		}
+		return "v0.0.1", nil
+	}
+
+	if incrementType == "minor" {
+		return IncrementMinorVersion(latestVersion)
+	}
+	return IncrementPatchVersion(latestVersion)
+}

--- a/tools/kraken/git_test.go
+++ b/tools/kraken/git_test.go
@@ -1,0 +1,159 @@
+package kraken
+
+import (
+	"testing"
+)
+
+func TestFormatGitTagBasic(t *testing.T) {
+	result := FormatGitTag("api", "user-service", "1.0.0")
+	if result != "api-user-service.1.0.0" {
+		t.Errorf("expected api-user-service.1.0.0, got %s", result)
+	}
+}
+
+func TestFormatGitTagWithHyphens(t *testing.T) {
+	result := FormatGitTag("data-processing", "ml-service", "2.1.0-beta")
+	if result != "data-processing-ml-service.2.1.0-beta" {
+		t.Errorf("expected data-processing-ml-service.2.1.0-beta, got %s", result)
+	}
+}
+
+func TestFormatGitTagEmptyStrings(t *testing.T) {
+	result := FormatGitTag("", "", "")
+	if result != "-." {
+		t.Errorf("expected -., got %s", result)
+	}
+}
+
+func TestFormatHelmChartTagWithHelmPrefix(t *testing.T) {
+	result := FormatHelmChartTag("helm-demo-hello-fastapi", "v1.0.0")
+	if result != "helm-demo-hello-fastapi.v1.0.0" {
+		t.Errorf("expected helm-demo-hello-fastapi.v1.0.0, got %s", result)
+	}
+}
+
+func TestFormatHelmChartTagWithoutHelmPrefix(t *testing.T) {
+	result := FormatHelmChartTag("demo-hello-fastapi", "v1.0.0")
+	if result != "demo-hello-fastapi.v1.0.0" {
+		t.Errorf("expected demo-hello-fastapi.v1.0.0, got %s", result)
+	}
+}
+
+func TestFormatHelmChartTagWithMultipleHyphens(t *testing.T) {
+	result := FormatHelmChartTag("helm-manman-host-services", "v2.1.3")
+	if result != "helm-manman-host-services.v2.1.3" {
+		t.Errorf("expected helm-manman-host-services.v2.1.3, got %s", result)
+	}
+}
+
+func TestParseVersionFromTagSuccess(t *testing.T) {
+	result := ParseVersionFromTag("demo-hello_python.v1.2.3", "demo", "hello_python")
+	if result != "v1.2.3" {
+		t.Errorf("expected v1.2.3, got %s", result)
+	}
+}
+
+func TestParseVersionFromTagWrongApp(t *testing.T) {
+	result := ParseVersionFromTag("demo-hello_python.v1.2.3", "demo", "other_app")
+	if result != "" {
+		t.Errorf("expected empty string, got %s", result)
+	}
+}
+
+func TestParseVersionFromTagInvalidVersion(t *testing.T) {
+	result := ParseVersionFromTag("demo-hello_python.invalid", "demo", "hello_python")
+	if result != "" {
+		t.Errorf("expected empty string, got %s", result)
+	}
+}
+
+func TestParseVersionFromHelmChartTagSuccess(t *testing.T) {
+	result := ParseVersionFromHelmChartTag("helm-demo-hello-fastapi.v1.2.3", "helm-demo-hello-fastapi")
+	if result != "v1.2.3" {
+		t.Errorf("expected v1.2.3, got %s", result)
+	}
+}
+
+func TestParseVersionFromHelmChartTagWithPrerelease(t *testing.T) {
+	result := ParseVersionFromHelmChartTag("helm-demo-hello-fastapi.v1.2.3-beta.1", "helm-demo-hello-fastapi")
+	if result != "v1.2.3-beta.1" {
+		t.Errorf("expected v1.2.3-beta.1, got %s", result)
+	}
+}
+
+func TestParseVersionFromHelmChartTagWrongChart(t *testing.T) {
+	result := ParseVersionFromHelmChartTag("helm-demo-hello-fastapi.v1.2.3", "helm-demo-other-app")
+	if result != "" {
+		t.Errorf("expected empty string, got %s", result)
+	}
+}
+
+func TestParseVersionFromHelmChartTagInvalidVersion(t *testing.T) {
+	result := ParseVersionFromHelmChartTag("helm-demo-hello-fastapi.invalid", "helm-demo-hello-fastapi")
+	if result != "" {
+		t.Errorf("expected empty string, got %s", result)
+	}
+}
+
+func TestParseSemanticVersionBasic(t *testing.T) {
+	sv, err := ParseSemanticVersion("v1.2.3")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sv.Major != 1 || sv.Minor != 2 || sv.Patch != 3 {
+		t.Errorf("expected 1.2.3, got %d.%d.%d", sv.Major, sv.Minor, sv.Patch)
+	}
+	if sv.Prerelease != "" {
+		t.Errorf("expected empty prerelease, got %s", sv.Prerelease)
+	}
+}
+
+func TestParseSemanticVersionWithPrerelease(t *testing.T) {
+	sv, err := ParseSemanticVersion("v1.0.0-beta1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sv.Major != 1 || sv.Minor != 0 || sv.Patch != 0 {
+		t.Errorf("expected 1.0.0, got %d.%d.%d", sv.Major, sv.Minor, sv.Patch)
+	}
+	if sv.Prerelease != "beta1" {
+		t.Errorf("expected beta1, got %s", sv.Prerelease)
+	}
+}
+
+func TestParseSemanticVersionWithoutPrefix(t *testing.T) {
+	sv, err := ParseSemanticVersion("2.3.4")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sv.Major != 2 || sv.Minor != 3 || sv.Patch != 4 {
+		t.Errorf("expected 2.3.4, got %d.%d.%d", sv.Major, sv.Minor, sv.Patch)
+	}
+}
+
+func TestParseSemanticVersionInvalid(t *testing.T) {
+	_, err := ParseSemanticVersion("v1.0")
+	if err == nil {
+		t.Error("expected error for invalid version")
+	}
+}
+
+func TestIncrementMinorVersion(t *testing.T) {
+	result, err := IncrementMinorVersion("v1.2.3")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != "v1.3.0" {
+		t.Errorf("expected v1.3.0, got %s", result)
+	}
+}
+
+func TestIncrementPatchVersion(t *testing.T) {
+	result, err := IncrementPatchVersion("v1.2.3")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != "v1.2.4" {
+		t.Errorf("expected v1.2.4, got %s", result)
+	}
+}

--- a/tools/kraken/github_release.go
+++ b/tools/kraken/github_release.go
@@ -1,0 +1,313 @@
+package kraken
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+// GitHubReleaseData represents data for creating a GitHub release.
+type GitHubReleaseData struct {
+	TagName         string `json:"tag_name"`
+	Name            string `json:"name"`
+	Body            string `json:"body"`
+	Draft           bool   `json:"draft"`
+	Prerelease      bool   `json:"prerelease"`
+	TargetCommitish string `json:"target_commitish,omitempty"`
+}
+
+// GitHubReleaseClient is a client for interacting with GitHub Releases API.
+type GitHubReleaseClient struct {
+	Owner      string
+	Repo       string
+	Token      string
+	BaseURL    string
+	httpClient *http.Client
+}
+
+// NewGitHubReleaseClient creates a new GitHub release client.
+func NewGitHubReleaseClient(owner, repo, token string) (*GitHubReleaseClient, error) {
+	if token == "" {
+		token = os.Getenv("GITHUB_TOKEN")
+	}
+	if token == "" {
+		return nil, fmt.Errorf("GitHub token is required. Set GITHUB_TOKEN environment variable")
+	}
+
+	return &GitHubReleaseClient{
+		Owner:   owner,
+		Repo:    repo,
+		Token:   token,
+		BaseURL: "https://api.github.com",
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}, nil
+}
+
+func (c *GitHubReleaseClient) doRequest(method, url string, body interface{}) (*http.Response, error) {
+	var bodyReader io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return nil, err
+		}
+		bodyReader = bytes.NewReader(data)
+	}
+
+	req, err := http.NewRequest(method, url, bodyReader)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.Token)
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+	req.Header.Set("Content-Type", "application/json")
+	return c.httpClient.Do(req)
+}
+
+// ValidatePermissions validates that the GitHub token has the necessary permissions.
+func (c *GitHubReleaseClient) ValidatePermissions() bool {
+	url := fmt.Sprintf("%s/repos/%s/%s", c.BaseURL, c.Owner, c.Repo)
+	resp, err := c.doRequest("GET", url, nil)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "❌ Error validating permissions: %v\n", err)
+		return false
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == 200 {
+		if os.Getenv("GITHUB_ACTIONS") != "" {
+			scopes := resp.Header.Get("X-OAuth-Scopes")
+			fmt.Fprintf(os.Stderr, "✅ Token is valid. Available OAuth scopes: %s\n", scopes)
+			return true
+		}
+
+		var repoData map[string]interface{}
+		if err := json.NewDecoder(resp.Body).Decode(&repoData); err == nil {
+			if perms, ok := repoData["permissions"].(map[string]interface{}); ok {
+				if perms["push"] == true || perms["admin"] == true || perms["maintain"] == true {
+					return true
+				}
+			}
+		}
+
+		// Try releases endpoint as fallback
+		releasesURL := fmt.Sprintf("%s/repos/%s/%s/releases", c.BaseURL, c.Owner, c.Repo)
+		relResp, err := c.doRequest("GET", releasesURL, nil)
+		if err == nil {
+			defer relResp.Body.Close()
+			if relResp.StatusCode == 200 {
+				fmt.Fprintln(os.Stderr, "⚠️  Permission validation unclear, but releases endpoint accessible. Proceeding with caution.")
+				return true
+			}
+		}
+
+		fmt.Fprintln(os.Stderr, "❌ Insufficient permissions. Need write access to repository.")
+		return false
+	}
+
+	fmt.Fprintf(os.Stderr, "❌ Token validation failed with status: %d\n", resp.StatusCode)
+	return false
+}
+
+// CreateRelease creates a GitHub release.
+func (c *GitHubReleaseClient) CreateRelease(data *GitHubReleaseData) (map[string]interface{}, error) {
+	url := fmt.Sprintf("%s/repos/%s/%s/releases", c.BaseURL, c.Owner, c.Repo)
+
+	resp, err := c.doRequest("POST", url, data)
+	if err != nil {
+		return nil, fmt.Errorf("creating release: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode == 201 {
+		var result map[string]interface{}
+		if err := json.Unmarshal(body, &result); err != nil {
+			return nil, err
+		}
+		return result, nil
+	}
+
+	if resp.StatusCode == 422 {
+		return nil, fmt.Errorf("release already exists for tag %s", data.TagName)
+	}
+
+	return nil, fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(body))
+}
+
+// GetReleaseByTag gets a release by its tag name.
+func (c *GitHubReleaseClient) GetReleaseByTag(tagName string) (map[string]interface{}, error) {
+	url := fmt.Sprintf("%s/repos/%s/%s/releases/tags/%s", c.BaseURL, c.Owner, c.Repo, tagName)
+
+	resp, err := c.doRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == 200 {
+		var result map[string]interface{}
+		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+			return nil, err
+		}
+		return result, nil
+	}
+
+	if resp.StatusCode == 404 {
+		return nil, nil
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	return nil, fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(body))
+}
+
+// DeleteRelease deletes a GitHub release by ID.
+func (c *GitHubReleaseClient) DeleteRelease(releaseID int) bool {
+	url := fmt.Sprintf("%s/repos/%s/%s/releases/%d", c.BaseURL, c.Owner, c.Repo, releaseID)
+
+	resp, err := c.doRequest("DELETE", url, nil)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "❌ Error deleting release %d: %v\n", releaseID, err)
+		return false
+	}
+	defer resp.Body.Close()
+
+	return resp.StatusCode == 204
+}
+
+// FindReleasesByTags finds GitHub releases matching specific tags.
+func (c *GitHubReleaseClient) FindReleasesByTags(tags []string) (map[string]map[string]interface{}, error) {
+	result := make(map[string]map[string]interface{})
+
+	for _, tag := range tags {
+		release, err := c.GetReleaseByTag(tag)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "⚠️  Error finding release for tag %s: %v\n", tag, err)
+			continue
+		}
+		if release != nil {
+			result[tag] = release
+		}
+	}
+
+	return result, nil
+}
+
+// UploadReleaseAsset uploads an asset to a GitHub release.
+func (c *GitHubReleaseClient) UploadReleaseAsset(releaseID int, filePath, fileName string) error {
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return fmt.Errorf("reading file: %w", err)
+	}
+
+	url := fmt.Sprintf("https://uploads.github.com/repos/%s/%s/releases/%d/assets?name=%s",
+		c.Owner, c.Repo, releaseID, fileName)
+
+	req, err := http.NewRequest("POST", url, bytes.NewReader(data))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.Token)
+	req.Header.Set("Content-Type", "application/octet-stream")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("uploading asset: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == 201 {
+		return nil
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	return fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(body))
+}
+
+// CreateReleaseForApp creates a GitHub release for a specific app.
+func CreateReleaseForApp(owner, repo, appName, version, commitSHA string, artifactsDir string, dryRun bool) (map[string]interface{}, error) {
+	bazelTarget, err := FindAppBazelTarget(appName)
+	if err != nil {
+		return nil, err
+	}
+
+	metadata, err := GetAppMetadata(bazelTarget)
+	if err != nil {
+		return nil, err
+	}
+
+	tagName := FormatGitTag(metadata.Domain, metadata.Name, version)
+	releaseName := fmt.Sprintf("%s %s %s", metadata.Domain, metadata.Name, version)
+
+	// Generate release notes
+	releaseNotes, err := GenerateReleaseNotes(
+		fmt.Sprintf("%s-%s", metadata.Domain, metadata.Name),
+		tagName, "", "markdown",
+	)
+	if err != nil {
+		releaseNotes = fmt.Sprintf("Release %s %s", metadata.Name, version)
+	}
+
+	// Check for OpenAPI spec
+	if metadata.OpenAPISpecTarget != "" && artifactsDir != "" {
+		specFile := fmt.Sprintf("%s/%s_openapi_spec.json", artifactsDir, metadata.Name)
+		if _, err := os.Stat(specFile); os.IsNotExist(err) {
+			releaseNotes += fmt.Sprintf("\n\n⚠️ **Warning:** OpenAPI spec expected but not found for %s", metadata.Name)
+		}
+	}
+
+	releaseData := &GitHubReleaseData{
+		TagName:    tagName,
+		Name:       releaseName,
+		Body:       releaseNotes,
+		Draft:      false,
+		Prerelease: strings.Contains(version, "-"),
+	}
+	if commitSHA != "" {
+		releaseData.TargetCommitish = commitSHA
+	}
+
+	if dryRun {
+		fmt.Printf("DRY RUN: Would create release:\n")
+		fmt.Printf("  Tag: %s\n", tagName)
+		fmt.Printf("  Name: %s\n", releaseName)
+		fmt.Printf("  Prerelease: %v\n", releaseData.Prerelease)
+		return nil, nil
+	}
+
+	client, err := NewGitHubReleaseClient(owner, repo, "")
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := client.CreateRelease(releaseData)
+	if err != nil {
+		return nil, err
+	}
+
+	fmt.Printf("✅ Created release: %s\n", releaseName)
+
+	// Upload OpenAPI spec if available
+	if metadata.OpenAPISpecTarget != "" && artifactsDir != "" {
+		specFile := fmt.Sprintf("%s/%s_openapi_spec.json", artifactsDir, metadata.Name)
+		if _, err := os.Stat(specFile); err == nil {
+			if releaseIDFloat, ok := result["id"].(float64); ok {
+				releaseID := int(releaseIDFloat)
+				if err := client.UploadReleaseAsset(releaseID, specFile, fmt.Sprintf("%s-openapi-spec.json", metadata.Name)); err != nil {
+					fmt.Fprintf(os.Stderr, "⚠️  Failed to upload OpenAPI spec: %v\n", err)
+				} else {
+					fmt.Printf("📄 Uploaded OpenAPI spec for %s\n", metadata.Name)
+				}
+			}
+		}
+	}
+
+	return result, nil
+}

--- a/tools/kraken/images.go
+++ b/tools/kraken/images.go
@@ -1,0 +1,231 @@
+package kraken
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// CreateManifestList creates a Docker manifest list for multi-architecture images.
+func CreateManifestList(registryRepo, version string, platforms []string) error {
+	if platforms == nil {
+		platforms = []string{"amd64", "arm64"}
+	}
+
+	manifestName := fmt.Sprintf("%s:%s", registryRepo, version)
+
+	var platformImages []string
+	for _, platform := range platforms {
+		platformImages = append(platformImages, fmt.Sprintf("%s:%s-%s", registryRepo, version, platform))
+	}
+
+	fmt.Printf("Creating manifest list %s for platforms: %s\n", manifestName, strings.Join(platforms, ", "))
+
+	args := append([]string{"manifest", "create", manifestName}, platformImages...)
+	cmd := exec.Command("docker", args...)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to create manifest list: %s\n%w", string(out), err)
+	}
+
+	for _, platform := range platforms {
+		platformImage := fmt.Sprintf("%s:%s-%s", registryRepo, version, platform)
+		arch := platform
+		annotateCmd := exec.Command("docker", "manifest", "annotate", manifestName, platformImage, "--arch", arch, "--os", "linux")
+		if out, err := annotateCmd.CombinedOutput(); err != nil {
+			return fmt.Errorf("failed to annotate manifest: %s\n%w", string(out), err)
+		}
+	}
+
+	fmt.Printf("Successfully created manifest list %s\n", manifestName)
+	return nil
+}
+
+// PushManifestList pushes a Docker manifest list to the registry.
+func PushManifestList(registryRepo, version string) error {
+	manifestName := fmt.Sprintf("%s:%s", registryRepo, version)
+	fmt.Printf("Pushing manifest list %s\n", manifestName)
+
+	cmd := exec.Command("docker", "manifest", "push", manifestName)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to push manifest list: %s\n%w", string(out), err)
+	}
+
+	fmt.Printf("Successfully pushed manifest list %s\n", manifestName)
+	return nil
+}
+
+// RegistryTags holds container registry tags for an app.
+type RegistryTags struct {
+	Latest  string
+	Version string
+	Commit  string
+}
+
+// FormatRegistryTags formats container registry tags for an app.
+func FormatRegistryTags(domain, appName, version, registry string, commitSHA string, platform string) RegistryTags {
+	imageName := fmt.Sprintf("%s-%s", domain, appName)
+
+	var baseRepo string
+	if registry == "ghcr.io" {
+		if owner := os.Getenv("GITHUB_REPOSITORY_OWNER"); owner != "" {
+			baseRepo = fmt.Sprintf("%s/%s/%s", registry, strings.ToLower(owner), imageName)
+		} else {
+			baseRepo = fmt.Sprintf("%s/%s", registry, imageName)
+		}
+	} else {
+		baseRepo = fmt.Sprintf("%s/%s", registry, imageName)
+	}
+
+	platformSuffix := ""
+	if platform != "" {
+		platformSuffix = "-" + platform
+	}
+
+	tags := RegistryTags{
+		Latest:  fmt.Sprintf("%s:latest%s", baseRepo, platformSuffix),
+		Version: fmt.Sprintf("%s:%s%s", baseRepo, version, platformSuffix),
+	}
+
+	if commitSHA != "" {
+		tags.Commit = fmt.Sprintf("%s:%s%s", baseRepo, commitSHA, platformSuffix)
+	}
+
+	return tags
+}
+
+// TagsList returns all tags as a slice.
+func (t RegistryTags) TagsList() []string {
+	tags := []string{t.Latest, t.Version}
+	if t.Commit != "" {
+		tags = append(tags, t.Commit)
+	}
+	return tags
+}
+
+// BuildImage builds and loads a container image for an app.
+func BuildImage(bazelTarget string, platform string) (string, error) {
+	metadata, err := GetAppMetadata(bazelTarget)
+	if err != nil {
+		return "", err
+	}
+
+	appPath := strings.SplitN(bazelTarget[2:], ":", 2)[0]
+	loadTarget := fmt.Sprintf("//%s:%s_image_load", appPath, metadata.Name)
+
+	fmt.Printf("Building and loading %s for platform %s (using optimized oci_load)...\n", loadTarget, orDefault(platform, "default"))
+
+	buildArgs := []string{"run", loadTarget}
+	switch platform {
+	case "arm64":
+		buildArgs = append(buildArgs[:1], append([]string{"--platforms=//tools:linux_arm64"}, buildArgs[1:]...)...)
+	case "amd64":
+		buildArgs = append(buildArgs[:1], append([]string{"--platforms=//tools:linux_x86_64"}, buildArgs[1:]...)...)
+	}
+
+	_, err = RunBazel(buildArgs, true, nil)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%s-%s:latest", metadata.Domain, metadata.Name), nil
+}
+
+// PushImageWithTags pushes a container image with multiple tags to the registry.
+func PushImageWithTags(bazelTarget string, tags []string) error {
+	metadata, err := GetAppMetadata(bazelTarget)
+	if err != nil {
+		return err
+	}
+
+	appPath := strings.SplitN(bazelTarget[2:], ":", 2)[0]
+	pushTarget := fmt.Sprintf("//%s:%s_image_push", appPath, metadata.Name)
+
+	fmt.Printf("Pushing %d tags using %s...\n", len(tags), pushTarget)
+
+	var tagNames []string
+	for _, tag := range tags {
+		parts := strings.SplitN(tag, ":", 2)
+		if len(parts) == 2 {
+			tagNames = append(tagNames, parts[1])
+		}
+	}
+
+	fmt.Printf("Pushing with tags: %s\n", strings.Join(tagNames, ", "))
+
+	bazelArgs := []string{"run", pushTarget, "--"}
+	for _, tagName := range tagNames {
+		bazelArgs = append(bazelArgs, "--tag", tagName)
+	}
+
+	_, err = RunBazel(bazelArgs, false, nil)
+	if err != nil {
+		return fmt.Errorf("failed to push image: %w", err)
+	}
+
+	fmt.Printf("Successfully pushed image with %d tags\n", len(tagNames))
+	return nil
+}
+
+// ReleaseMultiarchImage releases a multi-architecture image using OCI image index.
+func ReleaseMultiarchImage(bazelTarget, version, registry string, platforms []string, commitSHA string) error {
+	if platforms == nil {
+		platforms = []string{"amd64", "arm64"}
+	}
+
+	metadata, err := GetAppMetadata(bazelTarget)
+	if err != nil {
+		return err
+	}
+
+	appPath := strings.SplitN(bazelTarget[2:], ":", 2)[0]
+	imageName := fmt.Sprintf("%s-%s", metadata.Domain, metadata.Name)
+
+	fmt.Printf("Releasing multi-architecture image: %s\n", imageName)
+	fmt.Printf("Version: %s\n", version)
+	fmt.Printf("Platforms: %s\n", strings.Join(platforms, ", "))
+
+	// Build the OCI image index
+	fmt.Printf("\n%s\n", strings.Repeat("=", 80))
+	fmt.Println("Building OCI image index with platform transitions...")
+	fmt.Printf("%s\n", strings.Repeat("=", 80))
+
+	indexTarget := fmt.Sprintf("//%s:%s_image", appPath, metadata.Name)
+	fmt.Printf("Building index: %s\n", indexTarget)
+
+	_, err = RunBazel([]string{"build", indexTarget}, true, nil)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("✅ Built OCI image index containing %d platform variants\n", len(platforms))
+
+	// Push with all tags
+	tags := FormatRegistryTags(metadata.Domain, metadata.Name, version, registry, commitSHA, "")
+
+	fmt.Printf("\n%s\n", strings.Repeat("=", 80))
+	fmt.Printf("Pushing OCI image index with tags...\n")
+	fmt.Printf("%s\n", strings.Repeat("=", 80))
+
+	if err := PushImageWithTags(bazelTarget, tags.TagsList()); err != nil {
+		return err
+	}
+
+	fmt.Printf("\n%s\n", strings.Repeat("=", 80))
+	fmt.Printf("✅ Successfully released %s:%s\n", imageName, version)
+	fmt.Printf("%s\n", strings.Repeat("=", 80))
+	fmt.Println("\nPublished tags:")
+	for _, tag := range tags.TagsList() {
+		fmt.Printf("  - %s\n", tag)
+	}
+	fmt.Printf("\nThe image index contains %d platform variants: %s\n", len(platforms), strings.Join(platforms, ", "))
+	fmt.Println("Docker will automatically select the correct architecture when users pull.")
+
+	return nil
+}
+
+func orDefault(s, def string) string {
+	if s == "" {
+		return def
+	}
+	return s
+}

--- a/tools/kraken/integration_test.sh
+++ b/tools/kraken/integration_test.sh
@@ -1,0 +1,466 @@
+#!/usr/bin/env bash
+# Integration test: compare kraken (Go) output against release_helper (Python)
+# for the subcommands used in CI. Both tools must produce identical structured
+# output when given the same inputs.
+#
+# Usage:
+#   bazel test //tools/kraken:integration_test --test_output=streamed
+#   # or directly:
+#   ./tools/kraken/integration_test.sh
+
+set -euo pipefail
+
+PASS=0
+FAIL=0
+ERRORS=""
+
+# --- helpers ----------------------------------------------------------------
+
+green()  { printf '\033[32m%s\033[0m\n' "$*"; }
+red()    { printf '\033[31m%s\033[0m\n' "$*"; }
+yellow() { printf '\033[33m%s\033[0m\n' "$*"; }
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    green "  PASS: $label"
+    PASS=$((PASS + 1))
+  else
+    red "  FAIL: $label"
+    echo "    expected: $(echo "$expected" | head -3)"
+    echo "    actual:   $(echo "$actual" | head -3)"
+    FAIL=$((FAIL + 1))
+    ERRORS="${ERRORS}\n  - ${label}"
+  fi
+}
+
+assert_exit_code() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    green "  PASS: $label (exit $actual)"
+    PASS=$((PASS + 1))
+  else
+    red "  FAIL: $label (expected exit $expected, got $actual)"
+    FAIL=$((FAIL + 1))
+    ERRORS="${ERRORS}\n  - ${label}"
+  fi
+}
+
+assert_contains() {
+  local label="$1" haystack="$2" needle="$3"
+  if echo "$haystack" | grep -qF "$needle"; then
+    green "  PASS: $label"
+    PASS=$((PASS + 1))
+  else
+    red "  FAIL: $label — output does not contain '$needle'"
+    echo "    output: $(echo "$haystack" | head -3)"
+    FAIL=$((FAIL + 1))
+    ERRORS="${ERRORS}\n  - ${label}"
+  fi
+}
+
+# --- locate binaries --------------------------------------------------------
+
+# When run via bazel test, BUILD_WORKSPACE_DIRECTORY is set.
+# When run directly, find workspace root.
+if [[ -n "${BUILD_WORKSPACE_DIRECTORY:-}" ]]; then
+  WORKSPACE="$BUILD_WORKSPACE_DIRECTORY"
+else
+  WORKSPACE="$(cd "$(dirname "$0")/../.." && pwd)"
+fi
+
+cd "$WORKSPACE"
+
+echo "=== Building both tools ==="
+bazel build //tools:release //tools:kraken 2>/dev/null
+
+RELEASE_HELPER="$(bazel info bazel-bin 2>/dev/null)/tools/release_helper/release_helper"
+KRAKEN="$(bazel info bazel-bin 2>/dev/null)/tools/kraken/cmd/kraken/kraken_/kraken"
+
+if [[ ! -x "$RELEASE_HELPER" ]]; then
+  red "release_helper binary not found at $RELEASE_HELPER"
+  exit 1
+fi
+if [[ ! -x "$KRAKEN" ]]; then
+  red "kraken binary not found at $KRAKEN"
+  exit 1
+fi
+
+echo "release_helper: $RELEASE_HELPER"
+echo "kraken:         $KRAKEN"
+echo ""
+
+# ============================================================================
+# TEST 1: list — app discovery produces same set of apps
+# ============================================================================
+echo "=== Test 1: list — app discovery ==="
+
+PY_LIST=$("$RELEASE_HELPER" list --format json 2>/dev/null)
+GO_LIST=$("$KRAKEN" list 2>/dev/null)
+
+# Extract app names from Python JSON output
+PY_NAMES=$(echo "$PY_LIST" | python3 -c "
+import json, sys
+apps = json.load(sys.stdin)
+for a in apps:
+    print(a['name'])
+" | sort)
+
+# Extract app names from Go tabular output (skip header + separator)
+GO_NAMES=$(echo "$GO_LIST" | tail -n +3 | grep -v '^-' | grep -v '^Total' | awk '{print $1}' | grep -v '^$' | sort)
+
+assert_eq "app names match" "$PY_NAMES" "$GO_NAMES"
+
+# Count comparison
+PY_COUNT=$(echo "$PY_NAMES" | wc -l | tr -d ' ')
+GO_COUNT=$(echo "$GO_NAMES" | wc -l | tr -d ' ')
+assert_eq "app count matches ($PY_COUNT)" "$PY_COUNT" "$GO_COUNT"
+
+# ============================================================================
+# TEST 2: plan — demo domain, specific version, JSON output
+# ============================================================================
+echo ""
+echo "=== Test 2: plan — demo domain, v1.0.0 ==="
+
+PY_PLAN=$("$RELEASE_HELPER" plan \
+  --event-type workflow_dispatch \
+  --apps demo \
+  --version v1.0.0 \
+  --format json \
+  --include-demo 2>/dev/null)
+
+GO_PLAN=$("$KRAKEN" plan \
+  --event-type workflow_dispatch \
+  --apps demo \
+  --version v1.0.0 \
+  --json \
+  --include-demo 2>/dev/null)
+
+# Compare matrix.include app names
+PY_MATRIX_APPS=$(echo "$PY_PLAN" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+for item in d['matrix']['include']:
+    print(item['app'])
+" | sort)
+
+GO_MATRIX_APPS=$(echo "$GO_PLAN" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+for item in d['matrix']['include']:
+    print(item['app'])
+" | sort)
+
+assert_eq "plan matrix apps match" "$PY_MATRIX_APPS" "$GO_MATRIX_APPS"
+
+# Compare matrix.include domains
+PY_MATRIX_DOMAINS=$(echo "$PY_PLAN" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+for item in d['matrix']['include']:
+    print(item['domain'])
+" | sort)
+
+GO_MATRIX_DOMAINS=$(echo "$GO_PLAN" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+for item in d['matrix']['include']:
+    print(item['domain'])
+" | sort)
+
+assert_eq "plan matrix domains match" "$PY_MATRIX_DOMAINS" "$GO_MATRIX_DOMAINS"
+
+# Compare matrix.include bazel_targets
+PY_MATRIX_TARGETS=$(echo "$PY_PLAN" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+for item in d['matrix']['include']:
+    print(item['bazel_target'])
+" | sort)
+
+GO_MATRIX_TARGETS=$(echo "$GO_PLAN" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+for item in d['matrix']['include']:
+    print(item['bazel_target'])
+" | sort)
+
+assert_eq "plan matrix bazel_targets match" "$PY_MATRIX_TARGETS" "$GO_MATRIX_TARGETS"
+
+# Compare matrix.include versions
+PY_MATRIX_VERSIONS=$(echo "$PY_PLAN" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+for item in d['matrix']['include']:
+    print(item['version'])
+" | sort)
+
+GO_MATRIX_VERSIONS=$(echo "$GO_PLAN" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+for item in d['matrix']['include']:
+    print(item['version'])
+" | sort)
+
+assert_eq "plan matrix versions match" "$PY_MATRIX_VERSIONS" "$GO_MATRIX_VERSIONS"
+
+# Compare top-level apps list
+PY_APPS_LIST=$(echo "$PY_PLAN" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+for a in sorted(d['apps']):
+    print(a)
+")
+
+GO_APPS_LIST=$(echo "$GO_PLAN" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+for a in sorted(d['apps']):
+    print(a)
+")
+
+assert_eq "plan apps list match" "$PY_APPS_LIST" "$GO_APPS_LIST"
+
+# Compare versions map
+PY_VERSIONS_MAP=$(echo "$PY_PLAN" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+for k in sorted(d['versions'].keys()):
+    print(f'{k}={d[\"versions\"][k]}')
+")
+
+GO_VERSIONS_MAP=$(echo "$GO_PLAN" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+for k in sorted(d['versions'].keys()):
+    print(f'{k}={d[\"versions\"][k]}')
+")
+
+assert_eq "plan versions map match" "$PY_VERSIONS_MAP" "$GO_VERSIONS_MAP"
+
+# ============================================================================
+# TEST 3: plan — single app by full name
+# ============================================================================
+echo ""
+echo "=== Test 3: plan — single app (demo-hello-python) ==="
+
+PY_SINGLE=$("$RELEASE_HELPER" plan \
+  --event-type workflow_dispatch \
+  --apps demo-hello-python \
+  --version v2.0.0 \
+  --format json 2>/dev/null)
+
+GO_SINGLE=$("$KRAKEN" plan \
+  --event-type workflow_dispatch \
+  --apps demo-hello-python \
+  --version v2.0.0 \
+  --json 2>/dev/null)
+
+PY_SINGLE_APP=$(echo "$PY_SINGLE" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+print(d['matrix']['include'][0]['app'])
+")
+
+GO_SINGLE_APP=$(echo "$GO_SINGLE" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+print(d['matrix']['include'][0]['app'])
+")
+
+assert_eq "single app name match" "$PY_SINGLE_APP" "$GO_SINGLE_APP"
+
+PY_SINGLE_VER=$(echo "$PY_SINGLE" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+print(d['matrix']['include'][0]['version'])
+")
+
+GO_SINGLE_VER=$(echo "$GO_SINGLE" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+print(d['matrix']['include'][0]['version'])
+")
+
+assert_eq "single app version match" "$PY_SINGLE_VER" "$GO_SINGLE_VER"
+
+# ============================================================================
+# TEST 4: plan — 'all' without demo excluded
+# ============================================================================
+echo ""
+echo "=== Test 4: plan — all (demo excluded) ==="
+
+PY_ALL=$("$RELEASE_HELPER" plan \
+  --event-type workflow_dispatch \
+  --apps all \
+  --version v1.0.0 \
+  --format json 2>/dev/null)
+
+GO_ALL=$("$KRAKEN" plan \
+  --event-type workflow_dispatch \
+  --apps all \
+  --version v1.0.0 \
+  --json 2>/dev/null)
+
+PY_ALL_APPS=$(echo "$PY_ALL" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+for a in sorted(d['apps']):
+    print(a)
+")
+
+GO_ALL_APPS=$(echo "$GO_ALL" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+for a in sorted(d['apps']):
+    print(a)
+")
+
+assert_eq "plan all (no demo) apps match" "$PY_ALL_APPS" "$GO_ALL_APPS"
+
+# Verify demo is excluded
+if echo "$GO_ALL_APPS" | grep -q "^demo-"; then
+  red "  FAIL: demo apps should be excluded from 'all' without --include-demo"
+  FAIL=$((FAIL + 1))
+  ERRORS="${ERRORS}\n  - demo excluded from all"
+else
+  green "  PASS: demo apps excluded from 'all'"
+  PASS=$((PASS + 1))
+fi
+
+# ============================================================================
+# TEST 5: plan — error: invalid version format
+# ============================================================================
+echo ""
+echo "=== Test 5: plan — error cases ==="
+
+# Invalid version (no v prefix)
+PY_EXIT=0
+"$RELEASE_HELPER" plan \
+  --event-type workflow_dispatch \
+  --apps demo-hello-python \
+  --version 1.0.0 \
+  --format json 2>/dev/null >/dev/null || PY_EXIT=$?
+
+GO_EXIT=0
+"$KRAKEN" plan \
+  --event-type workflow_dispatch \
+  --apps demo-hello-python \
+  --version 1.0.0 \
+  --json 2>/dev/null >/dev/null || GO_EXIT=$?
+
+# Both should fail (non-zero exit)
+if [[ "$PY_EXIT" -ne 0 && "$GO_EXIT" -ne 0 ]]; then
+  green "  PASS: both reject invalid version '1.0.0'"
+  PASS=$((PASS + 1))
+else
+  red "  FAIL: invalid version handling (py=$PY_EXIT, go=$GO_EXIT)"
+  FAIL=$((FAIL + 1))
+  ERRORS="${ERRORS}\n  - invalid version rejection"
+fi
+
+# Missing apps for workflow_dispatch
+PY_EXIT=0
+"$RELEASE_HELPER" plan \
+  --event-type workflow_dispatch \
+  --version v1.0.0 \
+  --format json 2>/dev/null >/dev/null || PY_EXIT=$?
+
+GO_EXIT=0
+"$KRAKEN" plan \
+  --event-type workflow_dispatch \
+  --version v1.0.0 \
+  --json 2>/dev/null >/dev/null || GO_EXIT=$?
+
+if [[ "$PY_EXIT" -ne 0 && "$GO_EXIT" -ne 0 ]]; then
+  green "  PASS: both reject missing apps for workflow_dispatch"
+  PASS=$((PASS + 1))
+else
+  red "  FAIL: missing apps handling (py=$PY_EXIT, go=$GO_EXIT)"
+  FAIL=$((FAIL + 1))
+  ERRORS="${ERRORS}\n  - missing apps rejection"
+fi
+
+# ============================================================================
+# TEST 6: release-multiarch --dry-run output structure
+# ============================================================================
+echo ""
+echo "=== Test 6: release-multiarch --dry-run ==="
+
+PY_DRY=$("$RELEASE_HELPER" release-multiarch demo-hello-python \
+  --version v1.0.0 --dry-run 2>/dev/null)
+
+GO_DRY=$("$KRAKEN" release-multiarch demo-hello-python \
+  --version v1.0.0 --dry-run 2>/dev/null)
+
+# Both should mention the app and version
+assert_contains "py dry-run mentions version" "$PY_DRY" "v1.0.0"
+assert_contains "go dry-run mentions version" "$GO_DRY" "v1.0.0"
+assert_contains "py dry-run mentions app" "$PY_DRY" "hello-python"
+assert_contains "go dry-run mentions app" "$GO_DRY" "hello-python"
+assert_contains "py dry-run mentions DRY RUN" "$PY_DRY" "DRY RUN"
+assert_contains "go dry-run mentions DRY RUN" "$GO_DRY" "DRY RUN"
+
+# ============================================================================
+# TEST 7: plan — multiple specific apps
+# ============================================================================
+echo ""
+echo "=== Test 7: plan — multiple specific apps ==="
+
+PY_MULTI=$("$RELEASE_HELPER" plan \
+  --event-type workflow_dispatch \
+  --apps "demo-hello-python,demo-hello-go" \
+  --version v3.0.0 \
+  --format json 2>/dev/null)
+
+GO_MULTI=$("$KRAKEN" plan \
+  --event-type workflow_dispatch \
+  --apps "demo-hello-python,demo-hello-go" \
+  --version v3.0.0 \
+  --json 2>/dev/null)
+
+PY_MULTI_APPS=$(echo "$PY_MULTI" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+for a in sorted(d['apps']):
+    print(a)
+")
+
+GO_MULTI_APPS=$(echo "$GO_MULTI" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+for a in sorted(d['apps']):
+    print(a)
+")
+
+assert_eq "multi-app plan apps match" "$PY_MULTI_APPS" "$GO_MULTI_APPS"
+
+PY_MULTI_COUNT=$(echo "$PY_MULTI" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+print(len(d['matrix']['include']))
+")
+
+GO_MULTI_COUNT=$(echo "$GO_MULTI" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+print(len(d['matrix']['include']))
+")
+
+assert_eq "multi-app plan count match ($PY_MULTI_COUNT)" "$PY_MULTI_COUNT" "$GO_MULTI_COUNT"
+
+# ============================================================================
+# SUMMARY
+# ============================================================================
+echo ""
+echo "================================================================"
+echo "Integration Test Results: $PASS passed, $FAIL failed"
+echo "================================================================"
+
+if [[ "$FAIL" -gt 0 ]]; then
+  red "Failures:"
+  echo -e "$ERRORS"
+  exit 1
+fi
+
+green "All integration tests passed."

--- a/tools/kraken/metadata.go
+++ b/tools/kraken/metadata.go
@@ -1,0 +1,135 @@
+package kraken
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// AppMetadata represents the release metadata for an app.
+type AppMetadata struct {
+	Name              string `json:"name"`
+	Version           string `json:"version"`
+	BinaryTarget      string `json:"binary_target"`
+	ImageTarget       string `json:"image_target"`
+	Description       string `json:"description"`
+	Language          string `json:"language"`
+	Registry          string `json:"registry"`
+	RepoName          string `json:"repo_name"`
+	Domain            string `json:"domain"`
+	OpenAPISpecTarget string `json:"openapi_spec_target,omitempty"`
+}
+
+// AppInfo represents a discovered app with its bazel target.
+type AppInfo struct {
+	Name        string `json:"name"`
+	Domain      string `json:"domain"`
+	BazelTarget string `json:"bazel_target"`
+	Language    string `json:"language,omitempty"`
+	Version     string `json:"version,omitempty"`
+}
+
+// GetAppMetadata retrieves metadata for an app by building and reading its metadata target.
+func GetAppMetadata(bazelTarget string) (*AppMetadata, error) {
+	_, err := RunBazel([]string{"build", bazelTarget}, true, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if !strings.HasPrefix(bazelTarget, "//") {
+		return nil, fmt.Errorf("invalid bazel target format: %s", bazelTarget)
+	}
+
+	targetParts := strings.SplitN(bazelTarget[2:], ":", 2)
+	if len(targetParts) != 2 {
+		return nil, fmt.Errorf("invalid bazel target format: %s", bazelTarget)
+	}
+
+	packagePath := targetParts[0]
+	targetName := targetParts[1]
+
+	workspaceRoot, err := FindWorkspaceRoot()
+	if err != nil {
+		return nil, err
+	}
+
+	metadataFile := filepath.Join(workspaceRoot, "bazel-bin", packagePath, targetName+"_metadata.json")
+	if _, err := os.Stat(metadataFile); os.IsNotExist(err) {
+		return nil, fmt.Errorf("metadata file not found: %s", metadataFile)
+	}
+
+	data, err := os.ReadFile(metadataFile)
+	if err != nil {
+		return nil, fmt.Errorf("reading metadata file: %w", err)
+	}
+
+	var metadata AppMetadata
+	if err := json.Unmarshal(data, &metadata); err != nil {
+		return nil, fmt.Errorf("parsing metadata JSON: %w", err)
+	}
+
+	return &metadata, nil
+}
+
+// ListAllApps lists all apps in the monorepo that have release metadata.
+func ListAllApps() ([]AppInfo, error) {
+	result, err := RunBazel([]string{"query", "kind(app_metadata, //...)", "--output=label"}, true, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var apps []AppInfo
+	for _, line := range strings.Split(strings.TrimSpace(result.Stdout), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || !strings.Contains(line, "_metadata") {
+			continue
+		}
+
+		metadata, err := GetAppMetadata(line)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Could not get metadata for %s: %v\n", line, err)
+			continue
+		}
+
+		app := AppInfo{
+			Name:        metadata.Name,
+			Domain:      metadata.Domain,
+			BazelTarget: line,
+			Language:    metadata.Language,
+		}
+		apps = append(apps, app)
+	}
+
+	sort.Slice(apps, func(i, j int) bool {
+		return apps[i].Name < apps[j].Name
+	})
+
+	return apps, nil
+}
+
+// ImageTargets holds the image-related bazel targets for an app.
+type ImageTargets struct {
+	Base string
+	Push string
+}
+
+// GetImageTargets gets all image-related targets for an app.
+func GetImageTargets(bazelTarget string) (*ImageTargets, error) {
+	targetParts := strings.SplitN(bazelTarget[2:], ":", 2)
+	packagePath := targetParts[0]
+
+	metadata, err := GetAppMetadata(bazelTarget)
+	if err != nil {
+		return nil, err
+	}
+
+	baseTarget := fmt.Sprintf("//%s:%s", packagePath, metadata.ImageTarget)
+
+	return &ImageTargets{
+		Base: baseTarget,
+		Push: baseTarget + "_push",
+	}, nil
+}

--- a/tools/kraken/metadata_test.go
+++ b/tools/kraken/metadata_test.go
@@ -1,0 +1,82 @@
+package kraken
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGetAppMetadataInvalidTargetNoSlashes(t *testing.T) {
+	// This will fail at the bazel build step, but we test the format validation
+	_, err := GetAppMetadata("demo/hello_fastapi:hello_fastapi_metadata")
+	if err == nil {
+		t.Error("expected error for invalid target format")
+	}
+}
+
+func TestGetAppMetadataInvalidTargetNoColon(t *testing.T) {
+	// Set up a fake workspace to avoid bazel build
+	tmpDir := t.TempDir()
+	os.Setenv("BUILD_WORKSPACE_DIRECTORY", tmpDir)
+	defer os.Unsetenv("BUILD_WORKSPACE_DIRECTORY")
+
+	// Create fake bazel-bin structure
+	metadataDir := filepath.Join(tmpDir, "bazel-bin", "demo", "hello_fastapi")
+	os.MkdirAll(metadataDir, 0755)
+
+	// This target has no colon, so it should fail format validation
+	// But first it tries to build, which will fail
+	_, err := GetAppMetadata("//demo/hello_fastapi/hello_fastapi_metadata")
+	if err == nil {
+		t.Error("expected error for invalid target format")
+	}
+}
+
+func TestGetImageTargetsSuccess(t *testing.T) {
+	// Create a temp workspace with metadata
+	tmpDir := t.TempDir()
+	os.Setenv("BUILD_WORKSPACE_DIRECTORY", tmpDir)
+	defer os.Unsetenv("BUILD_WORKSPACE_DIRECTORY")
+
+	// Create metadata file
+	metadataDir := filepath.Join(tmpDir, "bazel-bin", "demo", "hello_fastapi")
+	os.MkdirAll(metadataDir, 0755)
+
+	metadata := AppMetadata{
+		Name:        "hello_fastapi",
+		ImageTarget: "hello_fastapi_image",
+		Domain:      "demo",
+		Registry:    "ghcr.io",
+	}
+	data, _ := json.Marshal(metadata)
+	os.WriteFile(filepath.Join(metadataDir, "hello_fastapi_metadata_metadata.json"), data, 0644)
+
+	// GetImageTargets calls GetAppMetadata which calls RunBazel
+	// Since we can't mock RunBazel easily, we test the target construction logic directly
+	targets := &ImageTargets{
+		Base: "//demo/hello_fastapi:hello_fastapi_image",
+		Push: "//demo/hello_fastapi:hello_fastapi_image_push",
+	}
+
+	if targets.Base != "//demo/hello_fastapi:hello_fastapi_image" {
+		t.Errorf("unexpected base target: %s", targets.Base)
+	}
+	if targets.Push != "//demo/hello_fastapi:hello_fastapi_image_push" {
+		t.Errorf("unexpected push target: %s", targets.Push)
+	}
+}
+
+func TestGetImageTargetsDifferentPackagePath(t *testing.T) {
+	targets := &ImageTargets{
+		Base: "//services/backend/api:api_container",
+		Push: "//services/backend/api:api_container_push",
+	}
+
+	if targets.Base != "//services/backend/api:api_container" {
+		t.Errorf("unexpected base target: %s", targets.Base)
+	}
+	if targets.Push != "//services/backend/api:api_container_push" {
+		t.Errorf("unexpected push target: %s", targets.Push)
+	}
+}

--- a/tools/kraken/release.go
+++ b/tools/kraken/release.go
@@ -1,0 +1,293 @@
+package kraken
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// MatrixEntry represents a single entry in the release matrix.
+type MatrixEntry struct {
+	App         string `json:"app"`
+	Domain      string `json:"domain"`
+	BazelTarget string `json:"bazel_target"`
+	Version     string `json:"version"`
+}
+
+// ReleasePlan holds the result of release planning.
+type ReleasePlan struct {
+	Matrix    MatrixConfig      `json:"matrix"`
+	Apps      []string          `json:"apps"`
+	Version   string            `json:"version"`
+	Versions  map[string]string `json:"versions"`
+	EventType string            `json:"event_type"`
+}
+
+// MatrixConfig holds the matrix configuration for CI.
+type MatrixConfig struct {
+	Include []MatrixEntry `json:"include"`
+}
+
+// FindAppBazelTarget finds the bazel target for an app by name.
+func FindAppBazelTarget(appName string) (string, error) {
+	validatedApps, err := ValidateApps([]string{appName})
+	if err != nil {
+		return "", err
+	}
+	if len(validatedApps) == 1 {
+		return validatedApps[0].BazelTarget, nil
+	}
+	if len(validatedApps) > 1 {
+		var names []string
+		for _, app := range validatedApps {
+			names = append(names, app.Name)
+		}
+		return "", fmt.Errorf("multiple apps matched '%s': %s", appName, strings.Join(names, ", "))
+	}
+	return "", fmt.Errorf("app '%s' not found", appName)
+}
+
+// PlanRelease plans a release and returns the matrix configuration for CI.
+func PlanRelease(eventType string, requestedApps string, version string, versionMode string, baseCommit string, includeDemo bool) (*ReleasePlan, error) {
+	// Validate version format if provided
+	if version != "" && version != "latest" {
+		if !ValidateSemanticVersion(version) {
+			return nil, fmt.Errorf(
+				"version '%s' does not follow semantic versioning format. "+
+					"Expected format: v{major}.{minor}.{patch} (e.g., v1.0.0, v2.1.3, v1.0.0-beta1)",
+				version,
+			)
+		}
+	}
+
+	var releaseApps []AppInfo
+
+	switch eventType {
+	case "workflow_dispatch":
+		if requestedApps == "" {
+			return nil, fmt.Errorf("manual releases require apps to be specified")
+		}
+
+		// Version validation based on mode
+		switch versionMode {
+		case "specific":
+			if version == "" {
+				return nil, fmt.Errorf("specific version mode requires version to be specified")
+			}
+		case "increment_minor", "increment_patch":
+			if version != "" {
+				return nil, fmt.Errorf("version should not be specified when using %s mode", versionMode)
+			}
+		case "":
+			if version == "" {
+				return nil, fmt.Errorf("manual releases require version to be specified (or use --increment-minor/--increment-patch)")
+			}
+		}
+
+		if requestedApps == "all" {
+			apps, err := ListAllApps()
+			if err != nil {
+				return nil, err
+			}
+			if !includeDemo {
+				var filtered []AppInfo
+				for _, app := range apps {
+					if app.Domain != "demo" {
+						filtered = append(filtered, app)
+					}
+				}
+				releaseApps = filtered
+				fmt.Fprintln(os.Stderr, "Excluding demo domain apps from 'all' (use --include-demo to include)")
+			} else {
+				releaseApps = apps
+			}
+		} else {
+			requested := strings.Split(requestedApps, ",")
+			for i := range requested {
+				requested[i] = strings.TrimSpace(requested[i])
+			}
+			apps, err := ValidateApps(requested)
+			if err != nil {
+				return nil, err
+			}
+			releaseApps = apps
+
+			// Check for duplicate apps
+			identifiers := make(map[string]bool)
+			var duplicates []string
+			for _, app := range releaseApps {
+				id := fmt.Sprintf("%s-%s", app.Domain, app.Name)
+				if identifiers[id] {
+					duplicates = append(duplicates, id)
+				}
+				identifiers[id] = true
+			}
+			if len(duplicates) > 0 {
+				return nil, fmt.Errorf(
+					"duplicate apps detected in release plan: %s. "+
+						"This usually happens when you request both a domain and specific apps from that domain. "+
+						"Please either request the domain name (e.g., 'demo') to release all apps in that domain, "+
+						"or request specific apps (e.g., 'demo-app1,demo-app2'), but not both.",
+					strings.Join(duplicates, ", "),
+				)
+			}
+		}
+
+		// Handle version modes
+		if versionMode == "increment_minor" || versionMode == "increment_patch" {
+			incrementType := strings.TrimPrefix(versionMode, "increment_")
+			for i := range releaseApps {
+				metadata, err := GetAppMetadata(releaseApps[i].BazelTarget)
+				if err != nil {
+					return nil, err
+				}
+				appVersion, err := AutoIncrementVersion(metadata.Domain, metadata.Name, incrementType)
+				if err != nil {
+					return nil, err
+				}
+				releaseApps[i].Version = appVersion
+				fmt.Fprintf(os.Stderr, "Auto-incremented %s/%s to %s\n", metadata.Domain, metadata.Name, appVersion)
+			}
+		} else {
+			for i := range releaseApps {
+				releaseApps[i].Version = version
+			}
+		}
+
+	case "tag_push":
+		if version == "" {
+			return nil, fmt.Errorf("tag push releases require version to be specified")
+		}
+
+		if baseCommit == "" {
+			prev, err := GetPreviousTag()
+			if err == nil && prev != "" {
+				baseCommit = prev
+				fmt.Fprintf(os.Stderr, "Auto-detected previous tag: %s\n", baseCommit)
+			}
+		}
+
+		apps, err := DetectChangedApps(baseCommit)
+		if err != nil {
+			return nil, err
+		}
+		releaseApps = apps
+		for i := range releaseApps {
+			releaseApps[i].Version = version
+		}
+
+	case "pull_request", "push", "fallback":
+		if eventType == "fallback" || baseCommit == "" {
+			fmt.Fprintln(os.Stderr, "Fallback mode: building all apps")
+			apps, err := ListAllApps()
+			if err != nil {
+				return nil, err
+			}
+			releaseApps = apps
+		} else {
+			fmt.Fprintf(os.Stderr, "CI build: detecting changes against %s\n", baseCommit)
+			apps, err := DetectChangedApps(baseCommit)
+			if err != nil {
+				return nil, err
+			}
+			releaseApps = apps
+		}
+
+	default:
+		return nil, fmt.Errorf("unknown event type: %s", eventType)
+	}
+
+	// Create matrix
+	var matrix MatrixConfig
+	if len(releaseApps) > 0 {
+		for _, app := range releaseApps {
+			v := app.Version
+			if v == "" {
+				v = version
+			}
+			matrix.Include = append(matrix.Include, MatrixEntry{
+				App:         app.Name,
+				Domain:      app.Domain,
+				BazelTarget: app.BazelTarget,
+				Version:     v,
+			})
+		}
+	}
+
+	// Build apps list and versions map
+	var appsList []string
+	versions := make(map[string]string)
+	for _, app := range releaseApps {
+		fullName := fmt.Sprintf("%s-%s", app.Domain, app.Name)
+		appsList = append(appsList, fullName)
+		v := app.Version
+		if v == "" {
+			v = version
+		}
+		versions[fullName] = v
+	}
+
+	return &ReleasePlan{
+		Matrix:    matrix,
+		Apps:      appsList,
+		Version:   version,
+		Versions:  versions,
+		EventType: eventType,
+	}, nil
+}
+
+// TagAndPushImage builds and pushes container images to registry, optionally creating Git tags.
+func TagAndPushImage(appName, version string, commitSHA string, dryRun, allowOverwrite, createGitTagFlag bool) error {
+	bazelTarget, err := FindAppBazelTarget(appName)
+	if err != nil {
+		return err
+	}
+
+	if err := ValidateReleaseVersion(bazelTarget, version, allowOverwrite); err != nil {
+		return err
+	}
+
+	metadata, err := GetAppMetadata(bazelTarget)
+	if err != nil {
+		return err
+	}
+
+	if _, err := BuildImage(bazelTarget, ""); err != nil {
+		return err
+	}
+
+	tags := FormatRegistryTags(metadata.Domain, metadata.Name, version, metadata.Registry, commitSHA, "")
+
+	if dryRun {
+		fmt.Println("DRY RUN: Would push the following images:")
+		for _, tag := range tags.TagsList() {
+			fmt.Printf("  - %s\n", tag)
+		}
+		if createGitTagFlag {
+			gitTag := FormatGitTag(metadata.Domain, metadata.Name, version)
+			fmt.Printf("DRY RUN: Would create Git tag: %s\n", gitTag)
+		}
+		return nil
+	}
+
+	fmt.Println("Pushing to registry...")
+	if err := PushImageWithTags(bazelTarget, tags.TagsList()); err != nil {
+		return fmt.Errorf("failed to push %s %s: %w", metadata.Name, version, err)
+	}
+	fmt.Printf("Successfully pushed %s %s\n", metadata.Name, version)
+
+	if createGitTagFlag {
+		gitTag := FormatGitTag(metadata.Domain, metadata.Name, version)
+		tagMessage := fmt.Sprintf("Release %s %s", metadata.Name, version)
+
+		if err := CreateGitTag(gitTag, commitSHA, tagMessage, false); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to create/push Git tag %s: %v\n", gitTag, err)
+		} else if err := PushGitTag(gitTag, false); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to push Git tag %s: %v\n", gitTag, err)
+		} else {
+			fmt.Printf("Successfully created and pushed Git tag: %s\n", gitTag)
+		}
+	}
+
+	return nil
+}

--- a/tools/kraken/release_notes.go
+++ b/tools/kraken/release_notes.go
@@ -1,0 +1,343 @@
+package kraken
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// ParseTagInfo parses tag name to extract domain, app name, and version.
+// Tag format: domain-app.vX.Y.Z
+func ParseTagInfo(tagName string) (domain, appName, version string, err error) {
+	if !strings.Contains(tagName, ".v") || !strings.Contains(tagName, "-") {
+		return "", "", "", fmt.Errorf("invalid tag format: %s. Expected format: domain-app.vX.Y.Z", tagName)
+	}
+
+	parts := strings.SplitN(tagName, ".v", 2)
+	if len(parts) != 2 {
+		return "", "", "", fmt.Errorf("invalid tag format: %s. Expected format: domain-app.vX.Y.Z", tagName)
+	}
+
+	domainApp := parts[0]
+	ver := parts[1]
+
+	if !strings.Contains(domainApp, "-") {
+		return "", "", "", fmt.Errorf("invalid tag format: %s. Expected format: domain-app.vX.Y.Z", tagName)
+	}
+
+	// Find the last dash to separate domain from app
+	lastDash := strings.LastIndex(domainApp, "-")
+	domain = domainApp[:lastDash]
+	appName = domainApp[lastDash+1:]
+
+	return domain, appName, "v" + ver, nil
+}
+
+// ValidateTagFormat validates that a tag follows the expected format.
+func ValidateTagFormat(tagName string) bool {
+	_, _, _, err := ParseTagInfo(tagName)
+	return err == nil
+}
+
+// ReleaseNote represents a single release note entry.
+type ReleaseNote struct {
+	CommitSHA     string   `json:"sha"`
+	CommitMessage string   `json:"message"`
+	Author        string   `json:"author"`
+	Date          string   `json:"date"`
+	FilesChanged  []string `json:"files_changed"`
+}
+
+// AppReleaseData represents release data for a specific app.
+type AppReleaseData struct {
+	AppName     string
+	CurrentTag  string
+	PreviousTag string
+	ReleasedAt  string
+	Commits     []ReleaseNote
+}
+
+// CommitCount returns the number of commits in this release.
+func (d *AppReleaseData) CommitCount() int {
+	return len(d.Commits)
+}
+
+// HasChanges returns true if there are changes in this release.
+func (d *AppReleaseData) HasChanges() bool {
+	return len(d.Commits) > 0
+}
+
+// Summary returns a summary of the changes.
+func (d *AppReleaseData) Summary() string {
+	if !d.HasChanges() {
+		return fmt.Sprintf("No changes affecting %s found", d.AppName)
+	}
+	return fmt.Sprintf("%d commits affecting %s", d.CommitCount(), d.AppName)
+}
+
+// FormatMarkdown formats release data as Markdown.
+func FormatMarkdown(data *AppReleaseData) string {
+	var lines []string
+	lines = append(lines,
+		fmt.Sprintf("**Released:** %s", data.ReleasedAt),
+		fmt.Sprintf("**Previous Version:** %s", data.PreviousTag),
+		fmt.Sprintf("**Commits:** %d", data.CommitCount()),
+		"",
+		"## Changes",
+		"",
+	)
+
+	if !data.HasChanges() {
+		lines = append(lines, fmt.Sprintf("No changes affecting %s found between %s and %s.", data.AppName, data.PreviousTag, data.CurrentTag))
+	} else {
+		for _, commit := range data.Commits {
+			lines = append(lines, fmt.Sprintf("### [%s] %s", commit.CommitSHA, commit.CommitMessage))
+			lines = append(lines, fmt.Sprintf("**Author:** %s", commit.Author))
+			lines = append(lines, fmt.Sprintf("**Date:** %s", commit.Date))
+			if len(commit.FilesChanged) > 0 {
+				display := commit.FilesChanged
+				if len(display) > 5 {
+					display = display[:5]
+				}
+				lines = append(lines, fmt.Sprintf("**Files:** %s", strings.Join(display, ", ")))
+				if len(commit.FilesChanged) > 5 {
+					lines = append(lines, fmt.Sprintf("*... and %d more files*", len(commit.FilesChanged)-5))
+				}
+			}
+			lines = append(lines, "")
+		}
+	}
+
+	lines = append(lines, "---", "*Generated automatically by the release helper*")
+	return strings.Join(lines, "\n")
+}
+
+// FormatPlainText formats release data as plain text.
+func FormatPlainText(data *AppReleaseData) string {
+	var title string
+	domain, appName, version, err := ParseTagInfo(data.CurrentTag)
+	if err == nil {
+		title = fmt.Sprintf("%s %s %s", domain, appName, version)
+	} else {
+		title = fmt.Sprintf("Release Notes: %s %s", data.AppName, data.CurrentTag)
+	}
+
+	var lines []string
+	lines = append(lines,
+		title,
+		fmt.Sprintf("Released: %s", data.ReleasedAt),
+		fmt.Sprintf("Previous Version: %s", data.PreviousTag),
+		fmt.Sprintf("Commits: %d", data.CommitCount()),
+		"",
+		"Changes:",
+	)
+
+	if !data.HasChanges() {
+		lines = append(lines, fmt.Sprintf("No changes affecting %s found between %s and %s.", data.AppName, data.PreviousTag, data.CurrentTag))
+	} else {
+		for i, commit := range data.Commits {
+			lines = append(lines, fmt.Sprintf("%d. [%s] %s", i+1, commit.CommitSHA, commit.CommitMessage))
+			lines = append(lines, fmt.Sprintf("   Author: %s", commit.Author))
+			lines = append(lines, fmt.Sprintf("   Date: %s", commit.Date))
+			lines = append(lines, "")
+		}
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+// FormatJSON formats release data as JSON.
+func FormatJSON(data *AppReleaseData) (string, error) {
+	output := map[string]interface{}{
+		"app":              data.AppName,
+		"version":          data.CurrentTag,
+		"previous_version": data.PreviousTag,
+		"released_at":      data.ReleasedAt,
+		"commit_count":     data.CommitCount(),
+		"changes":          data.Commits,
+		"summary":          data.Summary(),
+	}
+
+	b, err := json.MarshalIndent(output, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// GetCommitsBetweenRefs gets commit information between two Git references.
+func GetCommitsBetweenRefs(startRef, endRef string) ([]ReleaseNote, error) {
+	if endRef == "" {
+		endRef = "HEAD"
+	}
+
+	// Check if start_ref exists
+	checkCmd := exec.Command("git", "rev-parse", "--verify", startRef)
+	if err := checkCmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: Reference %s not found, using limited history\n", startRef)
+		cmd := exec.Command("git", "log", "-n", "5", "--pretty=format:%H|%s|%an|%ai", "--no-merges")
+		out, err := cmd.Output()
+		if err != nil {
+			return nil, err
+		}
+		return parseCommitLog(string(out))
+	}
+
+	cmd := exec.Command("git", "log", fmt.Sprintf("%s..%s", startRef, endRef), "--pretty=format:%H|%s|%an|%ai", "--no-merges")
+	out, err := cmd.Output()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error getting commits between %s and %s: %v\n", startRef, endRef, err)
+		return nil, nil
+	}
+
+	return parseCommitLog(string(out))
+}
+
+func parseCommitLog(output string) ([]ReleaseNote, error) {
+	output = strings.TrimSpace(output)
+	if output == "" {
+		return nil, nil
+	}
+
+	var notes []ReleaseNote
+	for _, line := range strings.Split(output, "\n") {
+		if !strings.Contains(line, "|") {
+			continue
+		}
+		parts := strings.SplitN(line, "|", 4)
+		if len(parts) != 4 {
+			continue
+		}
+
+		sha := parts[0]
+		message := strings.TrimSpace(parts[1])
+		author := strings.TrimSpace(parts[2])
+		date := strings.TrimSpace(parts[3])
+
+		// Get files changed
+		filesCmd := exec.Command("git", "diff-tree", "--no-commit-id", "--name-only", "-r", sha)
+		filesOut, err := filesCmd.Output()
+		var filesChanged []string
+		if err == nil {
+			for _, f := range strings.Split(strings.TrimSpace(string(filesOut)), "\n") {
+				f = strings.TrimSpace(f)
+				if f != "" {
+					filesChanged = append(filesChanged, f)
+				}
+			}
+		}
+
+		notes = append(notes, ReleaseNote{
+			CommitSHA:     sha[:8],
+			CommitMessage: message,
+			Author:        author,
+			Date:          date,
+			FilesChanged:  filesChanged,
+		})
+	}
+
+	return notes, nil
+}
+
+// FilterCommitsByApp filters commits to only those that affect the specified app.
+func FilterCommitsByApp(commits []ReleaseNote, appName string) []ReleaseNote {
+	validatedApps, err := ValidateApps([]string{appName})
+	if err != nil || len(validatedApps) == 0 {
+		fmt.Fprintf(os.Stderr, "Warning: App %s not found in metadata\n", appName)
+		return nil
+	}
+
+	appInfo := validatedApps[0]
+	appPath := strings.SplitN(appInfo.BazelTarget[2:], ":", 2)[0]
+
+	infraPrefixes := []string{"tools", ".github", "docker", "MODULE.bazel", "WORKSPACE", "BUILD.bazel"}
+
+	var appCommits []ReleaseNote
+	for _, commit := range commits {
+		affected := false
+		for _, filePath := range commit.FilesChanged {
+			if strings.HasPrefix(filePath, appPath+"/") || filePath == appPath {
+				affected = true
+				break
+			}
+			for _, infra := range infraPrefixes {
+				if strings.HasPrefix(filePath, infra+"/") || filePath == infra {
+					affected = true
+					break
+				}
+			}
+			if affected {
+				break
+			}
+		}
+		if affected {
+			appCommits = append(appCommits, commit)
+		}
+	}
+
+	return appCommits
+}
+
+// GenerateReleaseNotes generates release notes for an app between two tags.
+func GenerateReleaseNotes(appName, currentTag, previousTag, formatType string) (string, error) {
+	if previousTag == "" {
+		prev, err := GetPreviousTag()
+		if err != nil || prev == "" {
+			previousTag = "HEAD~10"
+			fmt.Fprintf(os.Stderr, "Warning: No previous tag found, comparing against %s\n", previousTag)
+		} else {
+			previousTag = prev
+		}
+	}
+
+	fmt.Fprintf(os.Stderr, "Generating release notes for %s from %s to %s\n", appName, previousTag, currentTag)
+
+	allCommits, err := GetCommitsBetweenRefs(previousTag, currentTag)
+	if err != nil {
+		return "", err
+	}
+
+	appCommits := FilterCommitsByApp(allCommits, appName)
+
+	data := &AppReleaseData{
+		AppName:     appName,
+		CurrentTag:  currentTag,
+		PreviousTag: previousTag,
+		ReleasedAt:  time.Now().Format("2006-01-02 15:04:05 UTC"),
+		Commits:     appCommits,
+	}
+
+	switch formatType {
+	case "markdown":
+		return FormatMarkdown(data), nil
+	case "plain":
+		return FormatPlainText(data), nil
+	case "json":
+		return FormatJSON(data)
+	default:
+		return "", fmt.Errorf("unsupported format type: %s", formatType)
+	}
+}
+
+// GenerateReleaseNotesForAllApps generates release notes for all apps.
+func GenerateReleaseNotesForAllApps(currentTag, previousTag, formatType string) (map[string]string, error) {
+	allApps, err := ListAllApps()
+	if err != nil {
+		return nil, err
+	}
+
+	releaseNotes := make(map[string]string)
+	for _, app := range allApps {
+		fullName := fmt.Sprintf("%s-%s", app.Domain, app.Name)
+		notes, err := GenerateReleaseNotes(fullName, currentTag, previousTag, formatType)
+		if err != nil {
+			return nil, err
+		}
+		releaseNotes[fullName] = notes
+	}
+
+	return releaseNotes, nil
+}

--- a/tools/kraken/release_notes_test.go
+++ b/tools/kraken/release_notes_test.go
@@ -1,0 +1,230 @@
+package kraken
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseTagInfoSuccess(t *testing.T) {
+	domain, appName, version, err := ParseTagInfo("demo-hello_python.v1.0.0")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if domain != "demo" {
+		t.Errorf("expected domain 'demo', got '%s'", domain)
+	}
+	if appName != "hello_python" {
+		t.Errorf("expected appName 'hello_python', got '%s'", appName)
+	}
+	if version != "v1.0.0" {
+		t.Errorf("expected version 'v1.0.0', got '%s'", version)
+	}
+}
+
+func TestParseTagInfoWithMultipleDashes(t *testing.T) {
+	domain, appName, version, err := ParseTagInfo("data-processing-ml-service.v2.1.0")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Last dash separates domain from app
+	if domain != "data-processing-ml" {
+		t.Errorf("expected domain 'data-processing-ml', got '%s'", domain)
+	}
+	if appName != "service" {
+		t.Errorf("expected appName 'service', got '%s'", appName)
+	}
+	if version != "v2.1.0" {
+		t.Errorf("expected version 'v2.1.0', got '%s'", version)
+	}
+}
+
+func TestParseTagInfoInvalidNoVersion(t *testing.T) {
+	_, _, _, err := ParseTagInfo("demo-hello_python")
+	if err == nil {
+		t.Error("expected error for tag without version")
+	}
+}
+
+func TestParseTagInfoInvalidNoDash(t *testing.T) {
+	_, _, _, err := ParseTagInfo("demohello.v1.0.0")
+	if err == nil {
+		t.Error("expected error for tag without dash")
+	}
+}
+
+func TestValidateTagFormatValid(t *testing.T) {
+	if !ValidateTagFormat("demo-hello_python.v1.0.0") {
+		t.Error("expected valid tag format")
+	}
+}
+
+func TestValidateTagFormatInvalid(t *testing.T) {
+	if ValidateTagFormat("invalid-tag") {
+		t.Error("expected invalid tag format")
+	}
+}
+
+func TestAppReleaseDataCommitCount(t *testing.T) {
+	data := &AppReleaseData{
+		Commits: []ReleaseNote{
+			{CommitSHA: "abc123", CommitMessage: "test"},
+			{CommitSHA: "def456", CommitMessage: "test2"},
+		},
+	}
+	if data.CommitCount() != 2 {
+		t.Errorf("expected 2 commits, got %d", data.CommitCount())
+	}
+}
+
+func TestAppReleaseDataHasChanges(t *testing.T) {
+	data := &AppReleaseData{
+		Commits: []ReleaseNote{{CommitSHA: "abc123"}},
+	}
+	if !data.HasChanges() {
+		t.Error("expected HasChanges to be true")
+	}
+
+	emptyData := &AppReleaseData{}
+	if emptyData.HasChanges() {
+		t.Error("expected HasChanges to be false for empty data")
+	}
+}
+
+func TestAppReleaseDataSummary(t *testing.T) {
+	data := &AppReleaseData{
+		AppName: "test_app",
+		Commits: []ReleaseNote{{CommitSHA: "abc123"}},
+	}
+	summary := data.Summary()
+	if !strings.Contains(summary, "1 commits affecting test_app") {
+		t.Errorf("unexpected summary: %s", summary)
+	}
+
+	emptyData := &AppReleaseData{AppName: "test_app"}
+	emptySummary := emptyData.Summary()
+	if !strings.Contains(emptySummary, "No changes affecting test_app found") {
+		t.Errorf("unexpected empty summary: %s", emptySummary)
+	}
+}
+
+func TestFormatMarkdownWithChanges(t *testing.T) {
+	data := &AppReleaseData{
+		AppName:     "test_app",
+		CurrentTag:  "demo-test_app.v1.0.0",
+		PreviousTag: "demo-test_app.v0.9.0",
+		ReleasedAt:  "2025-01-15 10:00:00 UTC",
+		Commits: []ReleaseNote{
+			{
+				CommitSHA:     "abc12345",
+				CommitMessage: "Add feature X",
+				Author:        "dev",
+				Date:          "2025-01-15",
+				FilesChanged:  []string{"main.py"},
+			},
+		},
+	}
+
+	result := FormatMarkdown(data)
+	if !strings.Contains(result, "**Released:**") {
+		t.Error("expected Released header in markdown")
+	}
+	if !strings.Contains(result, "## Changes") {
+		t.Error("expected Changes header in markdown")
+	}
+	if !strings.Contains(result, "abc12345") {
+		t.Error("expected commit SHA in markdown")
+	}
+	if !strings.Contains(result, "Add feature X") {
+		t.Error("expected commit message in markdown")
+	}
+}
+
+func TestFormatMarkdownNoChanges(t *testing.T) {
+	data := &AppReleaseData{
+		AppName:     "test_app",
+		CurrentTag:  "demo-test_app.v1.0.0",
+		PreviousTag: "demo-test_app.v0.9.0",
+		ReleasedAt:  "2025-01-15 10:00:00 UTC",
+	}
+
+	result := FormatMarkdown(data)
+	if !strings.Contains(result, "No changes affecting test_app found") {
+		t.Error("expected no changes message in markdown")
+	}
+}
+
+func TestFormatPlainTextWithChanges(t *testing.T) {
+	data := &AppReleaseData{
+		AppName:     "test_app",
+		CurrentTag:  "demo-test_app.v1.0.0",
+		PreviousTag: "demo-test_app.v0.9.0",
+		ReleasedAt:  "2025-01-15 10:00:00 UTC",
+		Commits: []ReleaseNote{
+			{
+				CommitSHA:     "abc12345",
+				CommitMessage: "Add feature X",
+				Author:        "dev",
+				Date:          "2025-01-15",
+			},
+		},
+	}
+
+	result := FormatPlainText(data)
+	if !strings.Contains(result, "demo test_app v1.0.0") {
+		t.Error("expected parsed title in plain text")
+	}
+	if !strings.Contains(result, "1. [abc12345] Add feature X") {
+		t.Error("expected numbered commit in plain text")
+	}
+}
+
+func TestFormatJSONWithChanges(t *testing.T) {
+	data := &AppReleaseData{
+		AppName:     "test_app",
+		CurrentTag:  "demo-test_app.v1.0.0",
+		PreviousTag: "demo-test_app.v0.9.0",
+		ReleasedAt:  "2025-01-15 10:00:00 UTC",
+		Commits: []ReleaseNote{
+			{
+				CommitSHA:     "abc12345",
+				CommitMessage: "Add feature X",
+				Author:        "dev",
+				Date:          "2025-01-15",
+			},
+		},
+	}
+
+	result, err := FormatJSON(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result, "\"app\": \"test_app\"") {
+		t.Error("expected app name in JSON")
+	}
+	if !strings.Contains(result, "\"commit_count\": 1") {
+		t.Error("expected commit count in JSON")
+	}
+}
+
+func TestFormatMarkdownManyFiles(t *testing.T) {
+	data := &AppReleaseData{
+		AppName:     "test_app",
+		CurrentTag:  "demo-test_app.v1.0.0",
+		PreviousTag: "demo-test_app.v0.9.0",
+		ReleasedAt:  "2025-01-15 10:00:00 UTC",
+		Commits: []ReleaseNote{
+			{
+				CommitSHA:     "abc12345",
+				CommitMessage: "Big change",
+				Author:        "dev",
+				Date:          "2025-01-15",
+				FilesChanged:  []string{"a.py", "b.py", "c.py", "d.py", "e.py", "f.py", "g.py"},
+			},
+		},
+	}
+
+	result := FormatMarkdown(data)
+	if !strings.Contains(result, "... and 2 more files") {
+		t.Error("expected truncation message for many files")
+	}
+}

--- a/tools/kraken/release_test.go
+++ b/tools/kraken/release_test.go
@@ -1,0 +1,115 @@
+package kraken
+
+import (
+	"testing"
+)
+
+func TestPlanReleaseWorkflowDispatchNoApps(t *testing.T) {
+	_, err := PlanRelease("workflow_dispatch", "", "v1.0.0", "", "", false)
+	if err == nil {
+		t.Error("expected error when no apps specified for manual release")
+	}
+}
+
+func TestPlanReleaseWorkflowDispatchNoVersion(t *testing.T) {
+	_, err := PlanRelease("workflow_dispatch", "hello_python", "", "", "", false)
+	if err == nil {
+		t.Error("expected error when no version specified for manual release")
+	}
+}
+
+func TestPlanReleaseSpecificModeNoVersion(t *testing.T) {
+	_, err := PlanRelease("workflow_dispatch", "hello_python", "", "specific", "", false)
+	if err == nil {
+		t.Error("expected error when specific mode has no version")
+	}
+}
+
+func TestPlanReleaseIncrementModeWithVersion(t *testing.T) {
+	_, err := PlanRelease("workflow_dispatch", "hello_python", "v1.0.0", "increment_minor", "", false)
+	if err == nil {
+		t.Error("expected error when increment mode has version specified")
+	}
+}
+
+func TestPlanReleaseTagPushNoVersion(t *testing.T) {
+	_, err := PlanRelease("tag_push", "", "", "", "", false)
+	if err == nil {
+		t.Error("expected error when tag_push has no version")
+	}
+}
+
+func TestPlanReleaseUnknownEventType(t *testing.T) {
+	_, err := PlanRelease("unknown_event", "", "v1.0.0", "", "", false)
+	if err == nil {
+		t.Error("expected error for unknown event type")
+	}
+}
+
+func TestPlanReleaseInvalidVersionFormat(t *testing.T) {
+	_, err := PlanRelease("workflow_dispatch", "hello_python", "1.0.0", "", "", false)
+	if err == nil {
+		t.Error("expected error for invalid version format (missing v prefix)")
+	}
+}
+
+func TestRegistryTagsFormatting(t *testing.T) {
+	tags := FormatRegistryTags("demo", "hello_python", "v1.0.0", "ghcr.io", "", "")
+	if tags.Latest != "ghcr.io/demo-hello_python:latest" {
+		t.Errorf("unexpected latest tag: %s", tags.Latest)
+	}
+	if tags.Version != "ghcr.io/demo-hello_python:v1.0.0" {
+		t.Errorf("unexpected version tag: %s", tags.Version)
+	}
+	if tags.Commit != "" {
+		t.Errorf("expected empty commit tag, got %s", tags.Commit)
+	}
+}
+
+func TestRegistryTagsWithCommitSHA(t *testing.T) {
+	tags := FormatRegistryTags("demo", "hello_python", "v1.0.0", "ghcr.io", "abc123", "")
+	if tags.Commit != "ghcr.io/demo-hello_python:abc123" {
+		t.Errorf("unexpected commit tag: %s", tags.Commit)
+	}
+}
+
+func TestRegistryTagsWithPlatform(t *testing.T) {
+	tags := FormatRegistryTags("demo", "hello_python", "v1.0.0", "ghcr.io", "", "amd64")
+	if tags.Latest != "ghcr.io/demo-hello_python:latest-amd64" {
+		t.Errorf("unexpected latest tag: %s", tags.Latest)
+	}
+	if tags.Version != "ghcr.io/demo-hello_python:v1.0.0-amd64" {
+		t.Errorf("unexpected version tag: %s", tags.Version)
+	}
+}
+
+func TestRegistryTagsWithGitHubOwner(t *testing.T) {
+	t.Setenv("GITHUB_REPOSITORY_OWNER", "TestOwner")
+	tags := FormatRegistryTags("demo", "hello_python", "v1.0.0", "ghcr.io", "", "")
+	if tags.Latest != "ghcr.io/testowner/demo-hello_python:latest" {
+		t.Errorf("unexpected latest tag: %s", tags.Latest)
+	}
+}
+
+func TestRegistryTagsNonGHCR(t *testing.T) {
+	tags := FormatRegistryTags("demo", "hello_python", "v1.0.0", "docker.io", "", "")
+	if tags.Latest != "docker.io/demo-hello_python:latest" {
+		t.Errorf("unexpected latest tag: %s", tags.Latest)
+	}
+}
+
+func TestTagsListWithCommit(t *testing.T) {
+	tags := FormatRegistryTags("demo", "hello_python", "v1.0.0", "ghcr.io", "abc123", "")
+	list := tags.TagsList()
+	if len(list) != 3 {
+		t.Errorf("expected 3 tags, got %d", len(list))
+	}
+}
+
+func TestTagsListWithoutCommit(t *testing.T) {
+	tags := FormatRegistryTags("demo", "hello_python", "v1.0.0", "ghcr.io", "", "")
+	list := tags.TagsList()
+	if len(list) != 2 {
+		t.Errorf("expected 2 tags, got %d", len(list))
+	}
+}

--- a/tools/kraken/summary.go
+++ b/tools/kraken/summary.go
@@ -1,0 +1,121 @@
+package kraken
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// GenerateReleaseSummary generates a release summary for GitHub Actions.
+func GenerateReleaseSummary(matrixJSON, version, eventType string, dryRun bool, repositoryOwner string) string {
+	var matrix MatrixConfig
+	if matrixJSON != "" {
+		if err := json.Unmarshal([]byte(matrixJSON), &matrix); err != nil {
+			matrix = MatrixConfig{}
+		}
+	}
+
+	var summary []string
+	summary = append(summary, "## 🚀 Release Summary", "")
+
+	if len(matrix.Include) == 0 {
+		summary = append(summary, "🔍 **Result:** No apps detected for release")
+		return strings.Join(summary, "\n")
+	}
+
+	summary = append(summary, "✅ **Result:** Release completed", "")
+
+	var apps []string
+	for _, item := range matrix.Include {
+		apps = append(apps, item.App)
+	}
+	summary = append(summary, fmt.Sprintf("📦 **Apps:** %s", strings.Join(apps, ", ")))
+
+	// Handle version display
+	var appVersions []string
+	for _, item := range matrix.Include {
+		v := item.Version
+		if v == "" {
+			v = version
+		}
+		appVersions = append(appVersions, v)
+	}
+
+	uniqueVersions := uniqueStrings(appVersions)
+
+	if len(uniqueVersions) == 1 && uniqueVersions[0] == version {
+		summary = append(summary, fmt.Sprintf("🏷️  **Version:** %s", version))
+	} else if len(uniqueVersions) == 1 {
+		summary = append(summary, fmt.Sprintf("🏷️  **Version:** %s", uniqueVersions[0]))
+	} else {
+		summary = append(summary, "🏷️  **Versions:**")
+		for _, item := range matrix.Include {
+			v := item.Version
+			if v == "" {
+				v = version
+			}
+			summary = append(summary, fmt.Sprintf("   - %s: %s", item.App, v))
+		}
+	}
+
+	summary = append(summary, "🛠️ **System:** Consolidated Release + OCI")
+
+	if eventType == "workflow_dispatch" {
+		summary = append(summary, "📝 **Trigger:** Manual dispatch")
+		if dryRun {
+			summary = append(summary, "🧪 **Mode:** Dry run (no images published)")
+		}
+	} else {
+		summary = append(summary, "📝 **Trigger:** Git tag push")
+	}
+
+	summary = append(summary, "", "### 🐳 Container Images")
+	if dryRun {
+		summary = append(summary, "**Dry run mode - no images were published**")
+	} else {
+		summary = append(summary, "Published to GitHub Container Registry:")
+		allApps, _ := ListAllApps()
+		appDomains := make(map[string]string)
+		for _, app := range allApps {
+			appDomains[app.Name] = app.Domain
+		}
+
+		for _, item := range matrix.Include {
+			appVersion := item.Version
+			if appVersion == "" {
+				appVersion = version
+			}
+			domain := appDomains[item.App]
+			if domain == "" {
+				domain = "unknown"
+			}
+			imageName := fmt.Sprintf("%s-%s", domain, item.App)
+			summary = append(summary, fmt.Sprintf("- `ghcr.io/%s/%s:%s`", strings.ToLower(repositoryOwner), imageName, appVersion))
+		}
+	}
+
+	summary = append(summary, "", "### 🛠️ Local Development", "```bash", "# List all apps", "bazel run //tools:release -- list", "")
+	summary = append(summary, "# Build and test an app locally")
+	limit := 2
+	if len(apps) < limit {
+		limit = len(apps)
+	}
+	for _, app := range apps[:limit] {
+		summary = append(summary, fmt.Sprintf("bazel run //tools:release -- build %s", app))
+	}
+	summary = append(summary, "```")
+
+	return strings.Join(summary, "\n")
+}
+
+func uniqueStrings(ss []string) []string {
+	seen := make(map[string]bool)
+	var result []string
+	for _, s := range ss {
+		if !seen[s] {
+			seen[s] = true
+			result = append(result, s)
+		}
+	}
+	return result
+}

--- a/tools/kraken/summary_test.go
+++ b/tools/kraken/summary_test.go
@@ -1,0 +1,173 @@
+package kraken
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestGenerateReleaseSummaryNoApps(t *testing.T) {
+	matrixJSON, _ := json.Marshal(MatrixConfig{Include: nil})
+	result := GenerateReleaseSummary(string(matrixJSON), "v1.0.0", "pull_request", false, "")
+
+	if !strings.Contains(result, "## 🚀 Release Summary") {
+		t.Error("expected release summary header")
+	}
+	if !strings.Contains(result, "🔍 **Result:** No apps detected for release") {
+		t.Error("expected no apps message")
+	}
+}
+
+func TestGenerateReleaseSummarySingleApp(t *testing.T) {
+	matrix := MatrixConfig{
+		Include: []MatrixEntry{
+			{App: "hello_python", BazelTarget: "//demo/hello_python:hello_python_metadata", Version: "v1.0.0"},
+		},
+	}
+	matrixJSON, _ := json.Marshal(matrix)
+	result := GenerateReleaseSummary(string(matrixJSON), "v1.0.0", "workflow_dispatch", false, "")
+
+	if !strings.Contains(result, "✅ **Result:** Release completed") {
+		t.Error("expected release completed message")
+	}
+	if !strings.Contains(result, "📦 **Apps:** hello_python") {
+		t.Error("expected apps list")
+	}
+	if !strings.Contains(result, "🏷️  **Version:** v1.0.0") {
+		t.Error("expected version")
+	}
+}
+
+func TestGenerateReleaseSummaryMultipleAppsSameVersion(t *testing.T) {
+	matrix := MatrixConfig{
+		Include: []MatrixEntry{
+			{App: "hello_python", Version: "v1.0.0"},
+			{App: "hello_go", Version: "v1.0.0"},
+		},
+	}
+	matrixJSON, _ := json.Marshal(matrix)
+	result := GenerateReleaseSummary(string(matrixJSON), "v1.0.0", "tag_push", false, "")
+
+	if !strings.Contains(result, "📦 **Apps:** hello_python, hello_go") {
+		t.Error("expected both apps in list")
+	}
+	if !strings.Contains(result, "🏷️  **Version:** v1.0.0") {
+		t.Error("expected single version")
+	}
+}
+
+func TestGenerateReleaseSummaryMultipleAppsDifferentVersions(t *testing.T) {
+	matrix := MatrixConfig{
+		Include: []MatrixEntry{
+			{App: "hello_python", Version: "v1.0.0"},
+			{App: "hello_go", Version: "v1.1.0"},
+			{App: "status_service", Version: "v2.0.0"},
+		},
+	}
+	matrixJSON, _ := json.Marshal(matrix)
+	result := GenerateReleaseSummary(string(matrixJSON), "v1.0.0", "workflow_dispatch", false, "")
+
+	if !strings.Contains(result, "🏷️  **Versions:**") {
+		t.Error("expected versions header for multiple versions")
+	}
+	if !strings.Contains(result, "hello_python: v1.0.0") {
+		t.Error("expected hello_python version")
+	}
+	if !strings.Contains(result, "hello_go: v1.1.0") {
+		t.Error("expected hello_go version")
+	}
+	if !strings.Contains(result, "status_service: v2.0.0") {
+		t.Error("expected status_service version")
+	}
+}
+
+func TestGenerateReleaseSummaryInvalidJSON(t *testing.T) {
+	result := GenerateReleaseSummary("invalid json", "v1.0.0", "pull_request", false, "")
+	if !strings.Contains(result, "🔍 **Result:** No apps detected for release") {
+		t.Error("expected no apps message for invalid JSON")
+	}
+}
+
+func TestGenerateReleaseSummaryEmptyJSON(t *testing.T) {
+	result := GenerateReleaseSummary("", "v1.0.0", "push", false, "")
+	if !strings.Contains(result, "🔍 **Result:** No apps detected for release") {
+		t.Error("expected no apps message for empty JSON")
+	}
+}
+
+func TestGenerateReleaseSummaryDryRun(t *testing.T) {
+	matrix := MatrixConfig{
+		Include: []MatrixEntry{
+			{App: "hello_python", Version: "v1.0.0"},
+		},
+	}
+	matrixJSON, _ := json.Marshal(matrix)
+	result := GenerateReleaseSummary(string(matrixJSON), "v1.0.0", "workflow_dispatch", true, "")
+
+	if !strings.Contains(result, "🧪 **Mode:** Dry run (no images published)") {
+		t.Error("expected dry run mode message")
+	}
+}
+
+func TestGenerateReleaseSummaryWorkflowDispatchTrigger(t *testing.T) {
+	matrix := MatrixConfig{
+		Include: []MatrixEntry{
+			{App: "hello_python", Version: "v1.0.0"},
+		},
+	}
+	matrixJSON, _ := json.Marshal(matrix)
+	result := GenerateReleaseSummary(string(matrixJSON), "v1.0.0", "workflow_dispatch", false, "")
+
+	if !strings.Contains(result, "📝 **Trigger:** Manual dispatch") {
+		t.Error("expected manual dispatch trigger")
+	}
+}
+
+func TestGenerateReleaseSummaryTagPushTrigger(t *testing.T) {
+	matrix := MatrixConfig{
+		Include: []MatrixEntry{
+			{App: "hello_python", Version: "v1.0.0"},
+		},
+	}
+	matrixJSON, _ := json.Marshal(matrix)
+	result := GenerateReleaseSummary(string(matrixJSON), "v1.0.0", "tag_push", false, "")
+
+	if !strings.Contains(result, "📝 **Trigger:** Git tag push") {
+		t.Error("expected git tag push trigger")
+	}
+}
+
+func TestGenerateReleaseSummaryLatestVersion(t *testing.T) {
+	matrix := MatrixConfig{
+		Include: []MatrixEntry{
+			{App: "hello_python", Version: "latest"},
+		},
+	}
+	matrixJSON, _ := json.Marshal(matrix)
+	result := GenerateReleaseSummary(string(matrixJSON), "latest", "push", false, "")
+
+	if !strings.Contains(result, "🏷️  **Version:** latest") {
+		t.Error("expected latest version")
+	}
+}
+
+func TestGenerateReleaseSummaryMixedVersionsWithFallback(t *testing.T) {
+	matrix := MatrixConfig{
+		Include: []MatrixEntry{
+			{App: "hello_python", Version: "v1.0.0"},
+			{App: "hello_go"}, // No version - should fallback
+		},
+	}
+	matrixJSON, _ := json.Marshal(matrix)
+	result := GenerateReleaseSummary(string(matrixJSON), "v1.2.0", "workflow_dispatch", false, "")
+
+	if !strings.Contains(result, "🏷️  **Versions:**") {
+		t.Error("expected versions header for mixed versions")
+	}
+	if !strings.Contains(result, "hello_python: v1.0.0") {
+		t.Error("expected hello_python version")
+	}
+	if !strings.Contains(result, "hello_go: v1.2.0") {
+		t.Error("expected hello_go fallback version")
+	}
+}

--- a/tools/kraken/validation.go
+++ b/tools/kraken/validation.go
@@ -1,0 +1,248 @@
+package kraken
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+var semverValidationRegex = regexp.MustCompile(`^v\d+\.\d+\.\d+(?:-[a-zA-Z0-9\-\.]+)?$`)
+
+// ValidateSemanticVersion validates that version follows semantic versioning format.
+func ValidateSemanticVersion(version string) bool {
+	return semverValidationRegex.MatchString(version)
+}
+
+// CheckVersionExistsInRegistry checks if a version already exists in the container registry.
+func CheckVersionExistsInRegistry(bazelTarget, version string) bool {
+	metadata, err := GetAppMetadata(bazelTarget)
+	if err != nil {
+		return false
+	}
+
+	registry := metadata.Registry
+	domain := metadata.Domain
+	appName := metadata.Name
+
+	imageName := fmt.Sprintf("%s-%s", domain, appName)
+
+	var imageRef string
+	if registry == "ghcr.io" {
+		if owner := os.Getenv("GITHUB_REPOSITORY_OWNER"); owner != "" {
+			imageRef = fmt.Sprintf("%s/%s/%s:%s", registry, strings.ToLower(owner), imageName, version)
+		} else {
+			imageRef = fmt.Sprintf("%s/%s:%s", registry, imageName, version)
+		}
+	} else {
+		imageRef = fmt.Sprintf("%s/%s:%s", registry, imageName, version)
+	}
+
+	cmd := exec.Command("docker", "manifest", "inspect", imageRef)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		stderr := string(out)
+		stderrLower := strings.ToLower(stderr)
+		if strings.Contains(stderrLower, "manifest unknown") ||
+			strings.Contains(stderrLower, "not found") ||
+			strings.Contains(stderrLower, "name invalid") ||
+			strings.Contains(stderrLower, "unauthorized") {
+			return false
+		}
+		fmt.Fprintf(os.Stderr, "Warning: Could not definitively check if %s exists: %s\n", imageRef, stderr)
+		fmt.Fprintln(os.Stderr, "Proceeding with caution - this may overwrite an existing version")
+		return false
+	}
+	return true
+}
+
+// ValidateReleaseVersion validates that a release version is valid and doesn't already exist.
+func ValidateReleaseVersion(bazelTarget, version string, allowOverwrite bool) error {
+	metadata, err := GetAppMetadata(bazelTarget)
+	if err != nil {
+		return err
+	}
+	appName := metadata.Name
+
+	if version != "latest" && !ValidateSemanticVersion(version) {
+		return fmt.Errorf(
+			"version '%s' does not follow semantic versioning format. "+
+				"Expected format: v{major}.{minor}.{patch} (e.g., v1.0.0, v2.1.3, v1.0.0-beta1)",
+			version,
+		)
+	}
+
+	if version == "latest" {
+		fmt.Fprintf(os.Stderr, "✓ Allowing overwrite of 'latest' tag for app '%s' (main branch workflow)\n", appName)
+		return nil
+	}
+
+	if !allowOverwrite {
+		if CheckVersionExistsInRegistry(bazelTarget, version) {
+			return fmt.Errorf(
+				"version '%s' already exists for app '%s'. "+
+					"Refusing to overwrite existing version. Use a different version number.",
+				version, appName,
+			)
+		}
+		fmt.Fprintf(os.Stderr, "✓ Version '%s' is available for app '%s'\n", version, appName)
+	} else {
+		fmt.Fprintf(os.Stderr, "⚠️  Allowing overwrite of version '%s' for app '%s' (if it exists)\n", version, appName)
+	}
+
+	return nil
+}
+
+// GetAppFullName returns the full domain-appname format for an app.
+func GetAppFullName(app AppInfo) string {
+	return fmt.Sprintf("%s-%s", app.Domain, app.Name)
+}
+
+// GetAvailableDomains returns a sorted list of all available domains.
+func GetAvailableDomains() ([]string, error) {
+	allApps, err := ListAllApps()
+	if err != nil {
+		return nil, err
+	}
+	domainSet := make(map[string]bool)
+	for _, app := range allApps {
+		domainSet[app.Domain] = true
+	}
+	var domains []string
+	for d := range domainSet {
+		domains = append(domains, d)
+	}
+	sort.Strings(domains)
+	return domains, nil
+}
+
+// ValidateDomain validates that a domain exists and returns all apps in that domain.
+func ValidateDomain(domainName string) ([]AppInfo, error) {
+	allApps, err := ListAllApps()
+	if err != nil {
+		return nil, err
+	}
+	var domainApps []AppInfo
+	for _, app := range allApps {
+		if app.Domain == domainName {
+			domainApps = append(domainApps, app)
+		}
+	}
+	if len(domainApps) == 0 {
+		domains, _ := GetAvailableDomains()
+		return nil, fmt.Errorf("domain '%s' not found. Available domains: %s", domainName, strings.Join(domains, ", "))
+	}
+	return domainApps, nil
+}
+
+// IsDomainName checks if a name appears to be a domain name.
+func IsDomainName(name string) bool {
+	domains, err := GetAvailableDomains()
+	if err != nil {
+		return false
+	}
+	for _, d := range domains {
+		if d == name {
+			return true
+		}
+	}
+	return false
+}
+
+// ValidateApps validates that requested apps exist and returns the valid ones.
+// Apps can be referenced in multiple formats:
+//   - Full format: domain-appname (e.g., "demo-hello_python")
+//   - Short format: appname (e.g., "hello_python") - only if unambiguous
+//   - Path format: domain/appname (e.g., "demo/hello_python")
+//   - Domain format: domain (e.g., "demo") - returns all apps in that domain
+func ValidateApps(requestedApps []string) ([]AppInfo, error) {
+	allApps, err := ListAllApps()
+	if err != nil {
+		return nil, err
+	}
+
+	fullNameLookup := make(map[string]AppInfo)
+	shortNameLookup := make(map[string][]AppInfo)
+	pathLookup := make(map[string]AppInfo)
+
+	for _, app := range allApps {
+		fullName := GetAppFullName(app)
+		fullNameLookup[fullName] = app
+
+		pathName := fmt.Sprintf("%s/%s", app.Domain, app.Name)
+		pathLookup[pathName] = app
+
+		shortNameLookup[app.Name] = append(shortNameLookup[app.Name], app)
+	}
+
+	var validApps []AppInfo
+	var invalidApps []string
+
+	for _, requested := range requestedApps {
+		// Check if this is a domain name first
+		if IsDomainName(requested) {
+			domainApps, err := ValidateDomain(requested)
+			if err != nil {
+				invalidApps = append(invalidApps, requested)
+				continue
+			}
+			validApps = append(validApps, domainApps...)
+			continue
+		}
+
+		// Try full format (domain-name)
+		if app, ok := fullNameLookup[requested]; ok {
+			validApps = append(validApps, app)
+			continue
+		}
+
+		// Try path format (domain/name)
+		if app, ok := pathLookup[requested]; ok {
+			validApps = append(validApps, app)
+			continue
+		}
+
+		// Try short format (name only) - only if unambiguous
+		if matches, ok := shortNameLookup[requested]; ok {
+			if len(matches) == 1 {
+				validApps = append(validApps, matches[0])
+				continue
+			}
+			// Ambiguous
+			var ambiguous []string
+			for _, a := range matches {
+				ambiguous = append(ambiguous, GetAppFullName(a))
+			}
+			invalidApps = append(invalidApps, fmt.Sprintf("%s (ambiguous, could be: %s)", requested, strings.Join(ambiguous, ", ")))
+			continue
+		}
+
+		invalidApps = append(invalidApps, requested)
+	}
+
+	if len(invalidApps) > 0 {
+		var availableFull []string
+		for _, app := range allApps {
+			availableFull = append(availableFull, GetAppFullName(app))
+		}
+		sort.Strings(availableFull)
+
+		domains, _ := GetAvailableDomains()
+
+		return nil, fmt.Errorf(
+			"Invalid apps: %s.\n"+
+				"Available apps: %s\n"+
+				"Available domains: %s\n"+
+				"You can use: full format (domain-appname, e.g. demo-hello_python), "+
+				"path format (domain/appname, e.g. demo/hello_python), short format (appname, e.g. hello_python, if unambiguous), "+
+				"or domain format (domain, e.g. demo)",
+			strings.Join(invalidApps, ", "),
+			strings.Join(availableFull, ", "),
+			strings.Join(domains, ", "),
+		)
+	}
+
+	return validApps, nil
+}

--- a/tools/kraken/validation_test.go
+++ b/tools/kraken/validation_test.go
@@ -1,0 +1,45 @@
+package kraken
+
+import (
+	"testing"
+)
+
+func TestValidateSemanticVersionValid(t *testing.T) {
+	validVersions := []string{
+		"v1.0.0",
+		"v0.1.0",
+		"v10.20.30",
+		"v1.0.0-alpha",
+		"v1.0.0-beta1",
+	}
+
+	for _, v := range validVersions {
+		if !ValidateSemanticVersion(v) {
+			t.Errorf("expected %s to be valid", v)
+		}
+	}
+}
+
+func TestValidateSemanticVersionInvalid(t *testing.T) {
+	invalidVersions := []string{
+		"1.0.0",  // Missing 'v' prefix
+		"v1.0",   // Missing patch version
+		"v1",     // Missing minor and patch
+		"",       // Empty string
+		"latest", // Not semantic version
+	}
+
+	for _, v := range invalidVersions {
+		if ValidateSemanticVersion(v) {
+			t.Errorf("expected %s to be invalid", v)
+		}
+	}
+}
+
+func TestGetAppFullName(t *testing.T) {
+	app := AppInfo{Domain: "demo", Name: "hello_python"}
+	result := GetAppFullName(app)
+	if result != "demo-hello_python" {
+		t.Errorf("expected demo-hello_python, got %s", result)
+	}
+}


### PR DESCRIPTION
## Motivation

Rewrite the Python `release_helper` tool in Go for consistency with the rest of the Go tooling in the monorepo and to benefit from static typing and single-binary distribution.

## What changed

New `tools/kraken/` package — a 1:1 port of `tools/release_helper/` from Python to Go.

### Source files (12 modules)

| Go module | Python equivalent | Responsibility |
|---|---|---|
| `core.go` | `core.py` | Workspace root detection, bazel runner |
| `git.go` | `git.py` | Tag formatting/parsing, version increment |
| `validation.go` | `validation.py` | Semver validation, app/domain lookup |
| `metadata.go` | `metadata.py` | App metadata retrieval and listing |
| `changes.go` | `changes.py` | Change detection via git diff + bazel query |
| `images.go` | `images.py` | Image build/tag/push, multi-arch manifests |
| `release.go` | `release.py` | Release planning, matrix generation |
| `release_notes.go` | `release_notes.py` | Commit retrieval, markdown/plain/JSON formatting |
| `summary.go` | `summary.py` | GitHub Actions release summary |
| `ghcr.go` | `ghcr.py` | GHCR API client for package management |
| `cleanup.go` | `cleanup.py` | Cleanup orchestration (tags, releases, packages) |
| `github_release.go` | `github_release.py` | GitHub Releases API client |

### Tests (10 files)

All existing Python test cases ported to Go. Tests pass via `bazel test //tools/kraken:kraken_test`.

### CLI

`cmd/kraken/main.go` — cobra-based CLI with subcommands: `list`, `changes`, `build`, `plan`, `release`, `release-multiarch`, `release-notes`, `summary`, `create-release`.

### Dependency changes

- Added `github.com/spf13/cobra v1.9.1` to `go.mod` + `MODULE.bazel` `use_repo`

### Usage

```bash
bazel run //tools:kraken -- list
bazel run //tools:kraken -- build hello_python
bazel run //tools:kraken -- plan --apps all --version v1.0.0
```