### PR TITLE
fix(manmanv2/host): support backups for named Docker volumes

### DIFF
--- a/manmanv2/host/backup.go
+++ b/manmanv2/host/backup.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/whale-net/everything/libs/go/docker"
 	"github.com/whale-net/everything/manmanv2/models"
 	hostrmq "github.com/whale-net/everything/manmanv2/host/rmq"
 )
@@ -22,7 +23,7 @@ func (h *CommandHandlerImpl) HandleBackup(ctx context.Context, cmd *hostrmq.Back
 		return fmt.Errorf("presigned_url is empty for backup %d", cmd.BackupID)
 	}
 
-	slog.Info("processing backup command", "backup_id", cmd.BackupID, "sgc_id", cmd.SGCID, "s3_key", cmd.S3Key)
+	slog.Info("processing backup command", "backup_id", cmd.BackupID, "sgc_id", cmd.SGCID, "s3_key", cmd.S3Key, "volume_type", cmd.VolumeType)
 
 	fail := func(err error) error {
 		msg := err.Error()
@@ -49,23 +50,21 @@ func (h *CommandHandlerImpl) HandleBackup(ctx context.Context, cmd *hostrmq.Back
 		}
 	}
 
-	// 2. Build tar command: stream to stdout
-	// VolumeHostPath is the host_subpath (e.g. "data"); build the full internal path:
-	//   {internalDataDir}/sgc[-{env}]-{sgcID}/{hostSubpath}
-	dirName := fmt.Sprintf("sgc-%d", cmd.SGCID)
-	if h.environment != "" {
-		dirName = fmt.Sprintf("sgc-%s-%d", h.environment, cmd.SGCID)
+	// 2. Resolve the directory to tar; cleanup removes any temp dir used for named volumes.
+	tarPath, cleanup, err := h.resolveBackupSourceDir(ctx, cmd)
+	if err != nil {
+		return fail(err)
 	}
-	subPath := strings.TrimPrefix(cmd.VolumeHostPath, "/")
-	if subPath == "" {
-		return fail(fmt.Errorf("volume_host_path is empty"))
+	if cleanup != nil {
+		defer cleanup()
 	}
-	tarPath := filepath.Join(h.internalDataDir, dirName, subPath)
+
 	backupPath := cmd.BackupPath
 	if backupPath == "" {
 		backupPath = "."
 	}
 
+	// 3. Build tar command: stream to stdout
 	tarCmd := exec.CommandContext(ctx, "tar", "-czf", "-", "-C", tarPath, backupPath)
 	tarReader, err := tarCmd.StdoutPipe()
 	if err != nil {
@@ -75,7 +74,7 @@ func (h *CommandHandlerImpl) HandleBackup(ctx context.Context, cmd *hostrmq.Back
 		return fail(fmt.Errorf("failed to start tar: %w", err))
 	}
 
-	// 3. Buffer tar output to temp file (needed for Content-Length on presigned PUT)
+	// 4. Buffer tar output to temp file (needed for Content-Length on presigned PUT)
 	tmpFile, err := os.CreateTemp("", "backup-*.tar.gz")
 	if err != nil {
 		_ = tarCmd.Process.Kill()
@@ -100,7 +99,7 @@ func (h *CommandHandlerImpl) HandleBackup(ctx context.Context, cmd *hostrmq.Back
 		return fail(fmt.Errorf("failed to rewind temp file: %w", err))
 	}
 
-	// 4. Upload to S3 via pre-signed PUT URL with known Content-Length
+	// 5. Upload to S3 via pre-signed PUT URL with known Content-Length
 	req, err := http.NewRequestWithContext(ctx, http.MethodPut, cmd.PresignedURL, io.NopCloser(tmpFile))
 	if err != nil {
 		return fail(fmt.Errorf("failed to create upload request: %w", err))
@@ -117,7 +116,6 @@ func (h *CommandHandlerImpl) HandleBackup(ctx context.Context, cmd *hostrmq.Back
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		_ = tarCmd.Process.Kill()
 		return fail(fmt.Errorf("failed to upload to S3: %w", err))
 	}
 	respBody, _ := io.ReadAll(resp.Body)
@@ -134,4 +132,114 @@ func (h *CommandHandlerImpl) HandleBackup(ctx context.Context, cmd *hostrmq.Back
 		S3URL:    &s3URL,
 		Status:   manman.BackupStatusCompleted,
 	})
+}
+
+// resolveBackupSourceDir returns the directory path to pass to tar and an optional cleanup func.
+// For bind-mount volumes it returns the host-accessible path directly.
+// For named volumes it copies the volume contents into a temporary directory via a busybox
+// helper container (the same pattern used by the workshop orchestrator for installs).
+func (h *CommandHandlerImpl) resolveBackupSourceDir(ctx context.Context, cmd *hostrmq.BackupCommand) (tarPath string, cleanup func(), err error) {
+	if cmd.VolumeType != "named" {
+		// Bind-mount: derive the internal path from host_subpath.
+		subPath := strings.TrimPrefix(cmd.VolumeHostPath, "/")
+		if subPath == "" {
+			return "", nil, fmt.Errorf("volume_host_path is empty for bind-mount backup %d", cmd.BackupID)
+		}
+		dirName := fmt.Sprintf("sgc-%d", cmd.SGCID)
+		if h.environment != "" {
+			dirName = fmt.Sprintf("sgc-%s-%d", h.environment, cmd.SGCID)
+		}
+		return filepath.Join(h.internalDataDir, dirName, subPath), nil, nil
+	}
+
+	// Named volume: Docker manages the storage location, so direct host filesystem access is
+	// not available. Use a busybox helper container to copy the volume contents into a
+	// temporary bind-mount directory that this process can then tar.
+	if cmd.VolumeName == "" {
+		return "", nil, fmt.Errorf("volume_name is empty for named-volume backup %d", cmd.BackupID)
+	}
+	dockerVolumeName := h.getNamedVolumeName(cmd.SGCID, cmd.VolumeName)
+
+	// Create staging dir under internalDataDir so we can read the files directly.
+	// Compute its equivalent host path for use as a Docker bind-mount source.
+	stagingInternal, err := os.MkdirTemp(h.internalDataDir, fmt.Sprintf("backup-%d-*", cmd.BackupID))
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to create backup staging dir: %w", err)
+	}
+	cleanup = func() { os.RemoveAll(stagingInternal) }
+
+	stagingHost := strings.Replace(stagingInternal, h.internalDataDir, h.hostDataDir, 1)
+
+	helperConfig := docker.ContainerConfig{
+		Name:    fmt.Sprintf("backup-extract-%d-%d", cmd.SGCID, cmd.BackupID),
+		Image:   "busybox:latest",
+		Command: []string{"sh", "-c", "cp -a /vol/. /staging/"},
+		Volumes: []string{
+			fmt.Sprintf("%s:/vol", dockerVolumeName),
+			fmt.Sprintf("%s:/staging", stagingHost),
+		},
+	}
+
+	slog.Info("extracting named volume via helper container", "volume", dockerVolumeName, "staging", stagingHost)
+	if err := h.runBackupHelperContainer(ctx, helperConfig); err != nil {
+		return "", cleanup, fmt.Errorf("failed to extract named volume %s: %w", dockerVolumeName, err)
+	}
+
+	return stagingInternal, cleanup, nil
+}
+
+// getNamedVolumeName mirrors the naming convention in the session manager and workshop orchestrator.
+func (h *CommandHandlerImpl) getNamedVolumeName(sgcID int64, volumeName string) string {
+	if h.environment != "" {
+		return fmt.Sprintf("manman-sgc-%s-%d-%s", h.environment, sgcID, volumeName)
+	}
+	return fmt.Sprintf("manman-sgc-%d-%s", sgcID, volumeName)
+}
+
+// runBackupHelperContainer creates, starts, waits for, and removes a short-lived container.
+func (h *CommandHandlerImpl) runBackupHelperContainer(ctx context.Context, config docker.ContainerConfig) error {
+	if existing, err := h.dockerClient.GetContainerStatus(ctx, config.Name); err == nil && existing != nil {
+		_ = h.dockerClient.RemoveContainer(ctx, existing.ContainerID, true)
+	}
+
+	const maxPullAttempts = 3
+	var pullErr error
+	for attempt := 1; attempt <= maxPullAttempts; attempt++ {
+		pullErr = h.dockerClient.PullImage(ctx, config.Image)
+		if pullErr == nil {
+			break
+		}
+		if attempt < maxPullAttempts {
+			time.Sleep(time.Duration(attempt) * time.Second)
+		}
+	}
+	if pullErr != nil {
+		return fmt.Errorf("failed to pull helper image %s: %w", config.Image, pullErr)
+	}
+
+	containerID, err := h.dockerClient.CreateContainer(ctx, config)
+	if err != nil {
+		return fmt.Errorf("failed to create helper container: %w", err)
+	}
+
+	if err := h.dockerClient.StartContainer(ctx, containerID); err != nil {
+		_ = h.dockerClient.RemoveContainer(ctx, containerID, true)
+		return fmt.Errorf("failed to start helper container: %w", err)
+	}
+
+	for {
+		status, err := h.dockerClient.GetContainerStatus(ctx, containerID)
+		if err != nil {
+			_ = h.dockerClient.RemoveContainer(ctx, containerID, true)
+			return fmt.Errorf("failed to get helper container status: %w", err)
+		}
+		if !status.Running {
+			_ = h.dockerClient.RemoveContainer(ctx, containerID, true)
+			if status.ExitCode != 0 {
+				return fmt.Errorf("helper container exited with code %d", status.ExitCode)
+			}
+			return nil
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
 }

--- a/manmanv2/host/main.go
+++ b/manmanv2/host/main.go
@@ -163,7 +163,9 @@ func run() error {
 		publisher:            rmqPublisher,
 		serverID:             serverID,
 		downloadOrchestrator: downloadOrchestrator,
+		dockerClient:         dockerClient,
 		internalDataDir:      session.InternalDataDir,
+		hostDataDir:          hostDataDir,
 		environment:          environment,
 	}
 
@@ -245,7 +247,9 @@ type CommandHandlerImpl struct {
 	publisher            *rmq.Publisher
 	serverID             int64
 	downloadOrchestrator *workshop.DownloadOrchestrator
+	dockerClient         *docker.Client
 	internalDataDir      string
+	hostDataDir          string
 	environment          string
 }
 

--- a/manmanv2/host/rmq/messages.go
+++ b/manmanv2/host/rmq/messages.go
@@ -121,7 +121,9 @@ type RemoveAddonCommand struct {
 type BackupCommand struct {
 	BackupID          int64     `json:"backup_id"`
 	SGCID             int64     `json:"sgc_id"`
-	VolumeHostPath    string    `json:"volume_host_path"`    // absolute path on host to the volume root
+	VolumeType        string    `json:"volume_type"`         // "bind" or "named"
+	VolumeHostPath    string    `json:"volume_host_path"`    // host path to volume root (bind volumes only)
+	VolumeName        string    `json:"volume_name"`         // logical volume name (used to derive Docker named volume)
 	BackupPath        string    `json:"backup_path"`         // relative path within volume to archive
 	S3Key             string    `json:"s3_key"`              // pre-computed: backups/{sgc_id}/{config_id}/{backup_id}.tar.gz
 	PresignedURL      string    `json:"presigned_url"`       // pre-signed PUT URL for direct upload

--- a/manmanv2/processor/backup_scheduler.go
+++ b/manmanv2/processor/backup_scheduler.go
@@ -156,7 +156,9 @@ func (w *scheduledBackupWorker) Work(ctx context.Context, job *river.Job[schedul
 		cmd := &hostrmq.BackupCommand{
 			BackupID:          backup.BackupID,
 			SGCID:             sgc.SGCID,
+			VolumeType:        volume.VolumeType,
 			VolumeHostPath:    hostPath,
+			VolumeName:        volume.Name,
 			BackupPath:        cfg.BackupPath,
 			S3Key:             s3Key,
 			PresignedURL:      presignedURL,

--- a/manmanv2/scripts/run-host-manager.sh
+++ b/manmanv2/scripts/run-host-manager.sh
@@ -8,12 +8,28 @@ SGC_HOST_DATA_PATH="$(pwd)/tmp/manman-data"
 
 # Parse arguments
 DETACH_MODE=""
-if [[ "$1" == "-d" ]] || [[ "$1" == "--detach" ]]; then
-    DETACH_MODE="-d"
-else
+WORKTREE_DIR=""
+for arg in "$@"; do
+    case "$arg" in
+        -d|--detach)
+            DETACH_MODE="-d"
+            ;;
+        --worktree=*)
+            WORKTREE_DIR="${arg#*=}"
+            ;;
+        *)
+            echo "Unknown argument: $arg"
+            echo "Usage: $0 [-d|--detach] [--worktree=PATH]"
+            exit 1
+            ;;
+    esac
+done
+if [[ -z "$DETACH_MODE" ]]; then
     # Interactive mode by default
     DETACH_MODE="-it"
 fi
+
+BAZEL_DIR="${WORKTREE_DIR:-$(pwd)}"
 
 # Ensure host data directory exists
 mkdir -p "$SGC_HOST_DATA_PATH"
@@ -27,8 +43,8 @@ if docker ps -a --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}$"; then
 fi
 
 # Build image
-echo "Building host manager image..."
-bazel run //manmanv2/host:host-manager_image_load
+echo "Building host manager image from: ${BAZEL_DIR}"
+(cd "${BAZEL_DIR}" && bazel run //manmanv2/host:host-manager_image_load)
 
 # Run container
 # We use host.docker.internal to access services running on the host (Tilt/K8s port-forwards)


### PR DESCRIPTION
## Summary

- Named volumes are managed by Docker and not accessible at a host filesystem path, so the previous bind-mount tar logic would fail with exit 2
- For named volumes, spin up a `busybox` helper container (same pattern as the workshop orchestrator) to `cp` the volume contents into a temp bind-mount dir, then tar from there
- Add `VolumeType`/`VolumeName` to `BackupCommand` so the host knows which strategy to use; processor populates these from the `GameConfigVolume` record
- `CommandHandlerImpl` gains `dockerClient` + `hostDataDir` fields to support the helper container approach
- `run-host-manager.sh` gains `--worktree=PATH` flag to build from a non-main worktree

Closes #421

## Test plan

- [x] `bazel build //manmanv2/host/... //manmanv2/processor/...` passes
- [x] Reproduced locally with Minecraft named volume (`manman-sgc-dev-5-data`) — backup now extracts via helper container and uploads to S3

🤖 Generated with [Claude Code](https://claude.com/claude-code)