### PR TITLE
chore: add devcontainer with Go, Python/uv, and Docker features

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,13 @@
+{
+  "name": "everything",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
+  "features": {
+    "ghcr.io/devcontainers/features/go": {},
+    "ghcr.io/devcontainers/features/python": {
+      "installUv": true
+    },
+    "ghcr.io/devcontainers/features/docker-in-docker": {
+      "moby": false
+    }
+  }
+}

--- a/.ona/automations.yaml
+++ b/.ona/automations.yaml
@@ -1,4 +1,18 @@
 tasks:
+  setup-bazel:
+    name: Install Bazel
+    description: Install Bazelisk which manages the correct Bazel version from .bazelversion.
+    command: |
+      if command -v bazel &> /dev/null; then
+        echo "Bazel already installed"
+      else
+        sudo curl -fsSL -o /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-amd64
+        sudo chmod +x /usr/local/bin/bazel
+      fi
+      bazel --version
+    triggeredBy:
+      - postDevcontainerStart
+
   setup-python:
     name: Setup Python venv
     description: Create Python virtual environment with uv and sync dependencies. Also symlinks python3 to /usr/bin for Bazel sandbox compatibility.


### PR DESCRIPTION
Add devcontainer configuration and update automations for a working dev environment.

### Changes

**`.devcontainer/devcontainer.json`** (new)
- Base image: `mcr.microsoft.com/devcontainers/base:ubuntu-24.04`
- Features: Go, Python (with uv), Docker-in-Docker
- Tools are baked into the image layer so they don't re-install on every start

**`.ona/automations.yaml`**
- Added `setup-bazel` task to install Bazelisk on `postDevcontainerStart`
- Bazel is installed via task (not feature) since there's no official devcontainer feature for it

### Why features over automation tasks for Go/Python/Docker

Features are installed during the container build and cached in the image. Automation tasks run on every environment start. For stable tooling that rarely changes, features avoid repeated downloads and are more reliable.