### PR TITLE
refactor: composable app building blocks POC

### DIFF
--- a/tools/bazel/app.bzl
+++ b/tools/bazel/app.bzl
@@ -1,0 +1,324 @@
+"""Composable application building blocks for the Everything monorepo.
+
+Each building block is a Bazel rule that produces a JSON fragment describing
+one aspect of an application. `app_manifest` merges any number of fragments
+into the final metadata JSON that release_helper and helm_composer consume.
+
+BUILDING BLOCKS:
+================
+
+  app_image    — references an OCI image target
+  app_deploy   — deployment shape (app_type, port, replicas, command, args)
+  app_ingress  — ingress routing
+  app_health   — health check config
+  app_resource — CPU/memory requests and limits
+  app_openapi  — references an OpenAPI spec target
+
+ASSEMBLY:
+=========
+
+  app_manifest — merges identity fields + any number of block labels
+                 into one metadata JSON (same shape as current app_metadata)
+
+USAGE:
+======
+
+    multiplatform_image(name = "my-app_image", ...)
+
+    app_image(name = "my-app_image_ref", image_target = ":my-app_image", ...)
+    app_deploy(name = "my-app_deploy", app_type = "external-api", port = 8000)
+    app_ingress(name = "my-app_ingress", host = "my-app.example.com")
+
+    app_manifest(
+        name = "my-app_metadata",
+        app_name = "my-app",
+        language = "go",
+        domain = "myteam",
+        binary_target = ":my-app",
+        components = [
+            ":my-app_image_ref",
+            ":my-app_deploy",
+            ":my-app_ingress",
+        ],
+    )
+
+A worker omits the ingress block. A CLI tool omits deploy entirely.
+You only plug in what applies.
+"""
+
+# =============================================================================
+# Provider
+# =============================================================================
+
+AppFragmentInfo = provider(
+    doc = "Marks a target as an app metadata JSON fragment.",
+    fields = {"json_file": "The JSON fragment file"},
+)
+
+# =============================================================================
+# app_image
+# =============================================================================
+
+def _app_image_impl(ctx):
+    fragment = {
+        "image_target": str(ctx.attr.image_target.label),
+        "registry": ctx.attr.registry,
+        "organization": ctx.attr.organization,
+        "repo_name": ctx.attr.repo_name,
+    }
+    output = ctx.actions.declare_file(ctx.label.name + ".json")
+    ctx.actions.write(output = output, content = json.encode(fragment))
+    return [
+        DefaultInfo(files = depset([output])),
+        AppFragmentInfo(json_file = output),
+    ]
+
+app_image = rule(
+    implementation = _app_image_impl,
+    doc = "Fragment referencing an OCI image target.",
+    attrs = {
+        "image_target": attr.label(mandatory = True),
+        "registry": attr.string(default = "ghcr.io"),
+        "organization": attr.string(default = "whale-net"),
+        "repo_name": attr.string(mandatory = True),
+    },
+)
+
+# =============================================================================
+# app_deploy
+# =============================================================================
+
+def _app_deploy_impl(ctx):
+    fragment = {}
+    if ctx.attr.app_type:
+        fragment["app_type"] = ctx.attr.app_type
+    if ctx.attr.port:
+        fragment["port"] = ctx.attr.port
+    if ctx.attr.replicas:
+        fragment["replicas"] = ctx.attr.replicas
+    if ctx.attr.command:
+        fragment["command"] = ctx.attr.command
+    if ctx.attr.args:
+        fragment["args"] = ctx.attr.args
+
+    output = ctx.actions.declare_file(ctx.label.name + ".json")
+    ctx.actions.write(output = output, content = json.encode(fragment))
+    return [
+        DefaultInfo(files = depset([output])),
+        AppFragmentInfo(json_file = output),
+    ]
+
+app_deploy = rule(
+    implementation = _app_deploy_impl,
+    doc = "Fragment for deployment shape (app_type, port, replicas, command, args).",
+    attrs = {
+        "app_type": attr.string(default = ""),
+        "port": attr.int(default = 0),
+        "replicas": attr.int(default = 0),
+        "command": attr.string_list(default = []),
+        "args": attr.string_list(default = []),
+    },
+)
+
+# =============================================================================
+# app_ingress
+# =============================================================================
+
+def _app_ingress_impl(ctx):
+    fragment = {
+        "ingress": {
+            "host": ctx.attr.host,
+            "tls_secret_name": ctx.attr.tls_secret,
+        },
+    }
+    output = ctx.actions.declare_file(ctx.label.name + ".json")
+    ctx.actions.write(output = output, content = json.encode(fragment))
+    return [
+        DefaultInfo(files = depset([output])),
+        AppFragmentInfo(json_file = output),
+    ]
+
+app_ingress = rule(
+    implementation = _app_ingress_impl,
+    doc = "Fragment for ingress routing.",
+    attrs = {
+        "host": attr.string(mandatory = True),
+        "tls_secret": attr.string(default = ""),
+    },
+)
+
+# =============================================================================
+# app_health
+# =============================================================================
+
+def _app_health_impl(ctx):
+    fragment = {
+        "health_check": {
+            "enabled": True,
+            "path": ctx.attr.path,
+        },
+    }
+    output = ctx.actions.declare_file(ctx.label.name + ".json")
+    ctx.actions.write(output = output, content = json.encode(fragment))
+    return [
+        DefaultInfo(files = depset([output])),
+        AppFragmentInfo(json_file = output),
+    ]
+
+app_health = rule(
+    implementation = _app_health_impl,
+    doc = "Fragment for health check config.",
+    attrs = {
+        "path": attr.string(default = "/health"),
+    },
+)
+
+# =============================================================================
+# app_resource
+# =============================================================================
+
+def _app_resource_impl(ctx):
+    fragment = {
+        "resources": {
+            "requests_cpu": ctx.attr.requests_cpu,
+            "requests_memory": ctx.attr.requests_memory,
+            "limits_cpu": ctx.attr.limits_cpu,
+            "limits_memory": ctx.attr.limits_memory,
+        },
+    }
+    output = ctx.actions.declare_file(ctx.label.name + ".json")
+    ctx.actions.write(output = output, content = json.encode(fragment))
+    return [
+        DefaultInfo(files = depset([output])),
+        AppFragmentInfo(json_file = output),
+    ]
+
+app_resource = rule(
+    implementation = _app_resource_impl,
+    doc = "Fragment for CPU/memory resource requests and limits.",
+    attrs = {
+        "requests_cpu": attr.string(default = ""),
+        "requests_memory": attr.string(default = ""),
+        "limits_cpu": attr.string(default = ""),
+        "limits_memory": attr.string(default = ""),
+    },
+)
+
+# =============================================================================
+# app_openapi
+# =============================================================================
+
+def _app_openapi_impl(ctx):
+    fragment = {
+        "openapi_spec_target": str(ctx.attr.spec_target.label),
+    }
+    output = ctx.actions.declare_file(ctx.label.name + ".json")
+    ctx.actions.write(output = output, content = json.encode(fragment))
+    return [
+        DefaultInfo(files = depset([output])),
+        AppFragmentInfo(json_file = output),
+    ]
+
+app_openapi = rule(
+    implementation = _app_openapi_impl,
+    doc = "Fragment referencing an OpenAPI spec target.",
+    attrs = {
+        "spec_target": attr.label(mandatory = True),
+    },
+)
+
+# =============================================================================
+# app_manifest
+# =============================================================================
+
+def _app_manifest_impl(ctx):
+    """Merges identity fields with all component JSON fragments."""
+    base = {
+        "name": ctx.attr.app_name,
+        "version": ctx.attr.version,
+        "description": ctx.attr.description,
+        "language": ctx.attr.language,
+        "domain": ctx.attr.domain,
+        "binary_target": str(ctx.attr.binary_target.label),
+    }
+
+    fragment_files = []
+    for component in ctx.attr.components:
+        if AppFragmentInfo in component:
+            fragment_files.append(component[AppFragmentInfo].json_file)
+        else:
+            for f in component[DefaultInfo].files.to_list():
+                if f.path.endswith(".json"):
+                    fragment_files.append(f)
+
+    if not fragment_files:
+        output = ctx.actions.declare_file(ctx.label.name + "_metadata.json")
+        ctx.actions.write(output = output, content = json.encode(base))
+        return [DefaultInfo(files = depset([output]))]
+
+    base_file = ctx.actions.declare_file(ctx.label.name + "_base.json")
+    ctx.actions.write(output = base_file, content = json.encode(base))
+
+    merge_script = ctx.actions.declare_file(ctx.label.name + "_merge.sh")
+    script_lines = [
+        "#!/bin/bash",
+        "set -e",
+        "",
+        'OUTPUT_FILE="$1"',
+        "shift",
+        "",
+        "RESULT=''",
+        'for FRAG_FILE in "$@"; do',
+        "    INNER=$(cat \"$FRAG_FILE\" | sed 's/^{//' | sed 's/}$//')",
+        "    INNER=$(echo \"$INNER\" | sed 's/^[[:space:]]*//' | sed 's/[[:space:]]*$//')",
+        '    if [ -z "$INNER" ]; then',
+        "        continue",
+        "    fi",
+        '    if [ -z "$RESULT" ]; then',
+        '        RESULT="$INNER"',
+        "    else",
+        '        RESULT="${RESULT},${INNER}"',
+        "    fi",
+        "done",
+        "",
+        'echo "{${RESULT}}" > "$OUTPUT_FILE"',
+    ]
+    ctx.actions.write(
+        output = merge_script,
+        content = "\n".join(script_lines) + "\n",
+        is_executable = True,
+    )
+
+    output = ctx.actions.declare_file(ctx.label.name + "_metadata.json")
+    all_inputs = [base_file] + fragment_files
+    run_args = [output.path] + [f.path for f in all_inputs]
+
+    ctx.actions.run(
+        executable = merge_script,
+        arguments = run_args,
+        inputs = all_inputs + [merge_script],
+        outputs = [output],
+        mnemonic = "AssembleAppManifest",
+        progress_message = "Assembling app manifest for %s" % ctx.attr.app_name,
+    )
+
+    return [DefaultInfo(files = depset([output]))]
+
+app_manifest = rule(
+    implementation = _app_manifest_impl,
+    doc = """Assembles a complete app metadata file from identity + pluggable component fragments.
+
+    Each component is a label pointing to a block rule (app_image, app_deploy,
+    app_ingress, etc.). Fragments are merged in order into a single JSON file
+    compatible with release_helper and helm_composer.
+    """,
+    attrs = {
+        "app_name": attr.string(mandatory = True),
+        "version": attr.string(default = "latest"),
+        "description": attr.string(default = ""),
+        "language": attr.string(mandatory = True),
+        "domain": attr.string(mandatory = True),
+        "binary_target": attr.label(mandatory = True),
+        "components": attr.label_list(default = []),
+    },
+)

