### PR TITLE
fix: speed up release CI by reducing redundant Bazel invocations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -345,6 +345,8 @@ jobs:
         VERSION: ${{ matrix.version || needs.plan-release.outputs.version }}
         DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
         GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
+        # Propagate CI config to inner Bazel calls from the release helper
+        BAZEL_CONFIG: ci-images
       run: |
         # Use full domain-app format to avoid ambiguity
         FULL_APP_NAME="${DOMAIN}-${APP}"
@@ -693,6 +695,7 @@ jobs:
         DRY_RUN: ${{ github.event.inputs.dry_run }}
         INCREMENT_MINOR: ${{ github.event.inputs.increment_minor }}
         INCREMENT_PATCH: ${{ github.event.inputs.increment_patch }}
+        BAZEL_CONFIG: ci
       run: |
         echo "Building helm charts with version $VERSION"
         

--- a/tools/release_helper/core.py
+++ b/tools/release_helper/core.py
@@ -25,9 +25,21 @@ def find_workspace_root() -> Path:
 
 
 def run_bazel(args: list[str], capture_output: bool = True, env: dict = None) -> subprocess.CompletedProcess:
-    """Run a bazel command with consistent configuration."""
+    """Run a bazel command with consistent configuration.
+    
+    Respects BAZEL_CONFIG env var to inject --config flags into build/run/test commands.
+    This ensures inner Bazel calls from the release helper use the same config as the
+    outer CI invocation (e.g., --config=ci-images for remote cache and download settings).
+    """
     workspace_root = find_workspace_root()
-    cmd = ["bazel"] + args
+    
+    # Inject --config flag for build/run/test commands if BAZEL_CONFIG is set
+    bazel_config = os.environ.get("BAZEL_CONFIG", "")
+    if bazel_config and len(args) > 0 and args[0] in ("build", "run", "test", "query"):
+        config_flags = [f"--config={c.strip()}" for c in bazel_config.split(",") if c.strip()]
+        cmd = ["bazel", args[0]] + config_flags + args[1:]
+    else:
+        cmd = ["bazel"] + args
     
     # Use provided environment or current environment
     run_env = env if env is not None else os.environ.copy()

--- a/tools/release_helper/test_core.py
+++ b/tools/release_helper/test_core.py
@@ -278,3 +278,84 @@ class TestRunBazel:
         )
         
         assert result == expected_result
