### PR TITLE
feat: add devcontainer config with bazel, tilt, docker-in-docker, and k3d

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,23 @@
+{
+	"name": "Everything Monorepo",
+	"image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
+	"features": {
+		"ghcr.io/devcontainers/features/docker-in-docker": {
+			"moby": false
+		},
+		"ghcr.io/devcontainers/features/python": {
+			"version": "3.13",
+			"installTools": true,
+			"toolsToInstall": ["uv"]
+		},
+		"ghcr.io/devcontainers/features/go": {
+			"version": "1.25"
+		},
+		"ghcr.io/devcontainers-community/features/bazel": {},
+		"ghcr.io/devcontainers/features/kubectl-helm-minikube": {
+			"minikube": "none"
+		},
+		"ghcr.io/rio/features/k3d": {},
+		"ghcr.io/audacioustux/devcontainers/tilt": {}
+	}
+}

--- a/.ona/automations.yaml
+++ b/.ona/automations.yaml
@@ -1,0 +1,42 @@
+tasks:
+  setup-python:
+    name: Setup Python venv
+    description: Create Python virtual environment with uv and sync dependencies. Also symlinks python3 to /usr/bin for Bazel sandbox compatibility.
+    command: |
+      # Bazel sandbox uses /usr/bin/env python3 but the devcontainer feature
+      # installs Python to /usr/local/python/current/bin. Create a symlink.
+      if [ ! -e /usr/bin/python3 ] && [ -e /usr/local/python/current/bin/python3 ]; then
+        sudo ln -sf /usr/local/python/current/bin/python3 /usr/bin/python3
+      fi
+
+      uv venv
+      source .venv/bin/activate
+      uv sync
+    triggeredBy:
+      - postDevcontainerStart
+
+  setup-k3d:
+    name: Create k3d cluster
+    description: Create a local k3d Kubernetes cluster for Tilt development.
+    command: |
+      if k3d cluster list 2>/dev/null | grep -q "everything"; then
+        echo "k3d cluster 'everything' already exists"
+      else
+        k3d cluster create everything --wait
+      fi
+
+      # dev-util Helm charts expect a "hostpath" StorageClass.
+      # k3d only ships "local-path", so create an alias.
+      if ! kubectl get storageclass hostpath >/dev/null 2>&1; then
+        kubectl apply -f - <<'EOF'
+      apiVersion: storage.k8s.io/v1
+      kind: StorageClass
+      metadata:
+        name: hostpath
+      provisioner: rancher.io/local-path
+      reclaimPolicy: Delete
+      volumeBindingMode: WaitForFirstConsumer
+      EOF
+      fi
+    triggeredBy:
+      - postDevcontainerStart

--- a/tools/tilt/common.tilt
+++ b/tools/tilt/common.tilt
@@ -100,6 +100,10 @@ def build_images_from_apps(apps_dict, watch_paths, platform='linux/arm64'):
             # Custom build command that uses Bazel to build and load image
             # Bazel loads as image_name:latest, then we tag it with Tilt's expected ref
             # $EXPECTED_REF is set by Tilt to the tag it expects
+            #
+            # disable_push=False allows Tilt to push to a local registry when one
+            # is detected (e.g. k3d with --registry-create). On Docker Desktop
+            # where no registry exists, Tilt skips the push automatically.
             custom_build(
                 config['image_name'],
                 'bazel run {} --platforms={} && docker tag {}:latest $EXPECTED_REF'.format(
@@ -107,7 +111,7 @@ def build_images_from_apps(apps_dict, watch_paths, platform='linux/arm64'):
                 ),
                 deps=watch_paths,
                 skips_local_docker=False,
-                disable_push=True,
+                disable_push=False,
             )
         else:
             print("  ✗ {} (disabled)".format(config['image_name']))
@@ -153,7 +157,7 @@ def bazel_build_image(app_name, watch_paths, bazel_target, platform='linux/arm64
         ),
         watch_paths,
         skips_local_docker=False,
-        disable_push=True,
+        disable_push=False,
     )
 
 def detect_platform():


### PR DESCRIPTION
Adds a devcontainer configuration and automation tasks for the monorepo.

## Changes

**`.devcontainer/devcontainer.json`** — Replaces the placeholder Dockerfile-based config with a feature-based setup:
- Base: `ubuntu-24.04`
- Python 3.13 + uv (matches `pyproject.toml`)
- Go 1.25 (matches `go.mod`)
- Bazel via Bazelisk
- Docker-in-docker (Docker CE)
- kubectl + helm (minikube disabled)
- k3d (lightweight k8s in Docker)
- Tilt (local dev orchestration)

**`.ona/automations.yaml`** — Post-start tasks:
- `setup-python`: Creates venv, syncs deps, symlinks python3 to `/usr/bin` for Bazel sandbox compatibility
- `setup-k3d`: Creates k3d cluster with a `hostpath` StorageClass alias (dev-util Helm charts expect `hostpath`, k3d only ships `local-path`)

**`tools/tilt/common.tilt`** — `disable_push=True` → `disable_push=False` in `custom_build` calls. This allows Tilt to push images to k3d's local registry when one is detected. On Docker Desktop (no registry), Tilt skips the push automatically. Without this, images built on the host Docker daemon are invisible to k3d's containerd.

## Tested

Verified in Gitpod environment:
- All tools install correctly (bazel 8.3.1, tilt 0.36.3, docker 29.2.1, kubectl 1.35.1, helm 4.1.1, k3d 5.8.3)
- `tilt up` for manman-v2: infrastructure (postgres, rabbitmq, minio, otel) comes up, Bazel image builds succeed, images push to k3d registry and pull into pods

## Known pre-existing issues (not introduced by this PR)

- RabbitMQ dev-util chart has a transient `.erlang.cookie` permission error on first start; self-heals after pod restart
- Migration job binary doesn't exit after completing, blocking downstream `resource_deps` in Tilt