### PR TITLE
chore: add .claude/worktrees/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,7 @@ go.work.sum
 .vscode/
 .idea/
 .cursor/
+.claude/worktrees/
 *.swp
 *.swo
 *~


### PR DESCRIPTION
## Summary
- Adds `.claude/worktrees/` to `.gitignore` to prevent Claude Code worktree directories from being tracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)