--- a/tools/bazel/app_poc.BUILD.example
+++ b/tools/bazel/app_poc.BUILD.example
@@ -1,0 +1,375 @@
+# =============================================================================
+# POC: manman-v2 apps using composable app building blocks
+#
+# This file is NOT a real BUILD file — it demonstrates the building-block
+# pattern for each manman-v2 app. Each app assembles only the blocks it needs.
+# =============================================================================
+
+load("//tools/bazel:container_image.bzl", "multiplatform_image")
+load(
+    "//tools/bazel:app.bzl",
+    "app_deploy",
+    "app_health",
+    "app_image",
+    "app_ingress",
+    "app_manifest",
+    "app_openapi",
+    "app_resource",
+)
+
+# =============================================================================
+# control-api: external gRPC API with ingress
+#
+# Blocks: image + deploy + ingress
+# =============================================================================
+
+multiplatform_image(
+    name = "control-api_image",
+    binary = ":control-api",
+    image_name = "manmanv2-control-api",
+    language = "go",
+    registry = "ghcr.io",
+    repository = "whale-net",
+)
+
+app_image(
+    name = "control-api_image_ref",
+    image_target = ":control-api_image",
+    repo_name = "manmanv2-control-api",
+)
+
+app_deploy(
+    name = "control-api_deploy",
+    app_type = "external-api",
+    port = 50051,
+    replicas = 2,
+)
+
+app_manifest(
+    name = "control-api_metadata",
+    app_name = "control-api",
+    binary_target = ":control-api",
+    domain = "manmanv2",
+    language = "go",
+    description = "ManMan control plane API (gRPC)",
+    components = [
+        ":control-api_image_ref",
+        ":control-api_deploy",
+    ],
+    tags = ["release-metadata"],
+    visibility = ["//visibility:public"],
+)
+
+
+# =============================================================================
+# event-processor: worker (no port, no ingress, no service)
+#
+# Blocks: image + deploy
+# =============================================================================
+
+multiplatform_image(
+    name = "event-processor_image",
+    binary = ":event-processor",
+    image_name = "manmanv2-event-processor",
+    language = "go",
+    registry = "ghcr.io",
+    repository = "whale-net",
+)
+
+app_image(
+    name = "event-processor_image_ref",
+    image_target = ":event-processor_image",
+    repo_name = "manmanv2-event-processor",
+)
+
+app_deploy(
+    name = "event-processor_deploy",
+    app_type = "worker",
+    replicas = 1,
+)
+
+app_manifest(
+    name = "event-processor_metadata",
+    app_name = "event-processor",
+    binary_target = ":event-processor",
+    domain = "manmanv2",
+    language = "go",
+    description = "ManMan event processor (RabbitMQ consumer, DB sync)",
+    components = [
+        ":event-processor_image_ref",
+        ":event-processor_deploy",
+    ],
+    tags = ["release-metadata"],
+    visibility = ["//visibility:public"],
+)
+
+
+# =============================================================================
+# control-migration: one-shot job
+#
+# Blocks: image + deploy (job type, nothing else)
+# =============================================================================
+
+multiplatform_image(
+    name = "control-migration_image",
+    binary = ":control-migration",
+    image_name = "manmanv2-control-migration",
+    language = "go",
+    registry = "ghcr.io",
+    repository = "whale-net",
+)
+
+app_image(
+    name = "control-migration_image_ref",
+    image_target = ":control-migration_image",
+    repo_name = "manmanv2-control-migration",
+)
+
+app_deploy(
+    name = "control-migration_deploy",
+    app_type = "job",
+)
+
+app_manifest(
+    name = "control-migration_metadata",
+    app_name = "control-migration",
+    binary_target = ":control-migration",
+    domain = "manmanv2",
+    language = "go",
+    description = "ManMan control plane database migration runner",
+    components = [
+        ":control-migration_image_ref",
+        ":control-migration_deploy",
+    ],
+    tags = ["release-metadata"],
+    visibility = ["//visibility:public"],
+)
+
+
+# =============================================================================
+# log-processor: internal API (cluster-only)
+#
+# Blocks: image + deploy
+# No ingress block — can't accidentally expose it.
+# =============================================================================
+
+multiplatform_image(
+    name = "log-processor_image",
+    binary = ":log-processor",
+    image_name = "manmanv2-log-processor",
+    language = "go",
+    registry = "ghcr.io",
+    repository = "whale-net",
+)
+
+app_image(
+    name = "log-processor_image_ref",
+    image_target = ":log-processor_image",
+    repo_name = "manmanv2-log-processor",
+)
+
+app_deploy(
+    name = "log-processor_deploy",
+    app_type = "internal-api",
+    port = 50053,
+    replicas = 1,
+)
+
+app_manifest(
+    name = "log-processor_metadata",
+    app_name = "log-processor",
+    binary_target = ":log-processor",
+    domain = "manmanv2",
+    language = "go",
+    description = "Real-time log streaming and S3 archival service with gRPC API",
+    components = [
+        ":log-processor_image_ref",
+        ":log-processor_deploy",
+    ],
+    tags = ["release-metadata"],
+    visibility = ["//visibility:public"],
+)
+
+
+# =============================================================================
+# manmanv2-ui: external API with ingress + TLS
+#
+# Blocks: image + deploy + ingress
+# Ingress is a separate block — only plugged in for external APIs.
+# =============================================================================
+
+multiplatform_image(
+    name = "manmanv2-ui_image",
+    binary = ":manmanv2-ui",
+    image_name = "manmanv2-manmanv2-ui",
+    language = "go",
+    registry = "ghcr.io",
+    repository = "whale-net",
+)
+
+app_image(
+    name = "manmanv2-ui_image_ref",
+    image_target = ":manmanv2-ui_image",
+    repo_name = "manmanv2-manmanv2-ui",
+)
+
+app_deploy(
+    name = "manmanv2-ui_deploy",
+    app_type = "external-api",
+    port = 8000,
+    replicas = 1,
+)
+
+app_ingress(
+    name = "manmanv2-ui_ingress",
+    host = "manman.whalenet.dev",
+    tls_secret = "manmanv2-tls",
+)
+
+app_manifest(
+    name = "manmanv2-ui_metadata",
+    app_name = "manmanv2-ui",
+    binary_target = ":manmanv2-ui",
+    domain = "manmanv2",
+    language = "go",
+    description = "HTMX-based management interface for ManManV2 control plane",
+    components = [
+        ":manmanv2-ui_image_ref",
+        ":manmanv2-ui_deploy",
+        ":manmanv2-ui_ingress",
+    ],
+    tags = ["release-metadata"],
+    visibility = ["//visibility:public"],
+)
+
+
+# =============================================================================
+# HYPOTHETICAL: manman worker with steamcmd + custom resources
+#
+# Blocks: image (with additional_tars) + deploy + resource
+# =============================================================================
+
+multiplatform_image(
+    name = "worker_image",
+    binary = "//manman/src/worker:worker",
+    image_name = "manman-worker",
+    language = "python",
+    registry = "ghcr.io",
+    repository = "whale-net",
+    env = {
+        "APP_NAME": "worker",
+        "APP_DOMAIN": "manman",
+        "APP_TYPE": "worker",
+    },
+    cmd = ["start"],
+    additional_tars = ["//tools/steamcmd:steamcmd_layers"],
+)
+
+app_image(
+    name = "worker_image_ref",
+    image_target = ":worker_image",
+    repo_name = "manman-worker",
+)
+
+app_deploy(
+    name = "worker_deploy",
+    app_type = "worker",
+    replicas = 1,
+    args = ["start"],
+)
+
+app_resource(
+    name = "worker_resources",
+    requests_cpu = "200m",
+    requests_memory = "512Mi",
+    limits_cpu = "500m",
+    limits_memory = "1Gi",
+)
+
+app_manifest(
+    name = "worker_metadata",
+    app_name = "worker",
+    binary_target = "//manman/src/worker:worker",
+    domain = "manman",
+    language = "python",
+    description = "Background worker with SteamCMD and custom resource limits",
+    components = [
+        ":worker_image_ref",
+        ":worker_deploy",
+        ":worker_resources",
+    ],
+    tags = ["release-metadata"],
+    visibility = ["//visibility:public"],
+)
+
+
+# =============================================================================
+# HYPOTHETICAL: FastAPI app — full block set
+#
+# Blocks: image + deploy + ingress + health + openapi
+# =============================================================================
+
+# (Assume openapi_spec rule already created ":experience-api_openapi_spec")
+
+multiplatform_image(
+    name = "experience-api_image",
+    binary = "//manman/src/host/api/experience:experience_api",
+    image_name = "manman-experience-api",
+    language = "python",
+    registry = "ghcr.io",
+    repository = "whale-net",
+    env = {
+        "APP_NAME": "experience-api",
+        "APP_DOMAIN": "manman",
+        "APP_TYPE": "external-api",
+    },
+    cmd = ["start-experience-api"],
+)
+
+app_image(
+    name = "experience-api_image_ref",
+    image_target = ":experience-api_image",
+    repo_name = "manman-experience-api",
+)
+
+app_deploy(
+    name = "experience-api_deploy",
+    app_type = "external-api",
+    port = 8000,
+    replicas = 1,
+    args = ["start-experience-api"],
+)
+
+app_ingress(
+    name = "experience-api_ingress",
+    host = "experience.manman.local",
+    tls_secret = "manman-tls",
+)
+
+app_health(
+    name = "experience-api_health",
+    path = "/health",
+)
+
+app_openapi(
+    name = "experience-api_openapi",
+    spec_target = ":experience-api_openapi_spec",
+)
+
+app_manifest(
+    name = "experience-api_metadata",
+    app_name = "experience-api",
+    binary_target = "//manman/src/host/api/experience:experience_api",
+    domain = "manman",
+    language = "python",
+    description = "Experience API service",
+    components = [
+        ":experience-api_image_ref",
+        ":experience-api_deploy",
+        ":experience-api_ingress",
+        ":experience-api_health",
+        ":experience-api_openapi",
+    ],
+    tags = ["release-metadata"],
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
## Motivation

`release_app` has 24+ flat parameters because it conflates image building, deployment config, and release identity into one macro. Every new deployment concern (env vars, volumes, sidecars) requires adding more parameters that every app pays for.

## Approach

Decompose into independent building blocks — each a Bazel rule producing a JSON fragment — that plug into an `app_manifest` collector.

### Building blocks (`tools/bazel/app.bzl`)

| Block | Produces | When to use |
|---|---|---|
| `app_image` | image_target, registry, organization, repo_name | Every releasable app |
| `app_deploy` | app_type, port, replicas, command, args | Apps deployed to k8s |
| `app_ingress` | ingress host + TLS config | External APIs only |
| `app_health` | health check path | APIs with health endpoints |
| `app_resource` | CPU/memory requests and limits | Apps with custom resource needs |
| `app_openapi` | OpenAPI spec target reference | FastAPI apps |

`app_manifest` merges identity fields + any combination of blocks into a single metadata JSON, same shape as current `app_metadata` — no changes needed in release_helper or helm_composer.

### Key difference from `release_app`

Internal vs external API isn't a parameter — it's structural. An internal API simply doesn't have an `app_ingress` block. You can't accidentally configure ingress on a worker because the block isn't there.

### POC (`tools/bazel/app_poc.BUILD.example`)

Shows all manman-v2 apps using the block pattern, plus hypothetical examples for:
- Worker with steamcmd layers + custom resources
- Full FastAPI app with health + openapi + ingress
- CLI tool with image only (no k8s deployment)

### Migration path

1. This PR adds the new API alongside the existing `release_app` (no breaking changes)
2. Complex apps can migrate to direct composition
3. Simple apps can stay on `release_app` or migrate at their own pace

## Files

- `tools/bazel/app.bzl` — Building block rules + `app_manifest` assembler
- `tools/bazel/app_poc.BUILD.example` — Usage examples for manman-v2