+
+    @patch('tools.release_helper.core.find_workspace_root')
+    @patch('subprocess.run')
+    def test_run_bazel_with_bazel_config_env(self, mock_subprocess_run, mock_find_workspace_root):
+        """Test that BAZEL_CONFIG env var injects --config flags into build commands."""
+        workspace_path = Path("/workspace/root")
+        mock_find_workspace_root.return_value = workspace_path
+        
+        expected_result = Mock(returncode=0, stdout="success", stderr="")
+        mock_subprocess_run.return_value = expected_result
+        
+        with patch.dict(os.environ, {"BAZEL_CONFIG": "ci-images"}):
+            result = run_bazel(["build", "//demo:hello_python"])
+        
+        # Verify --config=ci-images was injected after the subcommand
+        call_args = mock_subprocess_run.call_args[0][0]
+        assert call_args == ["bazel", "build", "--config=ci-images", "//demo:hello_python"]
+
+    @patch('tools.release_helper.core.find_workspace_root')
+    @patch('subprocess.run')
+    def test_run_bazel_config_env_applies_to_query(self, mock_subprocess_run, mock_find_workspace_root):
+        """Test that BAZEL_CONFIG applies to query commands too."""
+        workspace_path = Path("/workspace/root")
+        mock_find_workspace_root.return_value = workspace_path
+        
+        expected_result = Mock(returncode=0, stdout="", stderr="")
+        mock_subprocess_run.return_value = expected_result
+        
+        with patch.dict(os.environ, {"BAZEL_CONFIG": "ci"}):
+            run_bazel(["query", "kind(app_metadata, //...)"])
+        
+        call_args = mock_subprocess_run.call_args[0][0]
+        assert call_args == ["bazel", "query", "--config=ci", "kind(app_metadata, //...)"]
+
+    @patch('tools.release_helper.core.find_workspace_root')
+    @patch('subprocess.run')
+    def test_run_bazel_config_env_not_applied_to_info(self, mock_subprocess_run, mock_find_workspace_root):
+        """Test that BAZEL_CONFIG is not applied to non-build commands like info."""
+        workspace_path = Path("/workspace/root")
+        mock_find_workspace_root.return_value = workspace_path
+        
+        expected_result = Mock(returncode=0, stdout="/path/to/bin", stderr="")
+        mock_subprocess_run.return_value = expected_result
+        
+        with patch.dict(os.environ, {"BAZEL_CONFIG": "ci-images"}):
+            run_bazel(["info", "bazel-bin"])
+        
+        call_args = mock_subprocess_run.call_args[0][0]
+        assert call_args == ["bazel", "info", "bazel-bin"]
+
+    @patch('tools.release_helper.core.find_workspace_root')
+    @patch('subprocess.run')
+    def test_run_bazel_config_env_multiple_configs(self, mock_subprocess_run, mock_find_workspace_root):
+        """Test that comma-separated BAZEL_CONFIG values produce multiple --config flags."""
+        workspace_path = Path("/workspace/root")
+        mock_find_workspace_root.return_value = workspace_path
+        
+        expected_result = Mock(returncode=0, stdout="success", stderr="")
+        mock_subprocess_run.return_value = expected_result
+        
+        with patch.dict(os.environ, {"BAZEL_CONFIG": "ci,remote"}):
+            run_bazel(["build", "//demo:target"])
+        
+        call_args = mock_subprocess_run.call_args[0][0]
+        assert call_args == ["bazel", "build", "--config=ci", "--config=remote", "//demo:target"]
+
+    @patch('tools.release_helper.core.find_workspace_root')
+    @patch('subprocess.run')
+    def test_run_bazel_config_env_empty_string(self, mock_subprocess_run, mock_find_workspace_root):
+        """Test that empty BAZEL_CONFIG doesn't inject any flags."""
+        workspace_path = Path("/workspace/root")
+        mock_find_workspace_root.return_value = workspace_path
+        
+        expected_result = Mock(returncode=0, stdout="success", stderr="")
+        mock_subprocess_run.return_value = expected_result
+        
+        with patch.dict(os.environ, {"BAZEL_CONFIG": ""}):
+            run_bazel(["build", "//demo:target"])
+        
+        call_args = mock_subprocess_run.call_args[0][0]
+        assert call_args == ["bazel", "build", "//demo:target"]

--- a/tools/release_helper/test_metadata.py
+++ b/tools/release_helper/test_metadata.py
@@ -17,7 +17,16 @@ from pathlib import Path
 from unittest.mock import Mock, patch, mock_open, MagicMock
 from subprocess import CompletedProcess
 
+import tools.release_helper.metadata as metadata_module
 from tools.release_helper.metadata import get_app_metadata, list_all_apps, get_image_targets
+
+
+@pytest.fixture(autouse=True)
+def clear_metadata_cache():
+    """Clear the metadata cache before each test."""
+    metadata_module._metadata_cache.clear()
+    yield
+    metadata_module._metadata_cache.clear()
 
 
 @pytest.fixture
@@ -86,71 +95,89 @@ class TestGetAppMetadata:
     """Test cases for get_app_metadata function."""
 
     def test_get_app_metadata_success(self, mock_run_bazel, mock_find_workspace_root, 
-                                      mock_path_exists, mock_file_open, sample_metadata):
+                                      sample_metadata):
         """Test successful metadata retrieval."""
         bazel_target = "//demo/hello_fastapi:hello_fastapi_metadata"
         
