### PR TITLE
fix(libs/go/rmq): don't add x-expires to durable queues

### DIFF
--- a/libs/go/rmq/consumer_internal_test.go
+++ b/libs/go/rmq/consumer_internal_test.go
@@ -27,3 +27,77 @@ func TestMatchesRoutingKey(t *testing.T) {
 		})
 	}
 }
+
+// TestBuildQueueArguments_DurableQueueNoExpires verifies that durable queues
+// do not get x-expires. This was the root cause of a production failure where
+// re-declaring an existing durable queue with x-expires caused a
+// PRECONDITION_FAILED error from RabbitMQ.
+func TestBuildQueueArguments_DurableQueueNoExpires(t *testing.T) {
+	args := buildQueueArguments("processor-events", true, false, 0, 0)
+
+	if args == nil {
+		t.Fatal("expected non-nil arguments for durable queue (should have DLQ config)")
+	}
+
+	if _, ok := args["x-expires"]; ok {
+		t.Error("durable queue must not have x-expires; this causes PRECONDITION_FAILED when the queue already exists without it")
+	}
+
+	// Verify DLQ routing is still present
+	if v, ok := args["x-dead-letter-routing-key"]; !ok || v != "processor-events-dlq" {
+		t.Errorf("expected x-dead-letter-routing-key = 'processor-events-dlq', got %v", v)
+	}
+}
+
+// TestBuildQueueArguments_NonDurableNonAutoDeleteGetsExpires verifies that
+// non-durable, non-auto-delete queues still get x-expires as a safety net.
+func TestBuildQueueArguments_NonDurableNonAutoDeleteGetsExpires(t *testing.T) {
+	args := buildQueueArguments("temp-queue", false, false, 0, 0)
+
+	if args == nil {
+		t.Fatal("expected non-nil arguments for non-durable non-auto-delete queue")
+	}
+
+	expires, ok := args["x-expires"]
+	if !ok {
+		t.Fatal("non-durable, non-auto-delete queue should have x-expires")
+	}
+	if expires != 300000 {
+		t.Errorf("expected x-expires = 300000, got %v", expires)
+	}
+}
+
+// TestBuildQueueArguments_AutoDeleteNoExpires verifies that auto-delete queues
+// do not get x-expires (RabbitMQ handles cleanup automatically).
+func TestBuildQueueArguments_AutoDeleteNoExpires(t *testing.T) {
+	args := buildQueueArguments("auto-queue", false, true, 0, 0)
+
+	if args != nil {
+		if _, ok := args["x-expires"]; ok {
+			t.Error("auto-delete queue should not have x-expires")
+		}
+	}
+}
+
+// TestBuildQueueArguments_MessageTTLAndMaxMessages verifies optional limits.
+func TestBuildQueueArguments_MessageTTLAndMaxMessages(t *testing.T) {
+	args := buildQueueArguments("limited-queue", true, false, 60000, 1000)
+
+	if args == nil {
+		t.Fatal("expected non-nil arguments")
+	}
+
+	if v, ok := args["x-message-ttl"]; !ok || v != 60000 {
+		t.Errorf("expected x-message-ttl = 60000, got %v", v)
+	}
+	if v, ok := args["x-max-length"]; !ok || v != 1000 {
+		t.Errorf("expected x-max-length = 1000, got %v", v)
+	}
+	if v, ok := args["x-overflow"]; !ok || v != "drop-head" {
+		t.Errorf("expected x-overflow = 'drop-head', got %v", v)
+	}
+	// Still no x-expires on durable queue
+	if _, ok := args["x-expires"]; ok {
+		t.Error("durable queue with TTL/max-length must not have x-expires")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes event-processor crash on startup in prod due to `PRECONDITION_FAILED` when declaring the `processor-events` queue.

## Problem

The `NewConsumerWithOpts` function added `x-expires: 300000` to **all** non-auto-delete queues, including durable ones. When the `processor-events` queue already existed in RabbitMQ without `x-expires`, re-declaring it with the new argument caused:

```
PRECONDITION_FAILED - inequivalent arg 'x-expires' for queue 'processor-events'
in vhost 'manmanv2-dev': received the value '300000' of type 'signedint' but current is none
```

## Fix

Restrict `x-expires` to non-durable, non-auto-delete queues only. Durable queues are long-lived and should not expire during brief consumer absence.

Extracted `buildQueueArguments` into a standalone function with unit tests covering all queue type combinations.

## Production recovery

After deploying this fix, the existing `processor-events` queue in RabbitMQ will be declared without `x-expires`, matching its current state. No manual queue deletion needed.

## Testing

- ✅ `bazel test //libs/go/rmq:rmq_test` — all tests pass
- New tests: `TestBuildQueueArguments_DurableQueueNoExpires`, `TestBuildQueueArguments_NonDurableNonAutoDeleteGetsExpires`, `TestBuildQueueArguments_AutoDeleteNoExpires`, `TestBuildQueueArguments_MessageTTLAndMaxMessages`