### PR TITLE
fix(auth): redirect to login on expired/missing access token

### DIFF
--- a/libs/go/htmxauth/auth.go
+++ b/libs/go/htmxauth/auth.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -467,7 +469,8 @@ func (sm *SessionManager) VerifyOAuthState(r *http.Request, state string) (bool,
 	return true, nil
 }
 
-// GetAccessToken retrieves the stored access token from session
+// GetAccessToken retrieves the stored access token from session.
+// Returns an error if the token is missing or has expired.
 func (sm *SessionManager) GetAccessToken(r *http.Request) (string, error) {
 	session, err := sm.GetSession(r)
 	if err != nil {
@@ -477,7 +480,33 @@ func (sm *SessionManager) GetAccessToken(r *http.Request) (string, error) {
 	if !ok || token == "" {
 		return "", fmt.Errorf("no access token in session")
 	}
+	if isJWTExpired(token) {
+		return "", fmt.Errorf("access token expired")
+	}
 	return token, nil
+}
+
+// isJWTExpired decodes the JWT payload (without verification) and checks the exp claim.
+// Returns false if the token cannot be parsed, so non-JWT tokens are allowed through.
+func isJWTExpired(tokenStr string) bool {
+	parts := strings.SplitN(tokenStr, ".", 3)
+	if len(parts) != 3 {
+		return false
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return false
+	}
+	var claims struct {
+		Exp int64 `json:"exp"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return false
+	}
+	if claims.Exp == 0 {
+		return false
+	}
+	return time.Now().Unix() > claims.Exp
 }
 
 // GetNextURL retrieves and clears the next URL from session

--- a/manmanv2/ui/components/log_histogram.templ
+++ b/manmanv2/ui/components/log_histogram.templ
@@ -19,7 +19,10 @@ templ LogHistogram(data LogHistogramData) {
 		<div class="p-4 border-b border-gray-200 dark:border-slate-700">
 			<div class="flex items-center justify-between mb-2">
 				<div id="histogram-status" class="text-sm text-gray-600 dark:text-gray-400"></div>
-				<button id="zoom-out-btn" style="display: none;" class="text-sm text-blue-600 hover:text-blue-700 dark:text-blue-400">← Back to overview</button>
+				<div class="flex items-center gap-2">
+					<button id="zoom-out-btn" disabled style="display: none;" class="inline-flex items-center gap-1 px-2 py-1 text-sm bg-gray-100 hover:bg-gray-200 dark:bg-slate-700 dark:hover:bg-slate-600 disabled:opacity-40 disabled:cursor-not-allowed text-gray-700 dark:text-gray-300 rounded-md transition-colors">← Zoom Out</button>
+					<button id="zoom-in-btn" disabled style="display: none;" class="inline-flex items-center gap-1 px-2 py-1 text-sm bg-gray-100 hover:bg-gray-200 dark:bg-slate-700 dark:hover:bg-slate-600 disabled:opacity-40 disabled:cursor-not-allowed text-gray-700 dark:text-gray-300 rounded-md transition-colors">Zoom In →</button>
+				</div>
 			</div>
 			<div style="position: relative;">
 				<canvas id="log-histogram" style="width: 100%; height: 300px; cursor: crosshair;"></canvas>
@@ -51,6 +54,7 @@ templ LogHistogram(data LogHistogramData) {
 			const logContent = document.getElementById('log-content');
 			const tooltip = document.getElementById('tooltip');
 			const zoomOutBtn = document.getElementById('zoom-out-btn');
+			const zoomInBtn = document.getElementById('zoom-in-btn');
 
 			let histogramData = null;
 			let zoomStack = []; // stack of {start, end} for drill-down history
@@ -150,7 +154,7 @@ templ LogHistogram(data LogHistogramData) {
 					histogramData = data;
 					const zoomText = zoomStack.length > 0 ? ' (zoomed)' : '';
 					statusDiv.textContent = 'Showing ' + histogramData.buckets.length + ' time buckets (' + histogramData.granularity + ' resolution)' + zoomText;
-					zoomOutBtn.style.display = zoomStack.length > 0 ? 'inline' : 'none';
+					updateZoomButtons();
 					renderHistogram();
 					return true;
 				} catch (err) {
@@ -286,17 +290,20 @@ templ LogHistogram(data LogHistogramData) {
 				const x = e.clientX - rect.left;
 				const idx = xToIndex(x);
 
-				if (e.detail === 2) {
-					drillDown(idx);
-					return;
-				}
-
 				if (idx >= 0 && idx < histogramData.buckets.length) {
 					isSelecting = true;
 					selectionStart = idx;
 					selection = { startIdx: idx, endIdx: idx };
 					updateSelection();
 				}
+			});
+
+			canvas.addEventListener('dblclick', (e) => {
+				if (!histogramData) return;
+				const rect = canvas.getBoundingClientRect();
+				const x = e.clientX - rect.left;
+				const idx = xToIndex(x);
+				drillDown(idx, idx);
 			});
 
 			canvas.addEventListener('mousemove', (e) => {
@@ -315,7 +322,7 @@ templ LogHistogram(data LogHistogramData) {
 						(bucket.stdout_lines ? '<div style="color: #d4d4d4;">stdout: ' + bucket.stdout_lines.toLocaleString() + '</div>' : '') +
 						(bucket.stderr_lines ? '<div style="color: #f48771;">stderr: ' + bucket.stderr_lines.toLocaleString() + '</div>' : '') +
 						(bucket.host_lines ? '<div style="color: #4fc1ff;">host: ' + bucket.host_lines.toLocaleString() + '</div>' : '') +
-						(canZoom ? '<div style="margin-top: 4px; font-size: 11px; color: #aaa;">Double-click to zoom in</div>' : '');
+						(canZoom ? '<div style="margin-top: 4px; font-size: 11px; color: #aaa;">Select range then click Zoom In (or double-click)</div>' : '');
 					tooltip.style.display = 'block';
 					tooltip.style.left = (x + 10) + 'px';
 					tooltip.style.top = (e.clientY - rect.top + 10) + 'px';
@@ -333,20 +340,36 @@ templ LogHistogram(data LogHistogramData) {
 			canvas.addEventListener('mouseleave', () => { tooltip.style.display = 'none'; });
 			canvas.addEventListener('mouseup', () => { isSelecting = false; });
 
-			function drillDown(idx) {
+			function updateZoomButtons() {
+				const canZoomIn = histogramData && nextFinerGranularity(histogramData.granularity) !== null;
+				const canZoomOut = zoomStack.length > 0;
+				zoomInBtn.style.display = canZoomIn ? 'inline-flex' : 'none';
+				zoomInBtn.disabled = !selection;
+				zoomOutBtn.style.display = canZoomOut ? 'inline-flex' : 'none';
+				zoomOutBtn.disabled = false;
+			}
+
+			// drillDown: zoom into the index range [startIdx, endIdx]
+			function drillDown(startIdx, endIdx) {
 				if (!histogramData) return;
 				const nextGran = nextFinerGranularity(histogramData.granularity);
 				if (!nextGran) return;
-				const bucket = histogramData.buckets[idx];
-				const bucketDuration = granularityToSeconds(histogramData.granularity);
-				const startTime = bucket.timestamp;
-				const endTime = bucket.timestamp + bucketDuration;
+				const bucketSecs = granularityToSeconds(histogramData.granularity);
+				const si = Math.min(startIdx, endIdx);
+				const ei = Math.max(startIdx, endIdx);
+				const startTime = histogramData.buckets[si].timestamp;
+				const endTime = histogramData.buckets[ei].timestamp + bucketSecs;
 				zoomStack.push({ start: startTime, end: endTime });
 				selection = null;
 				selectionInfo.textContent = '';
 				loadBtn.disabled = true;
 				loadHistogram(startTime, endTime);
 			}
+
+			zoomInBtn.onclick = () => {
+				if (!selection) return;
+				drillDown(selection.startIdx, selection.endIdx);
+			};
 
 			zoomOutBtn.onclick = () => {
 				zoomStack.pop();
@@ -386,6 +409,7 @@ templ LogHistogram(data LogHistogramData) {
 				logOffset = 0;
 				loadBtn.disabled = false;
 				loadMoreBtn.style.display = 'none';
+				updateZoomButtons();
 			}
 
 			function loadLogs(start, end, offset, limit, append) {

--- a/manmanv2/ui/main.go
+++ b/manmanv2/ui/main.go
@@ -209,14 +209,24 @@ func main() {
 	}
 }
 
-// withAccessToken wraps a protected handler to also inject the user's access token
-// into the request context for gRPC forwarding.
+// withAccessToken wraps a protected handler to inject the user's access token
+// into the request context for gRPC forwarding. If the token is unavailable or
+// expired, the user is redirected to re-authenticate. HTMX partial requests
+// receive an HX-Redirect header so the full page reloads to the login URL.
 func (app *App) withAccessToken(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		token, err := app.auth.GetAccessToken(r)
-		if err == nil {
-			r = r.WithContext(grpcauth.WithUserToken(r.Context(), token))
+		if err != nil {
+			loginURL := fmt.Sprintf("/auth/login?next=%s", r.URL.RequestURI())
+			if r.Header.Get("HX-Request") == "true" {
+				w.Header().Set("HX-Redirect", loginURL)
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			http.Redirect(w, r, loginURL, http.StatusSeeOther)
+			return
 		}
+		r = r.WithContext(grpcauth.WithUserToken(r.Context(), token))
 		next(w, r)
 	}
 }


### PR DESCRIPTION
## Summary
- Add JWT expiry detection to `SessionManager.GetAccessToken` in `htmxauth` — cookie-backed sessions now return an error when the stored access token is expired, instead of silently returning a stale JWT
- Change `withAccessToken` middleware in manmanv2 UI to redirect to `/auth/login?next=<path>` when the token is unavailable or expired, rather than proceeding without a token and showing a 500 error
- HTMX partial requests receive an `HX-Redirect` header + 401 response so the full page navigates to the login URL instead of swapping a fragment

## Test plan
- [ ] Let a session's access token expire (or manually clear/expire it) and navigate to a protected page — should redirect to login, not show an error
- [ ] Verify HTMX polling endpoints (e.g. dashboard summary) also redirect cleanly on expiry
- [ ] Verify normal login/logout flow still works end-to-end
- [ ] Verify dev mode (`AUTH_MODE=none`) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)