### PR TITLE
fix(libs/go/rmq): stop DLQ flooding, fix PRECONDITION_FAILED channel reuse

### DIFF
--- a/libs/go/rmq/consumer.go
+++ b/libs/go/rmq/consumer.go
@@ -383,13 +383,16 @@ func (c *Consumer) handleMessage(ctx context.Context, delivery amqp.Delivery) {
 		retryCount := getRetryCount(delivery)
 		maxRetries := 3
 
-		// Check if it's a permanent error or max retries exceeded
+		// Check if it's a permanent error or max retries exceeded.
+		// Note: whether the message reaches a DLQ depends on whether the queue
+		// was declared with dead-letter routing. Queues with TTL/max-length limits
+		// do not have DLQ routing and will discard the message on Nack.
 		if IsPermanentError(err) {
-			log.Printf("Permanent error - sending to DLQ: %v", err)
-			delivery.Nack(false, false) // Reject and send to DLQ
+			log.Printf("Permanent error - discarding message (DLQ if configured): %v", err)
+			delivery.Nack(false, false)
 		} else if retryCount >= maxRetries {
-			log.Printf("Max retries (%d) exceeded - sending to DLQ", maxRetries)
-			delivery.Nack(false, false) // Reject and send to DLQ
+			log.Printf("Max retries (%d) exceeded - discarding message (DLQ if configured)", maxRetries)
+			delivery.Nack(false, false)
 		} else {
 			log.Printf("Transient error (retry %d/%d) - requeuing", retryCount+1, maxRetries)
 			delivery.Nack(false, true) // Reject and requeue for retry

--- a/libs/go/rmq/consumer.go
+++ b/libs/go/rmq/consumer.go
@@ -71,37 +71,48 @@ func NewConsumerWithOpts(conn *Connection, queueName string, durable, autoDelete
 		return nil, fmt.Errorf("failed to set QoS: %w", err)
 	}
 
-	if durable {
-		// Declare dead letter queue first
-		dlqName := queueName + "-dlq"
-		_, err = ch.QueueDeclare(
-			dlqName, // name
-			true,    // durable
-			false,   // delete when unused
-			false,   // exclusive
-			false,   // no-wait
-			nil,     // arguments
-		)
+	// reopenCh closes ch and returns a fresh channel with QoS set.
+	// Needed after PRECONDITION_FAILED (406) which closes the channel server-side.
+	reopenCh := func() error {
+		ch.Close()
+		ch, err = conn.Channel()
 		if err != nil {
+			return fmt.Errorf("failed to reopen channel: %w", err)
+		}
+		if err := ch.Qos(1, 0, false); err != nil {
 			ch.Close()
-			return nil, fmt.Errorf("failed to declare DLQ: %w", err)
+			return fmt.Errorf("failed to set QoS: %w", err)
+		}
+		return nil
+	}
+
+	if durable && messageTTL == 0 && maxMessages == 0 {
+		dlqName := queueName + "-dlq"
+		if _, err = ch.QueueDeclare(dlqName, true, false, false, false, nil); err != nil {
+			if !isPreconditionFailed(err) {
+				ch.Close()
+				return nil, fmt.Errorf("failed to declare DLQ: %w", err)
+			}
+			log.Printf("DLQ %s already exists with different args, using as-is: %v", dlqName, err)
+			if err := reopenCh(); err != nil {
+				return nil, err
+			}
 		}
 	}
 
 	arguments := buildQueueArguments(queueName, durable, autoDelete, messageTTL, maxMessages)
 
-	// Declare main queue
-	queue, err := ch.QueueDeclare(
-		queueName,  // name
-		durable,    // durable
-		autoDelete, // delete when unused
-		false,      // exclusive
-		false,      // no-wait
-		arguments,  // arguments
-	)
+	queue, err := ch.QueueDeclare(queueName, durable, autoDelete, false, false, arguments)
 	if err != nil {
-		ch.Close()
-		return nil, fmt.Errorf("failed to declare queue: %w", err)
+		if !isPreconditionFailed(err) {
+			ch.Close()
+			return nil, fmt.Errorf("failed to declare queue: %w", err)
+		}
+		log.Printf("queue %s already exists with different args, using as-is: %v", queueName, err)
+		if err := reopenCh(); err != nil {
+			return nil, err
+		}
+		queue.Name = queueName
 	}
 
 	return &Consumer{
@@ -118,13 +129,16 @@ func NewConsumerWithOpts(conn *Connection, queueName string, durable, autoDelete
 }
 
 // buildQueueArguments constructs the amqp.Table of arguments for queue declaration.
-// Durable queues get DLQ routing. Non-durable, non-auto-delete queues get x-expires
-// as a safety net for orphan cleanup. Durable queues must NOT get x-expires because
-// they are long-lived and would be incorrectly deleted during brief consumer absence.
+// DLQ routing is only added for durable queues without TTL or max-length limits.
+// Queues with those limits are high-throughput (e.g. log streams) where TTL expiry
+// and overflow are expected operational conditions — routing them to the DLQ would
+// flood it. Low-volume, critical queues (e.g. lifecycle events) have no limits and
+// should dead-letter on failure.
+// Non-durable, non-auto-delete queues get x-expires as a safety net for orphan cleanup.
 func buildQueueArguments(queueName string, durable, autoDelete bool, messageTTL, maxMessages int) amqp.Table {
 	var arguments amqp.Table
 
-	if durable {
+	if durable && messageTTL == 0 && maxMessages == 0 {
 		dlqName := queueName + "-dlq"
 		arguments = amqp.Table{
 			"x-dead-letter-exchange":    "", // Use default exchange
@@ -255,6 +269,22 @@ func (c *Consumer) startConsuming() (<-chan amqp.Delivery, error) {
 	}
 	c.mu.Unlock()
 
+	// reopenChannel closes ch and opens a fresh one with QoS applied.
+	// Required after PRECONDITION_FAILED because RabbitMQ closes the channel on 406.
+	reopenChannel := func() error {
+		ch.Close()
+		var err error
+		ch, err = c.conn.Channel()
+		if err != nil {
+			return fmt.Errorf("failed to reopen channel: %w", err)
+		}
+		if err := ch.Qos(1, 0, false); err != nil {
+			ch.Close()
+			return fmt.Errorf("failed to set QoS: %w", err)
+		}
+		return nil
+	}
+
 	if durable {
 		dlqName := declaredName + "-dlq"
 		if _, err := ch.QueueDeclare(dlqName, true, false, false, false, nil); err != nil {
@@ -263,6 +293,9 @@ func (c *Consumer) startConsuming() (<-chan amqp.Delivery, error) {
 				return nil, fmt.Errorf("failed to declare DLQ: %w", err)
 			}
 			log.Printf("DLQ %s already exists with different args, using as-is: %v", dlqName, err)
+			if err := reopenChannel(); err != nil {
+				return nil, err
+			}
 		}
 	}
 
@@ -273,6 +306,9 @@ func (c *Consumer) startConsuming() (<-chan amqp.Delivery, error) {
 			return nil, fmt.Errorf("failed to declare queue: %w", err)
 		}
 		log.Printf("queue %s already exists with different args, using as-is: %v", c.queue, err)
+		if err := reopenChannel(); err != nil {
+			return nil, err
+		}
 	}
 
 	for _, b := range bindings {

--- a/libs/go/rmq/consumer_internal_test.go
+++ b/libs/go/rmq/consumer_internal_test.go
@@ -28,6 +28,53 @@ func TestMatchesRoutingKey(t *testing.T) {
 	}
 }
 
+// TestBuildQueueArguments_DurableWithLimits_NoDLQ verifies that durable queues
+// with TTL or max-length do NOT get dead-letter routing. These are high-throughput
+// queues (e.g. log streams) where TTL expiry and overflow are expected operational
+// conditions — routing them to the DLQ would flood it.
+func TestBuildQueueArguments_DurableWithLimits_NoDLQ(t *testing.T) {
+	cases := []struct {
+		name        string
+		messageTTL  int
+		maxMessages int
+	}{
+		{"ttl only", 60000, 0},
+		{"max-messages only", 0, 1000},
+		{"both", 60000, 1000},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			args := buildQueueArguments("logs.session.1", true, false, tc.messageTTL, tc.maxMessages)
+			if args == nil {
+				return // no args at all is also fine — no DLQ
+			}
+			if _, ok := args["x-dead-letter-exchange"]; ok {
+				t.Errorf("durable queue with limits must not have x-dead-letter-exchange")
+			}
+			if _, ok := args["x-dead-letter-routing-key"]; ok {
+				t.Errorf("durable queue with limits must not have x-dead-letter-routing-key")
+			}
+		})
+	}
+}
+
+// TestBuildQueueArguments_DurableUnlimited_HasDLQ verifies that unlimited durable
+// queues (e.g. lifecycle event queues) still get dead-letter routing.
+func TestBuildQueueArguments_DurableUnlimited_HasDLQ(t *testing.T) {
+	args := buildQueueArguments("log-processor-lifecycle", true, false, 0, 0)
+
+	if args == nil {
+		t.Fatal("expected non-nil arguments for unlimited durable queue")
+	}
+	if _, ok := args["x-dead-letter-exchange"]; !ok {
+		t.Error("unlimited durable queue should have x-dead-letter-exchange")
+	}
+	if v, ok := args["x-dead-letter-routing-key"]; !ok || v != "log-processor-lifecycle-dlq" {
+		t.Errorf("expected x-dead-letter-routing-key = 'log-processor-lifecycle-dlq', got %v", v)
+	}
+}
+
 // TestBuildQueueArguments_DurableQueueNoExpires verifies that durable queues
 // do not get x-expires. This was the root cause of a production failure where
 // re-declaring an existing durable queue with x-expires caused a


### PR DESCRIPTION
## Summary

- **DLQ flooding fix**: DLQ routing is now only configured for durable queues with no TTL/max-length limits. Session log queues have both, so TTL-expired and overflow-dropped messages are silently discarded rather than routed to the DLQ. Lifecycle queues have no limits and keep dead-letter routing for failed event capture.
- **PRECONDITION_FAILED channel bug**: RabbitMQ closes the channel after a 406. The previous fallback logged and continued on the dead channel — `QueueBind` and `Consume` then failed silently. Now the channel is closed and reopened after any 406 so subsequent operations work.

## Test plan
- [ ] Deploy and verify DLQ stops flooding
- [ ] Verify lifecycle events still dead-letter to DLQ on repeated failure
- [ ] Verify consumers recover correctly after a PRECONDITION_FAILED during redeploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)