-        with patch('builtins.open', mock_file_open(json.dumps(sample_metadata))) as mock_file:
-            result = get_app_metadata(bazel_target)
+        # _read_metadata_file is called twice: once before build (returns None), once after
+        with patch('builtins.open', mock_open(read_data=json.dumps(sample_metadata))):
+            with patch('pathlib.Path.exists', side_effect=[False, True]):
+                result = get_app_metadata(bazel_target)
             
-            # Verify bazel build was called
-            mock_run_bazel.assert_called_once_with(["build", bazel_target])
-            
-            # Verify correct file path was used
-            expected_file_path = Path("/workspace/bazel-bin/demo/hello_fastapi/hello_fastapi_metadata_metadata.json")
-            mock_file.assert_called_once_with(expected_file_path)
-            
-            assert result == sample_metadata
+                # Verify bazel build was called (file didn't exist on first check)
+                mock_run_bazel.assert_called_once_with(["build", bazel_target])
+                
+                assert result == sample_metadata
 
-    def test_get_app_metadata_invalid_target_format_no_slashes(self, mock_run_bazel):
+    def test_get_app_metadata_cached(self, mock_run_bazel, mock_find_workspace_root,
+                                     sample_metadata):
+        """Test that repeated calls return cached result without rebuilding."""
+        bazel_target = "//demo/hello_fastapi:hello_fastapi_metadata"
+        
+        with patch('builtins.open', mock_open(read_data=json.dumps(sample_metadata))):
+            with patch('pathlib.Path.exists', side_effect=[False, True]):
+                result1 = get_app_metadata(bazel_target)
+        
+        # Second call should use cache, no additional bazel build
+        result2 = get_app_metadata(bazel_target)
+        
+        assert result1 == result2
+        mock_run_bazel.assert_called_once()  # Only one build call
+
+    def test_get_app_metadata_reads_from_disk_without_building(self, mock_run_bazel, 
+                                                                mock_find_workspace_root,
+                                                                sample_metadata):
+        """Test that if metadata file already exists on disk, no build is triggered."""
+        bazel_target = "//demo/hello_fastapi:hello_fastapi_metadata"
+        
+        with patch('builtins.open', mock_open(read_data=json.dumps(sample_metadata))):
+            with patch('pathlib.Path.exists', return_value=True):
+                result = get_app_metadata(bazel_target)
+        
+        # No bazel build should be called since file exists
+        mock_run_bazel.assert_not_called()
+        assert result == sample_metadata
+
+    def test_get_app_metadata_invalid_target_format_no_slashes(self):
         """Test error handling for invalid target format without double slashes."""
         bazel_target = "demo/hello_fastapi:hello_fastapi_metadata"
         
         with pytest.raises(ValueError, match="Invalid bazel target format"):
             get_app_metadata(bazel_target)
-        
-        # Verify run_bazel was called before validation
-        mock_run_bazel.assert_called_once_with(["build", bazel_target])
 
-    def test_get_app_metadata_invalid_target_format_no_colon(self, mock_run_bazel):
+    def test_get_app_metadata_invalid_target_format_no_colon(self):
         """Test error handling for invalid target format without colon."""
         bazel_target = "//demo/hello_fastapi/hello_fastapi_metadata"
         
         with pytest.raises(ValueError, match="Invalid bazel target format"):
             get_app_metadata(bazel_target)
-        
-        # Verify run_bazel was called before validation
-        mock_run_bazel.assert_called_once_with(["build", bazel_target])
 
-    def test_get_app_metadata_invalid_target_format_multiple_colons(self, mock_run_bazel):
+    def test_get_app_metadata_invalid_target_format_multiple_colons(self):
         """Test error handling for invalid target format with multiple colons."""
         bazel_target = "//demo/hello_fastapi:hello:fastapi_metadata"
         
         with pytest.raises(ValueError, match="Invalid bazel target format"):
             get_app_metadata(bazel_target)
-        
-        # Verify run_bazel was called before validation
-        mock_run_bazel.assert_called_once_with(["build", bazel_target])
 
     def test_get_app_metadata_file_not_found(self, mock_run_bazel, mock_find_workspace_root):
-        """Test error handling when metadata file doesn't exist."""
+        """Test error handling when metadata file doesn't exist even after build."""
         bazel_target = "//demo/hello_fastapi:hello_fastapi_metadata"
         
         with patch('pathlib.Path.exists', return_value=False):
             with pytest.raises(FileNotFoundError, match="Metadata file not found"):
                 get_app_metadata(bazel_target)
         
-        # Verify bazel build was still called
+        # Verify bazel build was called (first read returned None)
         mock_run_bazel.assert_called_once_with(["build", bazel_target])
 
-    def test_get_app_metadata_json_parse_error(self, mock_run_bazel, mock_find_workspace_root, 
-                                               mock_path_exists, mock_file_open):
+    def test_get_app_metadata_json_parse_error(self, mock_run_bazel, mock_find_workspace_root):
         """Test error handling when JSON parsing fails."""
         bazel_target = "//demo/hello_fastapi:hello_fastapi_metadata"
         
-        with patch('builtins.open', mock_file_open("invalid json")):
-            with pytest.raises(json.JSONDecodeError):
-                get_app_metadata(bazel_target)
+        with patch('builtins.open', mock_open(read_data="invalid json")):
+            with patch('pathlib.Path.exists', return_value=True):
+                with pytest.raises(json.JSONDecodeError):
+                    get_app_metadata(bazel_target)
 
 
 class TestListAllApps:
@@ -170,7 +197,7 @@ class TestListAllApps:
             {"name": "api", "domain": "services", "language": "go"}
         ]
         
-        # Mock the bazel query result
+        # Mock the bazel query and batch build results
         mock_run_bazel.return_value = Mock(stdout=bazel_query_output)
         
         # Mock get_app_metadata calls
@@ -178,9 +205,16 @@ class TestListAllApps:
         
         result = list_all_apps()
         
-        # Verify bazel query was called correctly
-        mock_run_bazel.assert_called_once_with([
+        # Verify bazel query was called, then batch build
+        assert mock_run_bazel.call_count == 2
+        mock_run_bazel.assert_any_call([
             "query", "kind(app_metadata, //...)", "--output=label"
+        ])
+        mock_run_bazel.assert_any_call([
+            "build",
+            "//demo/hello_fastapi:hello_fastapi_metadata",
+            "//demo/hello_python:hello_python_metadata",
+            "//services/api:api_metadata"
         ])
         
         # Verify get_app_metadata was called for each target


### PR DESCRIPTION
## Problem

Release jobs take ~6 minutes each. Investigating [run #22040037186](https://github.com/whale-net/everything/actions/runs/22040037186) revealed the release helper spawns many redundant Bazel invocations per app:

- `list_all_apps()` builds each metadata target in a **separate** Bazel invocation (N analysis phases)
- `get_app_metadata()` is called 3-4 times per release (CLI lookup, `release_multiarch_image`, `push_image_with_tags`), each triggering `bazel build`
- All inner Bazel calls from the release helper ran **without** `--config=ci-images`, missing remote cache compression and download optimizations

## Changes

1. **`core.py`**: `run_bazel()` now respects `BAZEL_CONFIG` env var, injecting `--config` flags into build/run/test/query commands
2. **`metadata.py`**: 
   - In-process cache for `get_app_metadata()` — avoids redundant builds
   - `_read_metadata_file()` checks disk before building — skips build if file already exists (e.g., from batch build)
   - `list_all_apps()` batch-builds all metadata targets in a single Bazel invocation
3. **`release.yml`**: Sets `BAZEL_CONFIG=ci-images` for release jobs and `BAZEL_CONFIG=ci` for helm chart builds

## Expected Impact

- Eliminates ~10+ redundant Bazel analysis phases per app release
- Inner Bazel calls now use remote cache compression and download optimizations
- Should reduce per-app release time significantly (exact savings depend on cache hit rates)