### PR TITLE
feat(wireframe): leaflab wireframe — device dashboard and detail views

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,13 @@
+{
+  "name": "everything-marketplace",
+  "owner": {
+    "name": "whale_net"
+  },
+  "plugins": [
+    {
+      "name": "project-manager",
+      "description": "Multi-persona, GitHub-tracked project management pipeline (producer/architect/planner/workers/system-validator)",
+      "source": "./tools/project-manager"
+    }
+  ]
+}

--- a/leaflab/ui/design/wireframes/_shell.html
+++ b/leaflab/ui/design/wireframes/_shell.html
@@ -1,0 +1,17 @@
+<div class="navbar bg-neutral text-neutral-content shadow-lg sticky top-0 z-40 px-4">
+  <div class="flex-1 gap-6">
+    <a href="#/dashboard" class="text-lg font-bold">LeafLab</a>
+    <ul class="menu menu-horizontal gap-1 px-0 hidden md:flex">
+      <li><a href="#/dashboard" class="hover:bg-base-content/10">Dashboard</a></li>
+      <li><a href="#/devices" class="hover:bg-base-content/10">Devices</a></li>
+    </ul>
+  </div>
+  <div class="flex-none">
+    <div class="avatar placeholder">
+      <div class="bg-primary text-primary-content w-9 rounded-full"><span class="text-sm">AH</span></div>
+    </div>
+  </div>
+</div>
+<main class="max-w-6xl mx-auto p-4 md:p-6">
+<!-- wf:screen -->
+</main>

--- a/leaflab/ui/design/wireframes/_shell.html
+++ b/leaflab/ui/design/wireframes/_shell.html
@@ -4,6 +4,8 @@
     <ul class="menu menu-horizontal gap-1 px-0 hidden md:flex">
       <li><a href="#/dashboard" class="hover:bg-base-content/10">Dashboard</a></li>
       <li><a href="#/devices" class="hover:bg-base-content/10">Devices</a></li>
+      <li><a href="#/regions" class="hover:bg-base-content/10">Regions</a></li>
+      <li><a href="#/readings" class="hover:bg-base-content/10">Readings</a></li>
     </ul>
   </div>
   <div class="flex-none">

--- a/leaflab/ui/design/wireframes/screens/01-dashboard.html
+++ b/leaflab/ui/design/wireframes/screens/01-dashboard.html
@@ -1,0 +1,114 @@
+<!-- wf: name="dashboard" title="LeafLab Dashboard" -->
+<div class="wf-hero p-6 md:p-8 mb-6 shadow-lg bg-gradient-to-br from-green-900 via-emerald-800 to-teal-900 text-green-50">
+  <h1 class="text-2xl md:text-3xl font-bold mb-2">LeafLab Dashboard</h1>
+  <p class="text-sm opacity-80">Overview of all sensorboard setups across the greenhouse</p>
+</div>
+
+<div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
+  <div class="stat bg-base-100 rounded-box shadow-md">
+    <div class="stat-title">Setups</div>
+    <div class="stat-value text-primary">3</div>
+    <div class="stat-desc">2 online</div>
+  </div>
+  <div class="stat bg-base-100 rounded-box shadow-md">
+    <div class="stat-title">Sensors</div>
+    <div class="stat-value">14</div>
+    <div class="stat-desc">across all boards</div>
+  </div>
+  <div class="stat bg-base-100 rounded-box shadow-md">
+    <div class="stat-title">Regions</div>
+    <div class="stat-value">4</div>
+    <div class="stat-desc">Room A · B, Shelf C, Pot D</div>
+  </div>
+  <div class="stat bg-base-100 rounded-box shadow-md">
+    <div class="stat-title">Readings / min</div>
+    <div class="stat-value text-success">42</div>
+    <div class="stat-desc">last 5 min avg</div>
+  </div>
+</div>
+
+<div class="card bg-base-100 shadow-md mb-6">
+  <div class="card-body p-0">
+    <div class="flex justify-between items-center p-4 border-b border-base-300">
+      <h2 class="text-lg font-semibold">Sensorboard setups</h2>
+    </div>
+    <table class="table">
+      <thead>
+        <tr class="bg-base-200">
+          <th>Device</th>
+          <th>Status</th>
+          <th>Sensors</th>
+          <th>Last Seen</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="hover">
+          <td>
+            <div class="flex flex-col">
+              <span class="font-semibold">leaflab-ccdba79f5fac</span>
+              <span class="text-xs opacity-60">Elegoo ESP32 · v1.2.0</span>
+            </div>
+          </td>
+          <td><span class="badge badge-success badge-sm gap-1"><svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg>Online</span></td>
+          <td>6 sensors</td>
+          <td class="opacity-60">12s ago</td>
+          <td><a href="#/device-detail" class="btn btn-sm btn-primary">View</a></td>
+        </tr>
+        <tr class="hover">
+          <td>
+            <div class="flex flex-col">
+              <span class="font-semibold">leaflab-a1b2c3d4e5f6</span>
+              <span class="text-xs opacity-60">Elegoo ESP32 · v1.2.0</span>
+            </div>
+          </td>
+          <td><span class="badge badge-success badge-sm gap-1"><svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg>Online</span></td>
+          <td>4 sensors</td>
+          <td class="opacity-60">8s ago</td>
+          <td><a href="#/device-detail" class="btn btn-sm btn-primary">View</a></td>
+        </tr>
+        <tr class="hover">
+          <td>
+            <div class="flex flex-col">
+              <span class="font-semibold">leaflab-9f8e7d6c5b4a</span>
+              <span class="text-xs opacity-60">Elegoo ESP32 · v1.1.3</span>
+            </div>
+          </td>
+          <td><span class="badge badge-neutral badge-sm gap-1"><svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l4 4"/></svg>Offline</span></td>
+          <td>4 sensors</td>
+          <td class="opacity-60">3h ago</td>
+          <td><a href="#/device-detail" class="btn btn-sm btn-primary">View</a></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<div class="card bg-base-100 shadow-md">
+  <div class="card-body p-0">
+    <div class="flex justify-between items-center p-4 border-b border-base-300">
+      <h2 class="text-lg font-semibold">Recent readings (last 5 min)</h2>
+      <a href="#/device-detail" class="btn btn-sm btn-primary">All readings</a>
+    </div>
+    <table class="table">
+      <thead>
+        <tr class="bg-base-200">
+          <th>Sensor</th>
+          <th>Type</th>
+          <th>Region</th>
+          <th>Value</th>
+          <th>Time</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr><td class="font-mono">BH1750-A1</td><td>Illuminance</td><td>Room A · Shelf 1</td><td>423 lux</td><td class="opacity-60">2s ago</td></tr>
+        <tr><td class="font-mono">SHT3x-T1</td><td>Temperature</td><td>Room A · Shelf 1</td><td>24.7 C</td><td class="opacity-60">5s ago</td></tr>
+        <tr><td class="font-mono">SHT3x-H1</td><td>Humidity</td><td>Room A · Shelf 1</td><td>62.1 %</td><td class="opacity-60">5s ago</td></tr>
+        <tr><td class="font-mono">BH1750-A2</td><td>Illuminance</td><td>Room B · Shelf 2</td><td>387 lux</td><td class="opacity-60">4s ago</td></tr>
+        <tr><td class="font-mono">SHT3x-T2</td><td>Temperature</td><td>Room B · Shelf 2</td><td>25.3 C</td><td class="opacity-60">7s ago</td></tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<p class="wf-note mt-4">note: real-time readings would need websocket or polling — wireframe shows static snapshot. Config UI TBD.</p>

--- a/leaflab/ui/design/wireframes/screens/02-devices.html
+++ b/leaflab/ui/design/wireframes/screens/02-devices.html
@@ -1,0 +1,57 @@
+<!-- wf: name="devices-list" title="Devices — List (legacy)" -->
+<div class="wf-hero p-6 md:p-8 mb-6 shadow-lg bg-gradient-to-br from-green-900 via-emerald-800 to-teal-900 text-green-50">
+  <h1 class="text-2xl md:text-3xl font-bold mb-2">Devices</h1>
+  <p class="text-sm opacity-80">All sensorboard setups — register, provision, and manage ESP32 nodes</p>
+</div>
+
+<div class="card bg-base-100 shadow-md mb-6">
+  <div class="card-body p-0">
+    <table class="table">
+      <thead><tr class="bg-base-200"><th>Device ID</th><th>Status</th><th>Firmware</th><th>Sensors</th><th>Last Seen</th><th></th></tr></thead>
+      <tbody>
+        <tr class="hover">
+          <td><span class="font-mono text-xs">leaflab-ccdba79f5fac</span></td>
+          <td><span class="badge badge-success badge-sm gap-1"><svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg>Online</span></td>
+          <td class="font-mono text-xs">v1.2.0</td>
+          <td>6 sensors</td>
+          <td class="opacity-60">12s ago</td>
+          <td><a href="#/device-detail" class="btn btn-sm btn-primary">View</a></td>
+        </tr>
+        <tr class="hover">
+          <td><span class="font-mono text-xs">leaflab-a1b2c3d4e5f6</span></td>
+          <td><span class="badge badge-success badge-sm gap-1"><svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg>Online</span></td>
+          <td class="font-mono text-xs">v1.2.0</td>
+          <td>4 sensors</td>
+          <td class="opacity-60">8s ago</td>
+          <td><a href="#/device-detail" class="btn btn-sm btn-primary">View</a></td>
+        </tr>
+        <tr class="hover">
+          <td><span class="font-mono text-xs">leaflab-9f8e7d6c5b4a</span></td>
+          <td><span class="badge badge-neutral badge-sm gap-1"><svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l4 4"/></svg>Offline</span></td>
+          <td class="font-mono text-xs">v1.1.3</td>
+          <td>4 sensors</td>
+          <td class="opacity-60">3h ago</td>
+          <td><a href="#/device-detail" class="btn btn-sm btn-primary">View</a></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<div class="card bg-base-100 shadow-md mb-6">
+  <div class="card-body p-0">
+    <div class="flex justify-between items-center p-4 border-b border-base-300"><h2 class="text-lg font-semibold">Config History</h2></div>
+    <table class="table table-sm">
+      <thead><tr><th>Device</th><th>#</th><th>Sensors enabled / total</th><th>Last applied</th></tr></thead>
+      <tbody>
+        <tr><td class="font-mono text-xs">leaflab-ccdba79f5fac</td><td>#47</td><td>6/6</td><td class="opacity-60">2h ago</td></tr>
+        <tr><td class="font-mono text-xs">leaflab-a1b2c3d4e5f6</td><td>#12</td><td>4/4</td><td class="opacity-60">1d ago</td></tr>
+        <tr><td class="font-mono text-xs">leaflab-9f8e7d6c5b4a</td><td>#3</td><td>2/4</td><td class="opacity-60">3h ago</td></tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<div class="flex gap-2 mt-4"><a href="#/device-edit-config" class="btn btn-primary btn-sm">Edit Config</a><button class="btn btn-secondary btn-sm">Register New Device</button></div>
+
+<p class="wf-note mt-4">note: register new device would open a provision wizard (Wi-Fi + MQTT creds). Config edit links to the per-device config form below.</p>

--- a/leaflab/ui/design/wireframes/screens/03-device-detail.html
+++ b/leaflab/ui/design/wireframes/screens/03-device-detail.html
@@ -1,0 +1,95 @@
+<!-- wf: name="device-detail" title="Device: leaflab-a4cf1234abcd" -->
+<div class="breadcrumbs text-sm mb-4">
+  <ul><li><a href="#/devices">Devices</a></li><li>leaflab-a4cf1234abcd</li></ul>
+</div>
+
+<div class="flex justify-between items-center mb-6">
+  <h1 class="text-2xl md:text-3xl font-bold">leaflab-a4cf1234abcd</h1>
+  <a href="#/device-edit-config" class="btn btn-primary btn-sm">Edit Config</a>
+</div>
+
+<div class="card bg-base-100 shadow-md mb-6">
+  <div class="card-body">
+    <h2 class="card-title text-lg">Device Manifest</h2>
+    <table class="table table-sm">
+      <tbody>
+        <tr><td class="opacity-60 w-48">Status</td><td><span class="badge badge-soft badge-success badge-sm">Online</span></td></tr>
+        <tr><td class="opacity-60">Device ID</td><td class="font-mono text-xs">leaflab-a4cf1234abcd</td></tr>
+        <tr><td class="opacity-60">Board Type</td><td>ESP32-S3 (WROOM)</td></tr>
+        <tr><td class="opacity-60">Firmware</td><td class="font-mono text-xs">v1.4.2+build.876</td></tr>
+        <tr><td class="opacity-60">Last Seen</td><td class="opacity-70 text-sm">now</td></tr>
+        <tr><td class="opacity-60">Region</td><td><a href="#/regions" class="link link-primary">Greenhouse A / Shelf 1 / Pot Row B</a></td></tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<div class="card bg-base-100 shadow-md mb-6">
+  <div class="card-body p-0">
+    <div class="flex justify-between items-center p-4 border-b border-base-300">
+      <h2 class="text-lg font-semibold">Sensor Configurations</h2>
+      <span class="text-sm opacity-60">active via DeviceConfig</span>
+    </div>
+    <table class="table">
+      <thead><tr><th>Sensor ID</th><th>Type</th><th>Name</th><th>Enabled</th><th>Poll Interval</th></tr></thead>
+      <tbody>
+        <tr class="hover"><td class="font-mono text-xs">bh1750-1</td><td>BH1750</td><td>Illuminance</td><td><span class="badge badge-soft badge-success badge-sm">Yes</span></td><td>2000 ms</td></tr>
+        <tr class="hover"><td class="font-mono text-xs">sht3x-temp-1</td><td>SHT3x</td><td>Temp – Pot A</td><td><span class="badge badge-soft badge-success badge-sm">Yes</span></td><td>5000 ms</td></tr>
+        <tr class="hover"><td class="font-mono text-xs">sht3x-hum-1</td><td>SHT3x</td><td>Humidity – Pot A</td><td><span class="badge badge-soft badge-success badge-sm">Yes</span></td><td>5000 ms</td></tr>
+        <tr class="hover"><td class="font-mono text-xs">sht3x-temp-2</td><td>SHT3x</td><td>Temp – Shelf 1</td><td><span class="badge badge-soft badge-success badge-sm">Yes</span></td><td>5000 ms</td></tr>
+        <tr class="hover"><td class="font-mono text-xs">sht3x-hum-2</td><td>SHT3x</td><td>Humidity – Shelf 1</td><td><span class="badge badge-soft badge-warning badge-sm">No</span></td><td>—</td></tr>
+        <tr class="hover"><td class="font-mono text-xs">sht3x-temp-3</td><td>SHT3x</td><td>Temp – Ambient</td><td><span class="badge badge-soft badge-success badge-sm">Yes</span></td><td>10000 ms</td></tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<div class="card bg-base-100 shadow-md mb-6">
+  <div class="card-body p-0">
+    <div class="p-4 border-b border-base-300"><h2 class="text-lg font-semibold">Config History (SCD2)</h2></div>
+    <table class="table table-sm">
+      <thead><tr><th>Version</th><th>Applied</th><th>Sensors enabled</th><th>Changes</th></tr></thead>
+      <tbody>
+        <tr><td class="font-mono text-xs">#5</td><td>2026-07-19 08:34</td><td>4 / 5</td><td>Disabled sht3x-hum-2</td></tr>
+        <tr><td class="font-mono text-xs">#4</td><td>2026-07-15 14:22</td><td>5 / 5</td><td>Poll interval → 2 s (BH1750)</td></tr>
+        <tr><td class="font-mono text-xs">#3</td><td>2026-07-10 09:01</td><td>4 / 5</td><td>Simplified config, removed mock-sensor</td></tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<div class="card bg-base-100 shadow-md mb-6">
+  <div class="card-body p-0">
+    <div class="flex justify-between items-center p-4 border-b border-base-300">
+      <h2 class="text-lg font-semibold">Recent Readings</h2>
+      <a href="#/readings" class="btn btn-sm btn-primary">All readings</a>
+    </div>
+    <table class="table table-sm">
+      <thead><tr><th>Sensor</th><th>Type</th><th>Value</th><th>Timestamp</th></tr></thead>
+      <tbody>
+        <tr><td class="font-mono text-xs">bh1750-1</td><td>BH1750</td><td>423.7 lux</td><td class="opacity-60 text-xs">now</td></tr>
+        <tr><td class="font-mono text-xs">sht3x-temp-1</td><td>SHT3x</td><td>22.4 °C</td><td class="opacity-60 text-xs">now</td></tr>
+        <tr><td class="font-mono text-xs">sht3x-hum-1</td><td>SHT3x</td><td>68.1 %</td><td class="opacity-60 text-xs">now</td></tr>
+        <tr><td class="font-mono text-xs">sht3x-temp-2</td><td>SHT3x</td><td>24.1 °C</td><td class="opacity-60 text-xs">3s ago</td></tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<div class="card bg-base-100 border-2 border-error/40 shadow-md mt-8">
+  <div class="bg-error/10 px-6 py-4 border-b-2 border-error/40 rounded-t-box">
+    <h3 class="text-lg font-semibold text-error">Danger Zone</h3>
+  </div>
+  <div class="card-body gap-3">
+    <div>
+      <h4 class="font-semibold">Delete this device</h4>
+      <p class="text-sm opacity-70 mb-2">Removes the device and all its sensor configs. This cannot be undone.</p>
+      <button class="btn btn-error btn-sm">Delete Device</button>
+    </div>
+    <div>
+      <h4 class="font-semibold">Reset config to defaults</h4>
+      <p class="text-sm opacity-70 mb-2">Reverts all sensor configs to factory defaults for this board.</p>
+      <button class="btn btn-error btn-outline btn-sm">Reset Config</button>
+    </div>
+  </div>
+</div>

--- a/leaflab/ui/design/wireframes/screens/03-device-detail.html
+++ b/leaflab/ui/design/wireframes/screens/03-device-detail.html
@@ -5,7 +5,10 @@
 
 <div class="flex justify-between items-center mb-6">
   <h1 class="text-2xl md:text-3xl font-bold">leaflab-a4cf1234abcd</h1>
-  <a href="#/device-edit-config" class="btn btn-primary btn-sm">Edit Config</a>
+  <div class="flex gap-2">
+    <a href="#/device-detail-v2" class="btn btn-ghost btn-sm">Preview redesign (v2)</a>
+    <a href="#/device-edit-config" class="btn btn-primary btn-sm">Edit Config</a>
+  </div>
 </div>
 
 <div class="card bg-base-100 shadow-md mb-6">

--- a/leaflab/ui/design/wireframes/screens/04-device-edit-config.html
+++ b/leaflab/ui/design/wireframes/screens/04-device-edit-config.html
@@ -1,0 +1,232 @@
+<!-- wf: name="device-edit-config" title="Edit Config — leaflab-ccdba79f5fac" -->
+<div class="breadcrumbs text-sm mb-4">
+  <ul><li><a href="#/devices">Devices</a></li><li><a href="#/device-detail">leaflab-ccdba79f5fac</a></li><li>Edit Config</li></ul>
+</div>
+
+<div class="flex justify-between items-center mb-6">
+  <h1 class="text-2xl md:text-3xl font-bold">Edit Config — leaflab-ccdba79f5fac</h1>
+  <div class="flex gap-2">
+    <a href="#/device-detail" class="btn btn-secondary btn-sm">Cancel</a>
+    <button class="btn btn-primary btn-sm">Push Config #48</button>
+  </div>
+</div>
+
+<div class="card bg-base-100 shadow-md mb-6">
+  <div class="card-body p-0">
+    <div class="flex justify-between items-center p-4 border-b border-base-300"><h2 class="text-lg font-semibold">Sensor Configurations</h2></div>
+
+    <!-- Sensor row: BH1750-A1 -->
+    <div class="p-4 border-b hover:bg-base-50 transition-colors" id="sensor-row-1">
+      <div class="flex flex-col md:flex-row md:items-center justify-between gap-3">
+        <div class="flex items-center gap-3 flex-1">
+          <label class="relative inline-flex items-center cursor-pointer">
+            <input type="checkbox" checked class="peer sr-only">
+            <span class="w-5 h-5 border-2 peer-checked:border-primary peer-checked:bg-primary rounded-[4px] transition-all"></span>
+          </label>
+          <div>
+            <input type="text" value="BH1750-A1" class="font-medium bg-transparent outline-none border-b border-transparent focus:border-primary w-32 text-sm">
+            <span class="text-xs opacity-60 ml-2">BH1750 · Illuminance</span>
+          </div>
+        </div>
+
+        <!-- sensor-name-form -->
+        <div class="flex flex-col gap-1 md:flex-row md:items-center gap-x-4">
+          <label class="inline-flex items-center gap-2 text-sm"><input type="text" value="BH1750-A1" class="bg-transparent border-b border-base-300 focus:border-primary outline-none w-28 py-0.5"></label>
+        </div>
+
+        <!-- sensor-id-form -->
+        <div class="flex flex-col gap-1 md:flex-row md:items-center gap-x-4">
+          <span class="text-sm opacity-60">I2C</span><input type="number" value="98" min="0" max="126" class="bg-transparent border-b border-base-300 focus:border-primary outline-none w-14 py-0.5 text-right font-mono text-xs"><span class="text-xs opacity-60">addr</span>
+        </div>
+
+        <!-- poll-interval-form -->
+        <div class="flex flex-col gap-1 md:flex-row md:items-center gap-x-2">
+          <label class="text-sm opacity-60 w-16 text-right">Poll</label><input type="number" value="2000" step="500" min="250" class="bg-transparent border-b border-base-300 focus:border-primary outline-none w-16 py-0.5 font-mono text-xs"><span class="text-sm opacity-60">ms</span>
+        </div>
+
+        <!-- region-form -->
+        <div class="flex flex-col gap-1 md:flex-row md:items-center gap-x-2">
+          <label class="text-sm opacity-60 w-14 text-right">Region</label><select class="bg-transparent border-b border-base-300 focus:border-primary outline-none py-0.5 pr-4 text-xs"><option>Room A · Shelf 1</option></select>
+        </div>
+
+        <button class="btn btn-sm btn-outline btn-circle md:hidden">...</button>
+      </div>
+    </div>
+
+    <!-- Sensor row: SHT3x-T1 -->
+    <div class="p-4 border-b hover:bg-base-50 transition-colors" id="sensor-row-2">
+      <div class="flex flex-col md:flex-row md:items-center justify-between gap-3">
+        <div class="flex items-center gap-3 flex-1">
+          <label class="relative inline-flex items-center cursor-pointer">
+            <input type="checkbox" checked class="peer sr-only">
+            <span class="w-5 h-5 border-2 peer-checked:border-primary peer-checked:bg-primary rounded-[4px] transition-all"></span>
+          </label>
+          <div>
+            <input type="text" value="SHT3x-T1" class="font-medium bg-transparent outline-none border-b border-transparent focus:border-primary w-28 text-sm">
+            <span class="text-xs opacity-60 ml-2">SHT3x · Temperature</span>
+          </div>
+        </div>
+
+        <div class="flex flex-col gap-1 md:flex-row md:items-center gap-x-4">
+          <label class="inline-flex items-center gap-2 text-sm"><input type="text" value="SHT3x-T1" class="bg-transparent border-b border-base-300 focus:border-primary outline-none w-28 py-0.5"></label>
+        </div>
+
+        <div class="flex flex-col gap-1 md:flex-row md:items-center gap-x-4">
+          <span class="text-sm opacity-60">I2C</span><input type="number" value="68" min="0" max="126" class="bg-transparent border-b border-base-300 focus:border-primary outline-none w-14 py-0.5 text-right font-mono text-xs"><span class="text-xs opacity-60">addr</span>
+        </div>
+
+        <div class="flex flex-col gap-1 md:flex-row md:items-center gap-x-2">
+          <label class="text-sm opacity-60 w-16 text-right">Poll</label><input type="number" value="5000" step="500" min="250" class="bg-transparent border-b border-base-300 focus:border-primary outline-none w-16 py-0.5 font-mono text-xs"><span class="text-sm opacity-60">ms</span>
+        </div>
+
+        <div class="flex flex-col gap-1 md:flex-row md:items-center gap-x-2">
+          <label class="text-sm opacity-60 w-14 text-right">Region</label><select class="bg-transparent border-b border-base-300 focus:border-primary outline-none py-0.5 pr-4 text-xs"><option>Room A · Shelf 1</option></select>
+        </div>
+
+        <button class="btn btn-sm btn-outline btn-circle md:hidden">...</button>
+      </div>
+    </div>
+
+    <!-- Sensor row: SHT3x-H1 (disabled) -->
+    <div class="p-4 border-b hover:bg-base-50 transition-colors opacity-50 bg-base-100" id="sensor-row-3">
+      <div class="flex flex-col md:flex-row md:items-center justify-between gap-3">
+        <div class="flex items-center gap-3 flex-1">
+          <label class="relative inline-flex items-center cursor-pointer">
+            <input type="checkbox" class="peer sr-only">
+            <span class="w-5 h-5 border-2 rounded-[4px] transition-all"></span>
+          </label>
+          <div>
+            <input type="text" value="SHT3x-H1" class="font-medium bg-transparent outline-none border-b border-transparent focus:border-primary w-28 text-sm">
+            <span class="text-xs opacity-60 ml-2">SHT3x · Humidity</span>
+          </div>
+        </div>
+
+        <div class="flex flex-col gap-1 md:flex-row md:items-center gap-x-4">
+          <label class="inline-flex items-center gap-2 text-sm"><input type="text" value="SHT3x-H1" class="bg-transparent border-b border-base-300 focus:border-primary outline-none w-28 py-0.5"></label>
+        </div>
+
+        <div class="flex flex-col gap-1 md:flex-row md:items-center gap-x-4">
+          <span class="text-sm opacity-60">I2C</span><input type="number" value="68" min="0" max="126" class="bg-transparent border-b border-base-300 focus:border-primary outline-none w-14 py-0.5 text-right font-mono text-xs"><span class="text-xs opacity-60">addr</span>
+        </div>
+
+        <div class="flex flex-col gap-1 md:flex-row md:items-center gap-x-2"></div>
+
+        <div class="flex flex-col gap-1 md:flex-row md:items-center gap-x-2">
+          <label class="text-sm opacity-60 w-14 text-right">Region</label><select class="bg-transparent border-b border-base-300 focus:border-primary outline-none py-0.5 pr-4 text-xs"><option>Room A · Shelf 1</option></select>
+        </div>
+
+        <button class="btn btn-sm btn-outline btn-circle md:hidden">...</button>
+      </div>
+    </div>
+
+    <!-- Sensor row: BH1750-A2 -->
+    <div class="p-4 border-b hover:bg-base-50 transition-colors" id="sensor-row-4">
+      <div class="flex flex-col md:flex-row md:items-center justify-between gap-3">
+        <div class="flex items-center gap-3 flex-1">
+          <label class="relative inline-flex items-center cursor-pointer">
+            <input type="checkbox" checked class="peer sr-only">
+            <span class="w-5 h-5 border-2 peer-checked:border-primary peer-checked:bg-primary rounded-[4px] transition-all"></span>
+          </label>
+          <div>
+            <input type="text" value="BH1750-A2" class="font-medium bg-transparent outline-none border-b border-transparent focus:border-primary w-32 text-sm">
+            <span class="text-xs opacity-60 ml-2">BH1750 · Illuminance</span>
+          </div>
+        </div>
+
+        <div class="flex flex-col gap-1 md:flex-row md:items-center gap-x-4">
+          <label class="inline-flex items-center gap-2 text-sm"><input type="text" value="BH1750-A2" class="bg-transparent border-b border-base-300 focus:border-primary outline-none w-28 py-0.5"></label>
+        </div>
+
+        <div class="flex flex-col gap-1 md:flex-row md:items-center gap-x-4">
+          <span class="text-sm opacity-60">I2C</span><input type="number" value="98" min="0" max="126" class="bg-transparent border-b border-base-300 focus:border-primary outline-none w-14 py-0.5 text-right font-mono text-xs"><span class="text-xs opacity-60">addr</span>
+        </div>
+
+        <div class="flex flex-col gap-1 md:flex-row md:items-center gap-x-2">
+          <label class="text-sm opacity-60 w-16 text-right">Poll</label><input type="number" value="2000" step="500" min="250" class="bg-transparent border-b border-base-300 focus:border-primary outline-none w-16 py-0.5 font-mono text-xs"><span class="text-sm opacity-60">ms</span>
+        </div>
+
+        <div class="flex flex-col gap-1 md:flex-row md:items-center gap-x-2">
+          <label class="text-sm opacity-60 w-14 text-right">Region</label><select class="bg-transparent border-b border-base-300 focus:border-primary outline-none py-0.5 pr-4 text-xs"><option>Room B · Shelf 2</option></select>
+        </div>
+
+        <button class="btn btn-sm btn-outline btn-circle md:hidden">...</button>
+      </div>
+    </div>
+
+    <!-- Sensor row: SHT3x-T2 -->
+    <div class="p-4 border-b hover:bg-base-50 transition-colors" id="sensor-row-5">
+      <div class="flex flex-col md:flex-row md:items-center justify-between gap-3">
+        <div class="flex items-center gap-3 flex-1">
+          <label class="relative inline-flex items-center cursor-pointer">
+            <input type="checkbox" checked class="peer sr-only">
+            <span class="w-5 h-5 border-2 peer-checked:border-primary peer-checked:bg-primary rounded-[4px] transition-all"></span>
+          </label>
+          <div>
+            <input type="text" value="SHT3x-T2" class="font-medium bg-transparent outline-none border-b border-transparent focus:border-primary w-32 text-sm">
+            <span class="text-xs opacity-60 ml-2">SHT3x · Temperature</span>
+          </div>
+        </div>
+
+        <div class="flex flex-col gap-1 md:flex-row md:items-center gap-x-4">
+          <label class="inline-flex items-center gap-2 text-sm"><input type="text" value="SHT3x-T2" class="bg-transparent border-b border-base-300 focus:border-primary outline-none w-28 py-0.5"></label>
+        </div>
+
+        <div class="flex flex-col gap-1 md:flex-row md:items-center gap-x-4">
+          <span class="text-sm opacity-60">I2C</span><input type="number" value="68" min="0" max="126" class="bg-transparent border-b border-base-300 focus:border-primary outline-none w-14 py-0.5 text-right font-mono text-xs"><span class="text-xs opacity-60">addr</span>
+        </div>
+
+        <div class="flex flex-col gap-1 md:flex-row md:items-center gap-x-2">
+          <label class="text-sm opacity-60 w-16 text-right">Poll</label><input type="number" value="5000" step="500" min="250" class="bg-transparent border-b border-base-300 focus:border-primary outline-none w-16 py-0.5 font-mono text-xs"><span class="text-sm opacity-60">ms</span>
+        </div>
+
+        <div class="flex flex-col gap-1 md:flex-row md:items-center gap-x-2">
+          <label class="text-sm opacity-60 w-14 text-right">Region</label><select class="bg-transparent border-b border-base-300 focus:border-primary outline-none py-0.5 pr-4 text-xs"><option>Room B · Shelf 2</option></select>
+        </div>
+
+        <button class="btn btn-sm btn-outline btn-circle md:hidden">...</button>
+      </div>
+    </div>
+
+    <!-- Sensor row: SHT3x-H2 -->
+    <div class="p-4 hover:bg-base-50 transition-colors" id="sensor-row-6">
+      <div class="flex flex-col md:flex-row md:items-center justify-between gap-3">
+        <div class="flex items-center gap-3 flex-1">
+          <label class="relative inline-flex items-center cursor-pointer">
+            <input type="checkbox" checked class="peer sr-only">
+            <span class="w-5 h-5 border-2 peer-checked:border-primary peer-checked:bg-primary rounded-[4px] transition-all"></span>
+          </label>
+          <div>
+            <input type="text" value="SHT3x-H2" class="font-medium bg-transparent outline-none border-b border-transparent focus:border-primary w-32 text-sm">
+            <span class="text-xs opacity-60 ml-2">SHT3x · Humidity</span>
+          </div>
+        </div>
+
+        <div class="flex flex-col gap-1 md:flex-row md:items-center gap-x-4">
+          <label class="inline-flex items-center gap-2 text-sm"><input type="text" value="SHT3x-H2" class="bg-transparent border-b border-base-300 focus:border-primary outline-none w-28 py-0.5"></label>
+        </div>
+
+        <div class="flex flex-col gap-1 md:flex-row md:items-center gap-x-4">
+          <span class="text-sm opacity-60">I2C</span><input type="number" value="68" min="0" max="126" class="bg-transparent border-b border-base-300 focus:border-primary outline-none w-14 py-0.5 text-right font-mono text-xs"><span class="text-xs opacity-60">addr</span>
+        </div>
+
+        <div class="flex flex-col gap-1 md:flex-row md:items-center gap-x-2">
+          <label class="text-sm opacity-60 w-16 text-right">Poll</label><input type="number" value="5000" step="500" min="250" class="bg-transparent border-b border-base-300 focus:border-primary outline-none w-16 py-0.5 font-mono text-xs"><span class="text-sm opacity-60">ms</span>
+        </div>
+
+        <div class="flex flex-col gap-1 md:flex-row md:items-center gap-x-2">
+          <label class="text-sm opacity-60 w-14 text-right">Region</label><select class="bg-transparent border-b border-base-300 focus:border-primary outline-none py-0.5 pr-4 text-xs"><option>Room B · Shelf 2</option></select>
+        </div>
+
+        <button class="btn btn-sm btn-outline btn-circle md:hidden">...</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="flex gap-2 mt-4">
+  <button class="btn btn-secondary btn-sm">Add Sensor (from manifest)</button>
+  <a href="#/device-detail" class="btn btn-secondary btn-sm">Cancel</a>
+  <button class="btn btn-primary btn-sm">Push Config #48</button>
+</div>
+
+<p class="wf-note mt-4">note: toggling a checkbox off should disable the sensor on device (config_applier destroys it). "Add Sensor" would list sensors from the device manifest not yet in config. Poll interval disabled when row is unchecked.</p>

--- a/leaflab/ui/design/wireframes/screens/05-regions.html
+++ b/leaflab/ui/design/wireframes/screens/05-regions.html
@@ -1,0 +1,73 @@
+<!-- wf: name="regions" title="Regions" -->
+<div class="wf-hero p-6 md:p-8 mb-6 shadow-lg bg-gradient-to-br from-green-900 via-emerald-800 to-teal-900 text-green-50">
+  <h1 class="text-2xl md:text-3xl font-bold mb-2">Regions</h1>
+  <p class="text-sm opacity-80">Hierarchical region definitions — physical placements for sensors</p>
+</div>
+
+<div class="card bg-base-100 shadow-md mb-6">
+  <div class="card-body p-0">
+    <div class="flex justify-between items-center p-4 border-b border-base-300"><h2 class="text-lg font-semibold">Region Tree</h2><button class="btn btn-primary btn-sm">New Region</button></div>
+
+    <!-- Parent: Room A -->
+    <table class="table table-sm">
+      <thead><tr><th>Name</th><th>Description</th><th>Children</th><th>Sensors Here</th></tr></thead>
+      <tbody>
+        <tr class="hover"><td colspan="4" class="p-0">
+          <!-- Expandable row: Room A -->
+          <div>
+            <table class="w-full">
+              <tr class="hover cursor-pointer" onclick="location.href='#/region-edit'">
+                <td class="font-medium"><svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 inline mr-1 opacity-60" viewBox="0 0 20 20" fill="currentColor"><path d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"/></svg>Room A</td>
+                <td class="opacity-60">Main greenhouse section</td><td>2 children</td><td>6 sensors</td>
+              </tr>
+              <!-- Children of Room A -->
+              <tr class="hover cursor-pointer" onclick="location.href='#/region-edit'"><td class="pl-8">&nbsp;&nbsp;Shelf 1</td><td class="opacity-60">Top shelf by window</td><td>—</td><td>4 sensors</td></tr>
+              <tr class="hover cursor-pointer" onclick="location.href='#/region-edit'"><td class="pl-8">&nbsp;&nbsp;Shelf 2</td><td class="opacity-60">Middle shelf, ambient</td><td>—</td><td>2 sensors</td></tr>
+            </table>
+          </div>
+        </td></tr>
+
+        <!-- Parent: Room B -->
+        <tr class="hover"><td colspan="4" class="p-0">
+          <div>
+            <table class="w-full">
+              <tr class="hover cursor-pointer" onclick="location.href='#/region-edit'">
+                <td class="font-medium"><svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 inline mr-1 opacity-60" viewBox="0 0 20 20" fill="currentColor"><path d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"/></svg>Room B</td>
+                <td class="opacity-60">Secondary greenhouse section</td><td>2 children</td><td>4 sensors</td>
+              </tr>
+              <tr class="hover cursor-pointer" onclick="location.href='#/region-edit'"><td class="pl-8">&nbsp;&nbsp;Shelf 1</td><td class="opacity-60">Near door, variable temp</td><td>—</td><td>2 sensors</td></tr>
+              <tr class="hover cursor-pointer" onclick="location.href='#/region-edit'"><td class="pl-8">&nbsp;&nbsp;Shelf 2</td><td class="opacity-60">Away from window</td><td>—</td><td>2 sensors</td></tr>
+            </table>
+          </div>
+        </td></tr>
+
+        <!-- Parent: Potting Area -->
+        <tr class="hover"><td colspan="4" class="p-0">
+          <div>
+            <table class="w-full">
+              <tr class="hover cursor-pointer" onclick="location.href='#/region-edit'">
+                <td class="font-medium"><svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 inline mr-1 opacity-60" viewBox="0 0 20 20" fill="currentColor"><path d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"/></svg>Potting Area</td>
+                <td class="opacity-60">Covered potting station</td><td>—</td><td>4 sensors</td>
+              </tr>
+            </table>
+          </div>
+        </td></tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<div class="card bg-base-100 shadow-md mb-6">
+  <div class="card-body p-0">
+    <div class="flex justify-between items-center p-4 border-b border-base-300"><h2 class="text-lg font-semibold">Region Rules</h2></div>
+    <table class="table table-sm">
+      <thead><tr><th>Rule</th><th>Value</th></tr></thead>
+      <tbody>
+        <tr><td class="opacity-60">Max children per parent</td><td>12</td></tr>
+        <tr><td class="opacity-60">Min region depth</td><td>3 levels (e.g. Room → Shelf → Pot)</td></tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<p class="wf-note mt-4">note: expanding/collapsing tree rows needs JS — wireframe uses onclick for now. Region edit screen shows a form with parent selector, name, description.</p>

--- a/leaflab/ui/design/wireframes/screens/06-region-edit.html
+++ b/leaflab/ui/design/wireframes/screens/06-region-edit.html
@@ -1,0 +1,41 @@
+<!-- wf: name="region-edit" title="Edit Region — Room A" -->
+<div class="breadcrumbs text-sm mb-4">
+  <ul><li><a href="#/regions">Regions</a></li><li>Room A</li></ul>
+</div>
+
+<div class="flex justify-between items-center mb-6">
+  <h1 class="text-2xl md:text-3xl font-bold">Edit Region — Room A</h1>
+  <div class="flex gap-2"><a href="#/regions" class="btn btn-secondary btn-sm">Cancel</a><button class="btn btn-primary btn-sm">Save Changes</button></div>
+</div>
+
+<div class="card bg-base-100 shadow-md mb-6">
+  <div class="card-body p-0">
+    <table class="table table-sm p-4 gap-y-2">
+      <tr><td class="opacity-60 w-32 py-2">Name</td></tr>
+      <tr><td class="py-1"><input type="text" value="Room A" class="border-b border-base-300 focus:border-primary outline-none w-full py-1"></td></tr>
+
+      <tr><td class="opacity-60 w-32 pt-4 pb-2">Description</td></tr>
+      <tr><td class="py-1"><textarea rows="2" class="border-b border-base-300 focus:border-primary outline-none w-full py-1 text-sm">Main greenhouse section, north-facing. Covers the eastern and central growing beds.</textarea></td></tr>
+
+      <tr><td class="opacity-60 w-32 pt-4 pb-2">Parent Region</td></tr>
+      <tr><td class="py-1"><select class="border-b border-base-300 focus:border-primary outline-none w-full py-1 text-sm"><option>(none) — top-level region</option></select></td></tr>
+
+      <tr><td class="opacity-60 w-32 pt-4 pb-2">Children (drag to reorder)</td></tr>
+      <tr><td class="py-2">
+        <ul class="list-none space-y-1 text-sm pl-2 border-l-2 border-base-200 ml-3">
+          <li class="pl-2 flex items-center gap-2 hover:bg-base-50"><svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 opacity-40 cursor-grab" viewBox="0 0 20 20" fill="currentColor">•••</svg><span>Shelf 1 — Top shelf by window</span></li>
+          <li class="pl-2 flex items-center gap-2 hover:bg-base-50"><svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 opacity-40 cursor-grab" viewBox="0 0 20 20" fill="currentColor">•••</svg><span>Shelf 2 — Middle shelf, ambient</span></li>
+        </ul>
+      </td></tr>
+
+      <tr><td class="opacity-60 w-32 pt-4 pb-2">Sensors in this region and children</td></tr>
+      <tr><td class="py-1 opacity-70 text-sm">6 sensors across 2 sub-regions (see details below)</td></tr>
+
+      <tr><td class="opacity-60 w-32 pt-4 pb-2">Sensors in this region only</td></tr>
+      <tr><td class="py-1 opacity-70 text-sm">0 sensors — all are assigned to sub-regions</td></tr>
+
+    </table>
+  </div>
+</div>
+
+<p class="wf-note mt-4">note: dragging children requires JS. Save should validate no cycle in parent chain.</p>

--- a/leaflab/ui/design/wireframes/screens/07-readings.html
+++ b/leaflab/ui/design/wireframes/screens/07-readings.html
@@ -1,0 +1,60 @@
+<!-- wf: name="readings" title="Sensor Readings" -->
+<div class="wf-hero p-6 md:p-8 mb-6 shadow-lg bg-gradient-to-br from-green-900 via-emerald-800 to-teal-900 text-green-50">
+  <h1 class="text-2xl md:text-3xl font-bold mb-2">Sensor Readings</h1>
+  <p class="text-sm opacity-80">Time-series data from all sensorboards — view latest values and historical trends</p>
+</div>
+
+<div class="flex flex-col md:flex-row gap-4 mb-6">
+  <!-- Filter bar -->
+  <div class="card bg-base-100 shadow-md flex-1">
+    <div class="card-body p-4 gap-3">
+      <h2 class="text-sm font-semibold opacity-60 uppercase tracking-wide">Filters</h2>
+      <div class="flex flex-col md:flex-row gap-3">
+        <!-- device selector -->
+        <select class="border-b border-base-300 focus:border-primary outline-none py-1 px-2 text-sm bg-transparent"><option>All devices (3)</option><option>leaflab-ccdba79f5fac</option><option>leaflab-a1b2c3d4e5f6</option><option>leaflab-9f8e7d6c5b4a (offline)</option></select>
+        <!-- sensor type -->
+        <select class="border-b border-base-300 focus:border-primary outline-none py-1 px-2 text-sm bg-transparent"><option>All types</option><option>BH1750 · Illuminance</option><option>SHT3x · Temperature</option><option>SHT3x · Humidity</option></select>
+        <!-- sensor name -->
+        <input type="text" placeholder="Sensor name…" class="border-b border-base-300 focus:border-primary outline-none py-1 px-2 text-sm bg-transparent w-full md:w-auto">
+      </div>
+    </div>
+  </div>
+
+  <!-- Time range -->
+  <div class="card bg-base-100 shadow-md md:w-56 shrink-0">
+    <div class="card-body p-4 gap-2">
+      <h2 class="text-sm font-semibold opacity-60 uppercase tracking-wide">Time Range</h2>
+      <select class="border-b border-base-300 focus:border-primary outline-none py-1 px-2 text-sm bg-transparent w-full"><option>Last 5 minutes</option><option>Last 30 minutes</option><option>Last hour</option><option>Last day</option><option>Custom range…</option></select>
+    </div>
+  </div>
+</div>
+
+<div class="card bg-base-100 shadow-md mb-6">
+  <div class="card-body p-4 gap-2">
+    <!-- Placeholder chart area -->
+    <div class="border-2 border-dashed border-base-300 rounded-box h-64 flex items-center justify-center text-sm opacity-50">
+      <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8 mr-2 inline opacity-60" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6m4 0l4-4m0 0l4 4m-4-4V3"/></svg>
+      Interactive chart — time-series line graph (lux / °C / %) with zoom &amp; cross-hair
+    </div>
+
+    <!-- Legend -->
+    <div class="flex flex-wrap gap-3 mt-2 pt-2 border-t border-base-200">
+      <span class="badge badge-sm bg-teal-500 text-white">● Illuminance (BH1750-A1)</span>
+      <span class="badge badge-sm bg-blue-400 text-white">● Temperature SHT3x-T1</span>
+      <span class="badge badge-sm bg-cyan-400 text-white">● Humidity SHT3x-H1</span>
+    </div>
+
+    <!-- Data table -->
+    <table class="table mt-6">
+      <thead><tr><th>Sensor</th><th>Type</th><th>Region</th><th>Lux</th><th>°C</th><th>% RH</th><th>Last Updated</th></tr></thead>
+      <tbody>
+        <tr class="hover"><td class="font-mono text-xs">BH1750-A1</td><td>Illuminance</td><td><a href="#/region-edit" class="link link-primary text-xs">Room A · Shelf 1</a></td><td>423 lux</td><td>24.7 °C</td><td>62.1 %</td><td class="opacity-60 text-xs">now</td></tr>
+        <tr class="hover"><td class="font-mono text-xs">BH1750-A2</td><td>Illuminance</td><td><a href="#/region-edit" class="link link-primary text-xs">Room B · Shelf 2</a></td><td>387 lux</td><td>25.3 °C</td><td>58.9 %</td><td class="opacity-60 text-xs">now</td></tr>
+        <tr class="hover"><td class="font-mono text-xs">SHT3x-T2</td><td>Temperature</td><td><a href="#/region-edit" class="link link-primary text-xs">Room B · Shelf 2</a></td><td>—</td><td>25.3 °C</td><td>58.9 %</td><td class="opacity-60 text-xs">now</td></tr>
+        <tr class="hover"><td class="font-mono text-xs">SHT3x-H1</td><td>Humidity</td><td><a href="#/region-edit" class="link link-primary text-xs">Room A · Shelf 1</a></td><td>—</td><td>24.7 °C</td><td>62.1 %</td><td class="opacity-60 text-xs">now</td></tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<p class="wf-note mt-4">note: chart needs JS + canvas/SVG library — wireframe shows placeholder. Chart would support toggling sensor lines, zooming time range, and hovering for exact values.</p>

--- a/leaflab/ui/design/wireframes/screens/08-admin-dashboard.html
+++ b/leaflab/ui/design/wireframes/screens/08-admin-dashboard.html
@@ -1,0 +1,120 @@
+<!-- wf: name="admin-dashboard" title="Admin Dashboard — Fleet Management" -->
+
+<div class="wf-hero p-6 md:p-8 mb-6 shadow-lg bg-gradient-to-br from-green-900 via-emerald-800 to-teal-900 text-green-50">
+  <h1 class="text-2xl md:text-3xl font-bold mb-2">LeafLab — Fleet Management</h1>
+  <p class="text-sm opacity-80">Admin overview of all sensorboard setups, devices, and alerts</p>
+</div>
+
+<!-- Quick actions bar (admin only) -->
+<div class="flex flex-wrap gap-2 mb-6">
+  <button class="btn btn-primary btn-sm">+ Register Device</button>
+  <button class="btn btn-secondary btn-sm">Push Config to All</button>
+  <a href="#/device-edit-config" class="btn btn-info btn-sm">Config History</a>
+  <button class="btn btn-outline btn-sm">Export Readings CSV</button>
+</div>
+
+<!-- Fleet health -->
+<div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
+  <div class="stat bg-base-100 rounded-box shadow-md">
+    <div class="stat-title">Devices</div>
+    <div class="stat-value text-primary">3</div>
+    <div class="stat-desc">2 online · 1 offline</div>
+  </div>
+  <div class="stat bg-base-100 rounded-box shadow-md">
+    <div class="stat-title">Sensors</div>
+    <div class="stat-value">14</div>
+    <div class="stat-desc">12 active · 2 disabled</div>
+  </div>
+  <div class="stat bg-base-100 rounded-box shadow-md">
+    <div class="stat-title">Regions</div>
+    <div class="stat-value">4</div>
+    <div class="stat-desc">3 rooms · 1 potting area</div>
+  </div>
+  <!-- Alerts: admin-only stat -->
+  <div class="stat bg-base-100 rounded-box shadow-md border-error/30">
+    <div class="stat-title">Alerts</div>
+    <div class="stat-value text-error">2</div>
+    <div class="stat-desc">leaflab-9f8e... offline · BH1750-A1 invalid reading</div>
+  </div>
+</div>
+
+<!-- Alerts panel (admin only) -->
+<div class="card bg-base-100 shadow-md mb-6 border-error/20">
+  <div class="card-body p-0">
+    <h2 class="text-lg font-semibold p-4 border-b border-base-300 text-error flex items-center gap-2">
+      <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 0l4 4m-4-4l-4 4M8.56 13a5 5 0 01-.775.058l-.074.01A5.72 5.72 0 019.5 21a5.72 5.72 0 01-4.136-1.625H5A5.007 5.007 0 010 14.375v-.75C0 12.586.9 11.7 1.99 11.7h.02c.89 0 1.67-.52 2.09-1.28l.64-1.03a1.32 1.32 0 012.16 0l.64 1.03c.42.76 1.2 1.28 2.09 1.28H12.5 14.375A5.007 5.007 0 019.375 20h-.75C8.16 20 7.5 19.25 7.5 18.5a5.72 5.72 0 014.44-2.625c.033-.002.065-.005.097-.005a5 5 0 01.775.058l.074.01A5.72 5.72 0 0112.5 21a5.72 5.72 0 01-3.94-1.575"/></svg>
+      Active Alerts
+    </h2>
+    <table class="table table-sm">
+      <thead><tr><th>Severity</th><th>Device</th><th>Message</th><th>Since</th></tr></thead>
+      <tbody>
+        <tr class="hover"><td><span class="badge badge-error badge-sm">Critical</span></td><td class="font-mono text-xs">leaflab-9f8e7d6c5b4a</td><td>Device offline — last heartbeat 3h ago</td><td class="opacity-60">3h ago</td></tr>
+        <tr class="hover"><td><span class="badge badge-warning badge-sm">Warning</span></td><td class="font-mono text-xs">leaflab-ccdba79f5fac</td><td>BH1750-A1 reported invalid reading (out of range)</td><td class="opacity-60">42m ago</td></tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<!-- Devices table (admin: full controls) -->
+<div class="card bg-base-100 shadow-md mb-6">
+  <div class="card-body p-0">
+    <h2 class="text-lg font-semibold p-4 border-b border-base-300">Devices</h2>
+    <table class="table">
+      <thead><tr class="bg-base-200"><th>Device ID</th><th>Status</th><th>Firmware</th><th>Sensors</th><th>Last Seen</th><th>Actions</th></tr></thead>
+      <tbody>
+        <tr class="hover">
+          <td><span class="font-mono text-xs">leaflab-ccdba79f5fac</span></td>
+          <td><span class="badge badge-success badge-sm gap-1"><svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg>Online</span></td>
+          <td class="font-mono text-xs">v1.2.0</td><td>6 sensors</td><td class="opacity-60">12s ago</td>
+          <td>
+            <div class="flex gap-1">
+              <a href="#/device-detail" class="btn btn-sm btn-primary">View</a>
+              <a href="#/device-edit-config" class="btn btn-sm btn-secondary">Edit Config</a>
+              <button class="btn btn-xs btn-outline">Reboot</button>
+            </div>
+          </td>
+        </tr>
+        <tr class="hover">
+          <td><span class="font-mono text-xs">leaflab-a1b2c3d4e5f6</span></td>
+          <td><span class="badge badge-success badge-sm gap-1"><svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg>Online</span></td>
+          <td class="font-mono text-xs">v1.2.0</td><td>4 sensors</td><td class="opacity-60">8s ago</td>
+          <td>
+            <div class="flex gap-1">
+              <a href="#/device-detail" class="btn btn-sm btn-primary">View</a>
+              <a href="#/device-edit-config" class="btn btn-sm btn-secondary">Edit Config</a>
+              <button class="btn btn-xs btn-outline">Reboot</button>
+            </div>
+          </td>
+        </tr>
+        <tr class="hover">
+          <td><span class="font-mono text-xs">leaflab-9f8e7d6c5b4a</span></td>
+          <td><span class="badge badge-neutral badge-sm gap-1"><svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l4 4"/></svg>Offline</span></td>
+          <td class="font-mono text-xs">v1.1.3</td><td>4 sensors</td><td class="opacity-60">3h ago</td>
+          <td>
+            <div class="flex gap-1 opacity-50">
+              <a href="#/device-detail" class="btn btn-sm btn-primary">View</a>
+              <span class="text-xs opacity-40 ml-1">Offline — controls disabled</span>
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<!-- Config history (admin only) -->
+<div class="card bg-base-100 shadow-md mb-6">
+  <div class="card-body p-0">
+    <h2 class="text-lg font-semibold p-4 border-b border-base-300">Config History</h2>
+    <table class="table table-sm">
+      <thead><tr><th>Device</th><th>#</th><th>Sensors enabled / total</th><th>Last applied</th></tr></thead>
+      <tbody>
+        <tr><td class="font-mono text-xs">leaflab-ccdba79f5fac</td><td>#47</td><td>6/6</td><td class="opacity-60">2h ago</td></tr>
+        <tr><td class="font-mono text-xs">leaflab-a1b2c3d4e5f6</td><td>#12</td><td>4/4</td><td class="opacity-60">1d ago</td></tr>
+        <tr><td class="font-mono text-xs">leaflab-9f8e7d6c5b4a</td><td>#3</td><td>2/4</td><td class="opacity-60">3h ago</td></tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<p class="wf-note mt-4">note: this is the admin-only dashboard. Regular users see a trimmed version (fewer stats, no reboot/config-push buttons). Gawkers never see this page at all.</p>

--- a/leaflab/ui/design/wireframes/screens/09-sensor-detail.html
+++ b/leaflab/ui/design/wireframes/screens/09-sensor-detail.html
@@ -1,0 +1,95 @@
+<!-- wf: name="sensor-detail" title="Sensor — BH1750-A1" -->
+
+<div class="breadcrumbs text-sm mb-4">
+  <ul><li><a href="#/device-edit-config">Edit Config</a></li><li>BH1750-A1</li></ul>
+</div>
+
+<div class="flex justify-between items-center mb-6">
+  <h1 class="text-2xl md:text-3xl font-bold">BH1750-A1 — Illuminance Sensor</h1>
+  <a href="#/device-edit-config" class="btn btn-secondary btn-sm">Back to Config</a>
+</div>
+
+<div class="grid md:grid-cols-2 gap-6 mb-6">
+  <!-- Current state card -->
+  <div class="card bg-base-100 shadow-md">
+    <div class="card-body p-4">
+      <h2 class="text-lg font-semibold mb-3 border-b border-base-300 pb-1">Current State</h2>
+      <table class="table table-sm">
+        <tbody>
+          <tr><td class="opacity-60 w-32">Status</td><td><span class="badge badge-success badge-sm gap-1"><svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg>Active</span></td></tr>
+          <tr><td class="opacity-60">Sensor ID</td><td class="font-mono text-xs">bh1750-1</td></tr>
+          <tr><td class="opacity-60">I2C Address</td><td class="font-mono">0x68 (98)</td></tr>
+          <tr><td class="opacity-60">Polling Interval</td><td class="font-mono">2000 ms</td></tr>
+          <tr><td class="opacity-60">Region</td><td><a href="#/region-edit" class="link link-primary text-sm">Room A · Shelf 1</a></td></tr>
+          <tr><td class="opacity-60">Latest Value</td><td class="text-lg font-semibold"><span class="text-teal-600">423</span> <span class="text-xs opacity-60">lux</span></td></tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <!-- Latest reading -->
+  <div class="card bg-base-100 shadow-md">
+    <div class="card-body p-4">
+      <h2 class="text-lg font-semibold mb-3 border-b border-base-300 pb-1">Latest Reading</h2>
+      <table class="table table-sm">
+        <tbody>
+          <tr><td class="opacity-60 w-32">Recorded at</td><td class="opacity-70 text-sm">2026-07-19 14:32:18 UTC</td></tr>
+          <tr><td class="opacity-60">Value</td><td class="font-mono font-semibold text-teal-600">423 lux (valid)</td></tr>
+          <tr><td class="opacity-60">Uptime at reading</td><td class="font-mono text-xs">14h 23m</td></tr>
+        </tbody>
+      </table>
+
+      <!-- Quick chart placeholder -->
+      <div class="border-2 border-dashed border-base-300 rounded-box h-36 mt-3 flex items-center justify-center text-sm opacity-50">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 mr-2 inline opacity-60" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6m4 0l4-4m0 0l4 4m-4-4V3"/></svg>
+        Mini sparkline — last hour trend
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Name change history (SCD2) -->
+<div class="card bg-base-100 shadow-md mb-6">
+  <div class="card-body p-0">
+    <h2 class="text-lg font-semibold p-4 border-b border-base-300">Name History</h2>
+    <table class="table table-sm">
+      <thead><tr><th>Name</th><th>Valid From</th><th>Valid To</th><th>Note</th></tr></thead>
+      <tbody>
+        <tr class="bg-base-100/50"><td class="font-medium font-mono">BH1750-A1</td><td>2026-07-01 09:00</td><td class="opacity-60">— (current)</td><td>Initial name after register</td></tr>
+        <tr><td class="font-mono opacity-50">sensor-bh1750-2</td><td>2026-03-15 14:22</td><td class="opacity-60">2026-07-01 09:00</td><td>Auto-generated on provision</td></tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<!-- I2C / wiring history (SCD2) -->
+<div class="card bg-base-100 shadow-md mb-6">
+  <div class="card-body p-0">
+    <h2 class="text-lg font-semibold p-4 border-b border-base-300">Wiring History</h2>
+    <table class="table table-sm">
+      <thead><tr><th>I2C Address</th><th>Mux Path</th><th>Valid From</th><th>Valid To</th></tr></thead>
+      <tbody>
+        <tr class="bg-base-100/50"><td class="font-mono">0x68 (98)</td><td class="font-mono text-xs">[] (direct bus)</td><td>2026-07-01 09:00</td><td class="opacity-60">— (current)</td></tr>
+        <tr><td class="font-mono opacity-50">0x68 (98)</td><td class="font-mono text-xs">[{"muxAddress":112,"muxChannel":3}]</td><td>2026-04-20 11:00</td><td class="opacity-60">2026-07-01 09:00</td></tr>
+        <tr><td class="font-mono opacity-50">0x3C (60)</td><td class="font-mono text-xs">[] (direct bus)</td><td>2026-03-15 14:22</td><td class="opacity-60">2026-04-20 11:00</td></tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<!-- Region history (SCD2) -->
+<div class="card bg-base-100 shadow-md mb-6">
+  <div class="card-body p-0">
+    <h2 class="text-lg font-semibold p-4 border-b border-base-300">Location History</h2>
+    <table class="table table-sm">
+      <thead><tr><th>Region</th><th>Valid From</th><th>Valid To</th></tr></thead>
+      <tbody>
+        <tr class="bg-base-100/50"><td><a href="#/region-edit" class="link link-primary text-sm">Room A · Shelf 1</a></td><td>2026-07-01 09:00</td><td class="opacity-60">— (current)</td></tr>
+        <tr><td><a href="#/region-edit" class="link link-primary text-sm opacity-50">Room A · Shelf 2</a></td><td>2026-04-20 11:00</td><td class="opacity-60">2026-07-01 09:00</td></tr>
+        <tr><td><a href="#/region-edit" class="link link-primary text-sm opacity-50">Potting Area · Bench</a></td><td>2026-03-15 14:22</td><td class="opacity-60">2026-04-20 11:00</td></tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<p class="wf-note mt-4">note: this screen combines name/wiring/region SCD2 timelines into one view. Each timeline is independently editable — moving a sensor to a new shelf doesn't affect its I2C address or logical name.</p>

--- a/leaflab/ui/design/wireframes/screens/10-device-detail.html
+++ b/leaflab/ui/design/wireframes/screens/10-device-detail.html
@@ -1,0 +1,148 @@
+<!-- wf: name="device-detail" title="Device: leaflab-ccdba79f5fac" -->
+<div class="breadcrumbs text-sm mb-4">
+  <ul>
+    <li><a href="#/dashboard">Dashboard</a></li>
+    <li>leaflab-ccdba79f5fac</li>
+  </ul>
+</div>
+
+<div class="flex flex-col md:flex-row justify-between md:items-center gap-3 mb-6">
+  <div class="flex items-center gap-3">
+    <h1 class="text-2xl md:text-3xl font-bold">leaflab-ccdba79f5fac</h1>
+    <span class="badge badge-soft badge-success">Online</span>
+  </div>
+  <div class="flex gap-2">
+    <a href="#/dashboard" class="btn btn-secondary btn-sm">Back to Dashboard</a>
+  </div>
+</div>
+
+<div class="grid md:grid-cols-2 gap-6 mb-6">
+  <div class="card bg-base-100 shadow-md">
+    <div class="card-body">
+      <h2 class="card-title text-lg">Board Info</h2>
+      <table class="table table-sm">
+        <tbody>
+          <tr><td class="opacity-60">Device ID</td><td class="font-mono text-sm">leaflab-ccdba79f5fac</td></tr>
+          <tr><td class="opacity-60">Board type</td><td>Elegoo ESP32</td></tr>
+          <tr><td class="opacity-60">Firmware</td><td class="font-mono">v1.2.0</td></tr>
+          <tr><td class="opacity-60">Last heartbeat</td><td>12s ago</td></tr>
+          <tr><td class="opacity-60">Config version</td><td class="font-mono">#47</td></tr>
+          <tr><td class="opacity-60">Wi-Fi RSSI</td><td>-52 dBm</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <div class="card bg-base-100 shadow-md">
+    <div class="card-body">
+      <h2 class="card-title text-lg">Active sensors (6)</h2>
+      <ul class="space-y-2">
+        <li class="flex justify-between items-center">
+          <div>
+            <span class="font-medium">BH1750-A1</span>
+            <span class="text-xs opacity-60 ml-1">illuminance</span>
+          </div>
+          <span class="badge badge-sm">Room A · Shelf 1</span>
+        </li>
+        <li class="flex justify-between items-center">
+          <div>
+            <span class="font-medium">SHT3x-T1</span>
+            <span class="text-xs opacity-60 ml-1">temperature</span>
+          </div>
+          <span class="badge badge-sm">Room A · Shelf 1</span>
+        </li>
+        <li class="flex justify-between items-center">
+          <div>
+            <span class="font-medium">SHT3x-H1</span>
+            <span class="text-xs opacity-60 ml-1">humidity</span>
+          </div>
+          <span class="badge badge-sm">Room A · Shelf 1</span>
+        </li>
+        <li class="flex justify-between items-center">
+          <div>
+            <span class="font-medium">BH1750-A2</span>
+            <span class="text-xs opacity-60 ml-1">illuminance</span>
+          </div>
+          <span class="badge badge-sm">Room A · Shelf 2</span>
+        </li>
+        <li class="flex justify-between items-center">
+          <div>
+            <span class="font-medium">SHT3x-T2</span>
+            <span class="text-xs opacity-60 ml-1">temperature</span>
+          </div>
+          <span class="badge badge-sm">Room A · Shelf 2</span>
+        </li>
+        <li class="flex justify-between items-center">
+          <div>
+            <span class="font-medium">SHT3x-H2</span>
+            <span class="text-xs opacity-60 ml-1">humidity</span>
+          </div>
+          <span class="badge badge-sm">Room A · Shelf 2</span>
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+
+<div class="card bg-base-100 shadow-md">
+  <div class="card-body p-0">
+    <h2 class="text-lg font-semibold p-4 border-b border-base-300">Latest readings</h2>
+    <table class="table">
+      <thead>
+        <tr class="bg-base-200">
+          <th>Sensor</th>
+          <th>Type</th>
+          <th>Value</th>
+          <th>Region</th>
+          <th>Recorded at</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="font-mono">BH1750-A1</td>
+          <td>Illuminance</td>
+          <td><span class="font-semibold">423</span> <span class="text-xs opacity-60">lux</span></td>
+          <td>Room A · Shelf 1</td>
+          <td class="opacity-60">2026-07-19 14:32:18 UTC</td>
+        </tr>
+        <tr>
+          <td class="font-mono">SHT3x-T1</td>
+          <td>Temperature</td>
+          <td><span class="font-semibold">24.7</span> <span class="text-xs opacity-60">C</span></td>
+          <td>Room A · Shelf 1</td>
+          <td class="opacity-60">2026-07-19 14:32:15 UTC</td>
+        </tr>
+        <tr>
+          <td class="font-mono">SHT3x-H1</td>
+          <td>Humidity</td>
+          <td><span class="font-semibold">62.1</span> <span class="text-xs opacity-60">%</span></td>
+          <td>Room A · Shelf 1</td>
+          <td class="opacity-60">2026-07-19 14:32:15 UTC</td>
+        </tr>
+        <tr>
+          <td class="font-mono">BH1750-A2</td>
+          <td>Illuminance</td>
+          <td><span class="font-semibold">387</span> <span class="text-xs opacity-60">lux</span></td>
+          <td>Room A · Shelf 2</td>
+          <td class="opacity-60">2026-07-19 14:32:14 UTC</td>
+        </tr>
+        <tr>
+          <td class="font-mono">SHT3x-T2</td>
+          <td>Temperature</td>
+          <td><span class="font-semibold">25.3</span> <span class="text-xs opacity-60">C</span></td>
+          <td>Room A · Shelf 2</td>
+          <td class="opacity-60">2026-07-19 14:32:11 UTC</td>
+        </tr>
+        <tr>
+          <td class="font-mono">SHT3x-H2</td>
+          <td>Humidity</td>
+          <td><span class="font-semibold">58.9</span> <span class="text-xs opacity-60">%</span></td>
+          <td>Room A · Shelf 2</td>
+          <td class="opacity-60">2026-07-19 14:32:11 UTC</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<p class="wf-note mt-4">note: readings are latest snapshot only — time-series chart needs dedicated screen. Config editing not in scope for initial view-only UI.</p>

--- a/leaflab/ui/design/wireframes/screens/10-device-detail.html
+++ b/leaflab/ui/design/wireframes/screens/10-device-detail.html
@@ -1,4 +1,4 @@
-<!-- wf: name="device-detail" title="Device: leaflab-ccdba79f5fac" -->
+<!-- wf: name="device-detail-v2" title="Device: leaflab-ccdba79f5fac" -->
 <div class="breadcrumbs text-sm mb-4">
   <ul>
     <li><a href="#/dashboard">Dashboard</a></li>

--- a/leaflab/ui/design/wireframes/screens/11-register-device.html
+++ b/leaflab/ui/design/wireframes/screens/11-register-device.html
@@ -1,0 +1,77 @@
+<!-- wf: name="register-device" title="Register Device — Provision Wizard" parent="dashboard" -->
+
+<div class="breadcrumbs text-sm mb-4">
+  <ul><li><a href="#/devices">Devices</a></li><li>New Device Provisioning</li></ul>
+</div>
+
+<div class="flex justify-between items-center mb-6">
+  <h1 class="text-2xl md:text-3xl font-bold">Register New Device</h1>
+  <button class="btn btn-secondary btn-sm" onclick="history.back()">Cancel</button>
+</div>
+
+<!-- Progress stepper -->
+<div class="flex items-center gap-4 mb-8 px-4">
+  <div class="flex items-center gap-2">
+    <span class="w-7 h-7 rounded-full bg-primary text-primary-content flex items-center justify-center font-bold text-sm">1</span>
+    <span class="text-sm font-medium">Serial Number</span>
+  </div>
+  <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 opacity-30" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+  <div class="flex items-center gap-2 opacity-30">
+    <span class="w-7 h-7 rounded-full border-2 flex items-center justify-center font-bold text-sm">2</span>
+    <span class="text-sm font-medium">Wi-Fi Credentials</span>
+  </div>
+  <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 opacity-30" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+  <div class="flex items-center gap-2 opacity-30">
+    <span class="w-7 h-7 rounded-full border-2 flex items-center justify-center font-bold text-sm">3</span>
+    <span class="text-sm font-medium">MQTT Broker</span>
+  </div>
+  <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 opacity-30" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+  <div class="flex items-center gap-2 opacity-30">
+    <span class="w-7 h-7 rounded-full border-2 flex items-center justify-center font-bold text-sm">4</span>
+    <span class="text-sm font-medium">Verify &amp; Assign</span>
+  </div>
+</div>
+
+<!-- Step 1: Serial number -->
+<div class="card bg-base-100 shadow-md mb-6">
+  <div class="card-body p-4">
+    <h2 class="text-lg font-semibold mb-3">Step 1 — Identify Device</h2>
+    <p class="text-sm opacity-70 mb-4">Connect the ESP32 via USB and read its serial number from the eFuse MAC address.</p>
+
+    <div class="flex gap-3 items-end">
+      <!-- Serial input -->
+      <div class="flex flex-col gap-1">
+        <label class="text-sm opacity-60">Serial Number</label>
+        <input type="text" value="leaflab-ccdba79f5fac" disabled class="border-b border-base-300 focus:border-primary outline-none py-2 w-64 font-mono text-xs bg-base-200 rounded-box px-3">
+      </div>
+
+      <!-- Read from device button -->
+      <button class="btn btn-info btn-sm gap-1">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"/></svg>
+        Read from Device
+      </button>
+
+      <!-- Manual override -->
+      <span class="text-sm text-primary underline">Or enter manually</span>
+    </div>
+
+    <!-- Detected sensors -->
+    <div class="mt-4 p-3 bg-base-200 rounded-box">
+      <h3 class="text-sm font-semibold mb-2 opacity-60 uppercase tracking-wide">Detected Sensors (on I2C bus)</h3>
+      <table class="table table-sm w-full">
+        <thead><tr><th>I2C Address</th><th>Detected Device</th></tr></thead>
+        <tbody>
+          <tr><td class="font-mono text-xs">0x68 (98)</td><td>BH1750 Ambient Light Sensor</td></tr>
+          <tr><td class="font-mono text-xs">0x40 (64)</td><td>SHT3x Temperature/Humidity Sensor</td></tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="flex gap-2 mt-4 justify-end">
+      <a href="#/devices" class="btn btn-secondary btn-sm">Cancel</a>
+      <button class="btn btn-primary btn-sm">Next: Wi-Fi →</button>
+    </div>
+  </div>
+</div>
+
+<p class="wf-note mt-4">note: wizard is multi-step, each step advances. "Read from device" reads the eFuse MAC to generate a unique device ID. Detected sensors come from probing I2C — helps tinkerers know what's physically connected.</p>

--- a/leaflab/ui/design/wireframes/screens/12-gawker-dashboard.html
+++ b/leaflab/ui/design/wireframes/screens/12-gawker-dashboard.html
@@ -1,0 +1,78 @@
+<!-- wf: name="gawker-dashboard" title="LeafLab — Sensor Dashboard" -->
+
+<div class="wf-hero p-6 md:p-8 mb-6 shadow-lg bg-gradient-to-br from-green-900 via-emerald-800 to-teal-900 text-green-50">
+  <h1 class="text-2xl md:text-3xl font-bold mb-2">LeafLab — Sensor Dashboard</h1>
+  <p class="text-sm opacity-80">Real-time greenhouse sensor readings</p>
+</div>
+
+<!-- Only the essential stats — no device management -->
+<div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
+  <div class="stat bg-base-100 rounded-box shadow-md">
+    <div class="stat-title">Active Sensors</div>
+    <div class="stat-value text-success">10</div>
+    <div class="stat-desc">All reporting normally</div>
+  </div>
+  <div class="stat bg-base-100 rounded-box shadow-md">
+    <div class="stat-title">Avg Illuminance</div>
+    <div class="stat-value text-teal-500">405</div>
+    <div class="stat-desc">lux · range 280–530</div>
+  </div>
+  <div class="stat bg-base-100 rounded-box shadow-md">
+    <div class="stat-title">Avg Temperature</div>
+    <div class="stat-value text-blue-400">24.9°C</div>
+    <div class="stat-desc">range 23.5–26.1°C</div>
+  </div>
+  <div class="stat bg-base-100 rounded-box shadow-md">
+    <div class="stat-title">Avg Humidity</div>
+    <div class="stat-value text-cyan-400">61.8%</div>
+    <div class="stat-desc">range 57–66%</div>
+  </div>
+</div>
+
+<!-- Readings table — read-only, no edit buttons -->
+<div class="card bg-base-100 shadow-md mb-6">
+  <div class="card-body p-0">
+    <h2 class="text-lg font-semibold p-4 border-b border-base-300">Current Sensor Readings</h2>
+    <table class="table">
+      <thead><tr class="bg-base-200"><th>Sensor</th><th>Type</th><th>Location</th><th>Value</th><th>Last Updated</th></tr></thead>
+      <tbody>
+        <tr><td class="font-mono">BH1750-A1</td><td>Illuminance</td><td>Room A · Shelf 1</td><td class="text-teal-600 font-semibold">423 lux</td><td class="opacity-60">now</td></tr>
+        <tr><td class="font-mono">SHT3x-T1</td><td>Temperature</td><td>Room A · Shelf 1</td><td class="text-blue-400 font-semibold">24.7 °C</td><td class="opacity-60">5s ago</td></tr>
+        <tr><td class="font-mono">SHT3x-H1</td><td>Humidity</td><td>Room A · Shelf 1</td><td class="text-cyan-400 font-semibold">62.1 %</td><td class="opacity-60">5s ago</td></tr>
+        <tr><td class="font-mono">BH1750-A2</td><td>Illuminance</td><td>Room B · Shelf 2</td><td class="text-teal-600 font-semibold">387 lux</td><td class="opacity-60">4s ago</td></tr>
+        <tr><td class="font-mono">SHT3x-T2</td><td>Temperature</td><td>Room B · Shelf 2</td><td class="text-blue-400 font-semibold">25.3 °C</td><td class="opacity-60">7s ago</td></tr>
+        <tr><td class="font-mono">SHT3x-H2</td><td>Humidity</td><td>Room B · Shelf 2</td><td class="text-cyan-400 font-semibold">58.9 %</td><td class="opacity-60">7s ago</td></tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<!-- Mini sparklines — read-only, no drill-in controls -->
+<div class="grid grid-cols-2 md:grid-cols-3 gap-4 mb-6">
+  <div class="card bg-base-100 shadow-md">
+    <div class="card-body p-4">
+      <h3 class="text-sm font-semibold opacity-70 mb-2">Illuminance Trend</h3>
+      <div class="border-2 border-dashed border-base-300 rounded-box h-28 flex items-center justify-center text-xs opacity-50">
+        [sparkline chart]
+      </div>
+    </div>
+  </div>
+  <div class="card bg-base-100 shadow-md">
+    <div class="card-body p-4">
+      <h3 class="text-sm font-semibold opacity-70 mb-2">Temperature Trend</h3>
+      <div class="border-2 border-dashed border-base-300 rounded-box h-28 flex items-center justify-center text-xs opacity-50">
+        [sparkline chart]
+      </div>
+    </div>
+  </div>
+  <div class="card bg-base-100 shadow-md">
+    <div class="card-body p-4">
+      <h3 class="text-sm font-semibold opacity-70 mb-2">Humidity Trend</h3>
+      <div class="border-2 border-dashed border-base-300 rounded-box h-28 flex items-center justify-center text-xs opacity-50">
+        [sparkline chart]
+      </div>
+    </div>
+  </div>
+</div>
+
+<p class="wf-note mt-4">note: gawker dashboard is pure read-only — no device management, config editing, or admin controls. This view could be embedded in a public kiosk or shared via a simple URL.</p>

--- a/leaflab/ui/design/wireframes/screens/13-tinkerer-sensor-config.html
+++ b/leaflab/ui/design/wireframes/screens/13-tinkerer-sensor-config.html
@@ -1,0 +1,110 @@
+<!-- wf: name="sensor-edit" title="Edit Sensor — BH1750-A1 (Tinkering)" parent="device-edit-config" -->
+
+<div class="breadcrumbs text-sm mb-4">
+  <ul><li><a href="#/devices">Devices</a></li><li><a href="#/device-detail">leaflab-ccdba79f5fac</a></li><li>BH1750-A1 — Edit Sensor</li></ul>
+</div>
+
+<div class="flex justify-between items-center mb-6">
+  <h1 class="text-2xl md:text-3xl font-bold">Edit Sensor — BH1750-A1</h1>
+  <div class="flex gap-2"><a href="#/device-edit-config" class="btn btn-secondary btn-sm">Cancel</a><button class="btn btn-primary btn-sm">Apply Changes</button></div>
+</div>
+
+<div class="grid md:grid-cols-3 gap-6 mb-6">
+  <!-- Sensor identity -->
+  <div class="card bg-base-100 shadow-md md:col-span-2">
+    <div class="card-body p-4">
+      <h2 class="text-lg font-semibold mb-3 border-b border-base-300 pb-1">Sensor Identity</h2>
+
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <!-- Name -->
+        <div class="flex flex-col gap-1">
+          <label class="text-sm opacity-60">Logical Name</label>
+          <input type="text" value="BH1750-A1" placeholder="e.g. BH1750-A3" class="border-b border-base-300 focus:border-primary outline-none py-2 w-full text-sm">
+        </div>
+
+        <!-- Sensor ID (immutable) -->
+        <div class="flex flex-col gap-1 opacity-60">
+          <label class="text-sm">Sensor ID</label>
+          <span class="font-mono text-xs bg-base-200 rounded-box px-3 py-2 w-full select-all">bh1750-1</span>
+        </div>
+
+        <!-- I2C Address -->
+        <div class="flex flex-col gap-1">
+          <label class="text-sm opacity-60">I2C Address</label>
+          <select class="border-b border-base-300 focus:border-primary outline-none py-2 w-full text-sm bg-transparent"><option>0x68 (98) — BH1750</option><option>0x3C (60) — OLED Display</option><option>0x40 (64) — SHT3x Temp/Humidity</option><option>0x23 (35) — TSL2591 Ambient Light</option></select>
+          <span class="text-xs opacity-40 mt-1">Matches detected hardware address on I2C bus</span>
+        </div>
+
+        <!-- Polling interval -->
+        <div class="flex flex-col gap-1">
+          <label class="text-sm opacity-60">Polling Interval (ms)</label>
+          <input type="number" value="2000" min="250" step="250" class="border-b border-base-300 focus:border-primary outline-none py-2 w-full font-mono text-sm">
+        </div>
+
+        <!-- Region -->
+        <div class="flex flex-col gap-1 md:col-span-2">
+          <label class="text-sm opacity-60 mb-1">Physical Location (Region)</label>
+          <!-- Nested select tree for tinkering — shows full path -->
+          <select class="border-b border-base-300 focus:border-primary outline-none py-2 w-full text-sm bg-transparent md:col-span-2">
+            <option value="">— No region assigned —</option>
+            <optgroup label="Room A">
+              <option value="roomA" selected>&nbsp;&nbsp;└ Room A (main greenhouse section)</option>
+              <option value="shelf1">&nbsp;&nbsp;&nbsp;&nbsp;├ Shelf 1 (top shelf by window)</option>
+              <option value="shelf2">&nbsp;&nbsp;&nbsp;&nbsp;└ Shelf 2 (middle shelf, ambient)</option>
+            </optgroup>
+            <optgroup label="Room B">
+              <option value="roomB">&nbsp;&nbsp;└ Room B (secondary section)</option>
+              <option value="shelf3">&nbsp;&nbsp;&nbsp;&nbsp;├ Shelf 1 (near door, variable temp)</option>
+              <option value="shelf4">&nbsp;&nbsp;&nbsp;&nbsp;└ Shelf 2 (away from window)</option>
+            </optgroup>
+            <optgroup label="Potting Area">
+              <option value="pots">&nbsp;&nbsp;└ Potting Area (covered potting station)</option>
+            </optgroup>
+          </select>
+        </div>
+
+        <!-- Enable/disable -->
+        <div class="flex flex-col gap-1 md:col-span-2">
+          <label class="inline-flex items-center gap-3 text-sm cursor-pointer">
+            <input type="checkbox" checked class="peer sr-only">
+            <span class="w-5 h-5 border-2 peer-checked:border-primary peer-checked:bg-primary rounded-[4px] transition-all"></span>
+            <span><strong>Enabled</strong> — sensor will be instantiated on device and begin reporting readings</span>
+          </label>
+        </div>
+
+      </div>
+    </div>
+  </div>
+
+  <!-- Hardware info panel -->
+  <div class="card bg-base-100 shadow-md">
+    <div class="card-body p-4">
+      <h2 class="text-lg font-semibold mb-3 border-b border-base-300 pb-1">Hardware Info</h2>
+
+      <!-- Detected chip -->
+      <table class="table table-sm">
+        <tbody>
+          <tr><td class="opacity-60 w-24">Chip</td><td>BH1750FVC</td></tr>
+          <tr><td class="opacity-60">Manufacturer</td><td>Rohm Semiconductor</td></tr>
+          <tr><td class="opacity-60">Range</td><td class="text-xs">0.1 – 100,000 lux</td></tr>
+          <tr><td class="opacity-60">Default addr</td><td class="font-mono text-xs">0x23 (35)</td></tr>
+        </tbody>
+      </table>
+
+      <!-- Config version info -->
+      <div class="mt-4 p-3 bg-base-200 rounded-box">
+        <h3 class="text-sm font-semibold mb-1 opacity-60 uppercase tracking-wide">Config Version</h3>
+        <p class="text-xs opacity-70">Current device config: <span class="font-mono">#47</span></p>
+        <p class="text-xs opacity-70 mt-1">Pending changes will push <span class="font-mono text-primary font-semibold">#48</span></p>
+      </div>
+
+      <!-- Quick actions -->
+      <div class="mt-4 flex flex-col gap-2">
+        <button class="btn btn-secondary btn-sm justify-start gap-1"><svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"/></svg>Export Config JSON</button>
+        <button class="btn btn-outline btn-sm justify-start gap-1 text-error"><svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-8 8-4-4-1 1"/></svg>Remove from Device</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<p class="wf-note mt-4">note: tinkering screen exposes all sensor knobs — I2C address, poll interval, region nesting, enable/disable. "Apply Changes" pushes config #48 to the device via MQTT. Remove from Device destroys the sensor at hardware level.</p>

--- a/leaflab/ui/design/wireframes/screens/14-device-list.html
+++ b/leaflab/ui/design/wireframes/screens/14-device-list.html
@@ -1,0 +1,94 @@
+<!-- wf: name="devices" title="Devices — Fleet Overview" -->
+
+<div class="wf-hero p-6 md:p-8 mb-6 shadow-lg bg-gradient-to-br from-green-900 via-emerald-800 to-teal-900 text-green-50">
+  <h1 class="text-2xl md:text-3xl font-bold mb-2">Devices — Fleet Overview</h1>
+  <p class="text-sm opacity-80">Manage all sensorboard setups — register, provision, monitor health</p>
+</div>
+
+<!-- Quick stats -->
+<div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
+  <div class="stat bg-base-100 rounded-box shadow-md">
+    <div class="stat-title">Total Devices</div>
+    <div class="stat-value text-primary">3</div>
+  </div>
+  <div class="stat bg-base-100 rounded-box shadow-md">
+    <div class="stat-title">Online Now</div>
+    <div class="stat-value text-success">2</div>
+  </div>
+  <div class="stat bg-base-100 rounded-box shadow-md">
+    <div class="stat-title">Offline (24h+)</div>
+    <div class="stat-value text-error">1</div>
+  </div>
+  <div class="stat bg-base-100 rounded-box shadow-md">
+    <div class="stat-title">Total Sensors</div>
+    <div class="stat-value">14</div>
+  </div>
+</div>
+
+<!-- Fleet table -->
+<div class="card bg-base-100 shadow-md mb-6">
+  <div class="card-body p-0">
+    <table class="table">
+      <thead><tr class="bg-base-200"><th>Device ID</th><th>Status</th><th>Firmware</th><th>Sensors</th><th>Last Seen</th><th></th></tr></thead>
+      <tbody>
+        <!-- Online device 1 -->
+        <tr class="hover">
+          <td colspan="5" class="p-0"><table class="w-full">
+            <tr class="cursor-pointer hover:bg-base-50/60 transition-colors" onclick="location.href='#/device-detail'">
+              <td><span class="font-mono text-xs">leaflab-ccdba79f5fac</span></td>
+              <td><span class="badge badge-success badge-sm gap-1"><svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg>Online</span></td>
+              <td class="font-mono text-xs">v1.2.0</td><td>6 sensors</td><td class="opacity-60">12s ago</td>
+            </tr>
+          </table></td>
+        </tr>
+
+        <!-- Online device 2 -->
+        <tr class="hover">
+          <td colspan="5" class="p-0"><table class="w-full">
+            <tr class="cursor-pointer hover:bg-base-50/60 transition-colors" onclick="location.href='#/device-detail'">
+              <td><span class="font-mono text-xs">leaflab-a1b2c3d4e5f6</span></td>
+              <td><span class="badge badge-success badge-sm gap-1"><svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg>Online</span></td>
+              <td class="font-mono text-xs">v1.2.0</td><td>4 sensors</td><td class="opacity-60">8s ago</td>
+            </tr>
+          </table></td>
+        </tr>
+
+        <!-- Offline device -->
+        <tr class="hover opacity-50 bg-base-100/30">
+          <td colspan="5" class="p-0"><table class="w-full">
+            <tr class="cursor-pointer hover:bg-base-50/60 transition-colors" onclick="location.href='#/device-detail'">
+              <td><span class="font-mono text-xs">leaflab-9f8e7d6c5b4a</span></td>
+              <td><span class="badge badge-neutral badge-sm gap-1"><svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l4 4"/></svg>Offline</span></td>
+              <td class="font-mono text-xs">v1.1.3</td><td>4 sensors</td><td class="opacity-60">3h ago</td>
+            </tr>
+          </table></td>
+        </tr>
+
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<!-- Config history -->
+<div class="card bg-base-100 shadow-md mb-6">
+  <div class="card-body p-0">
+    <h2 class="text-lg font-semibold p-4 border-b border-base-300">Config History</h2>
+    <table class="table table-sm">
+      <thead><tr><th>Device</th><th>#</th><th>Sensors enabled / total</th><th>Last applied</th></tr></thead>
+      <tbody>
+        <tr><td class="font-mono text-xs">leaflab-ccdba79f5fac</td><td>#47</td><td>6/6</td><td class="opacity-60">2h ago</td></tr>
+        <tr><td class="font-mono text-xs">leaflab-a1b2c3d4e5f6</td><td>#12</td><td>4/4</td><td class="opacity-60">1d ago</td></tr>
+        <tr><td class="font-mono text-xs">leaflab-9f8e7d6c5b4a</td><td>#3</td><td>2/4</td><td class="opacity-60">3h ago</td></tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<!-- Actions -->
+<div class="flex flex-wrap gap-2 mt-4 mb-8">
+  <button class="btn btn-primary btn-sm" onclick="location.href='#/register-device'">+ Register Device</button>
+  <a href="#/device-edit-config" class="btn btn-secondary btn-sm">Edit Config — leaflab-ccdba79f5fac</a>
+  <button class="btn btn-outline btn-sm">Export Fleet Report</button>
+</div>
+
+<p class="wf-note mt-4">note: clicking a row drills into device-detail. Register Device opens the provision wizard (register-device). Config edit links to per-device config form.</p>

--- a/leaflab/ui/design/wireframes/screens/15-register-wifi.html
+++ b/leaflab/ui/design/wireframes/screens/15-register-wifi.html
@@ -1,0 +1,84 @@
+<!-- wf: name="register-wifi" title="Register Device — Step 2: Wi-Fi" parent="dashboard" -->
+
+<div class="breadcrumbs text-sm mb-4">
+  <ul><li><a href="#/devices">Devices</a></li><li>New Device Provisioning → Wi-Fi</li></ul>
+</div>
+
+<div class="flex justify-between items-center mb-6">
+  <h1 class="text-2xl md:text-3xl font-bold">Step 2 — Wi-Fi Credentials</h1>
+  <a href="#/register-device" class="btn btn-secondary btn-sm">< Back to Step 1</a>
+</div>
+
+<!-- Progress stepper -->
+<div class="flex items-center gap-4 mb-8 px-4">
+  <div class="flex items-center gap-2 opacity-50">
+    <span class="w-7 h-7 rounded-full bg-success text-success-content flex items-center justify-center font-bold text-sm"><svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg></span>
+    <span class="text-sm font-medium">Serial Number</span>
+  </div>
+  <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 opacity-50" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+  <div class="flex items-center gap-2">
+    <span class="w-7 h-7 rounded-full bg-primary text-primary-content flex items-center justify-center font-bold text-sm">2</span>
+    <span class="text-sm font-medium">Wi-Fi Credentials</span>
+  </div>
+  <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 opacity-30" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+  <div class="flex items-center gap-2 opacity-30">
+    <span class="w-7 h-7 rounded-full border-2 flex items-center justify-center font-bold text-sm">3</span>
+    <span class="text-sm font-medium">MQTT Broker</span>
+  </div>
+  <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 opacity-30" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7-7"/></svg>
+  <div class="flex items-center gap-2 opacity-30">
+    <span class="w-7 h-7 rounded-full border-2 flex items-center justify-center font-bold text-sm">4</span>
+    <span class="text-sm font-medium">Verify &amp; Assign</span>
+  </div>
+</div>
+
+<div class="card bg-base-100 shadow-md mb-6">
+  <div class="card-body p-4">
+    <h2 class="text-lg font-semibold mb-3 border-b border-base-300 pb-1">Wi-Fi Configuration</h2>
+    <p class="text-sm opacity-70 mb-4">These credentials will be stored in the ESP32's NVS (non-volatile storage) and used on every boot. The device connects to your Wi-Fi via MQTT broker.</p>
+
+    <!-- Device info summary -->
+    <div class="bg-base-200 rounded-box p-3 mb-4 flex items-center gap-3">
+      <span class="text-sm opacity-60">Device:</span>
+      <span class="font-mono text-xs font-medium">leaflab-ccdba79f5fac</span>
+    </div>
+
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+      <!-- Wi-Fi SSID -->
+      <div class="flex flex-col gap-1 md:col-span-2">
+        <label class="text-sm opacity-60">Wi-Fi SSID (network name)</label>
+        <input type="text" value="" placeholder="e.g. Greenhouse-WiFi" class="border-b border-base-300 focus:border-primary outline-none py-2 w-full text-sm">
+      </div>
+
+      <!-- Wi-Fi Password -->
+      <div class="flex flex-col gap-1 md:col-span-2">
+        <label class="text-sm opacity-60">Wi-Fi Password</label>
+        <input type="password" value="" placeholder="Enter password" class="border-b border-base-300 focus:border-primary outline-none py-2 w-full text-sm">
+      </div>
+
+      <!-- Wi-Fi credentials will be provisioned to the ESP32 via MQTT on the same network. -->
+    </div>
+
+    <p class="wf-note mt-4">note: step 1 (serial number) already completed. Step 2 is collecting Wi-Fi credentials for the device.</p>
+
+    <!-- Advanced options -->
+    <details class="collapse collapse-arrow bg-base-200 rounded-box">
+      <summary class="collapse-title text-sm font-medium opacity-60 flex items-center gap-1"><svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M12 4a9 9 0 100 18 9 9 0 000-18z"/></svg>Advanced Options</summary>
+      <div class="mt-2 space-y-3">
+        <!-- Static IP (optional) -->
+        <label class="inline-flex items-center gap-2 text-sm cursor-pointer"><input type="checkbox" class="peer sr-only"><span class="w-5 h-5 border-2 rounded-[4px] transition-all"></span><span>Use static IP address</span></label>
+        <!-- Static IP fields (hidden until checkbox is checked) -->
+
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-3 mt-2">
+          <input type="text" placeholder="IP Address" class="border-b border-base-300 focus:border-primary outline-none py-2 w-full text-sm font-mono"><input type="text" placeholder="Subnet Mask" class="border-b border-base-300 focus:border-primary outline-none py-2 w-full text-sm font-mono"><input type="text" placeholder="Gateway" class="border-b border-base-300 focus:border-primary outline-none py-2 w-full text-sm font-mono">
+        </div>
+
+        <!-- Wi-Fi credentials will be provisioned to the ESP32 via MQTT on the same network. -->
+      </div>
+    </details>
+
+    <div class="flex gap-2 mt-6 justify-end"><button class="btn btn-secondary btn-sm">< Back</button><button class="btn btn-primary btn-sm">Next: MQTT →</button></div>
+  </div>
+</div>
+
+<p class="wf-note mt-4">note: Wi-Fi credentials are provisioned to the ESP32 via USB or OTA after initial provisioning. Advanced options let you set a static IP if DHCP is not available on the greenhouse network.</p>

--- a/leaflab/ui/design/wireframes/screens/16-register-mqtt.html
+++ b/leaflab/ui/design/wireframes/screens/16-register-mqtt.html
@@ -1,0 +1,98 @@
+<!-- wf: name="register-mqtt" title="Register Device — Step 3: MQTT Broker" parent="dashboard" -->
+
+<div class="breadcrumbs text-sm mb-4">
+  <ul><li><a href="#/devices">Devices</a></li><li>New Device Provisioning → MQTT</li></ul>
+</div>
+
+<div class="flex justify-between items-center mb-6">
+  <h1 class="text-2xl md:text-3xl font-bold">Step 3 — MQTT Broker Configuration</h1>
+  <a href="#/register-wifi" class="btn btn-secondary btn-sm">< Back to Wi-Fi</a>
+</div>
+
+<!-- Progress stepper -->
+<div class="flex items-center gap-4 mb-8 px-4">
+  <div class="flex items-center gap-2 opacity-50">
+    <span class="w-7 h-7 rounded-full bg-success text-success-content flex items-center justify-center font-bold text-sm"><svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg></span>
+    <span class="text-sm font-medium">Serial Number</span>
+  </div>
+  <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 opacity-50" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+  <div class="flex items-center gap-2 opacity-50">
+    <span class="w-7 h-7 rounded-full bg-primary text-primary-content flex items-center justify-center font-bold text-sm"><svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg></span>
+    <span class="text-sm font-medium">Wi-Fi Credentials</span>
+  </div>
+  <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 opacity-50" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+  <div class="flex items-center gap-2">
+    <span class="w-7 h-7 rounded-full bg-primary text-primary-content flex items-center justify-center font-bold text-sm">3</span>
+    <span class="text-sm font-medium">MQTT Broker</span>
+  </div>
+  <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 opacity-30" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+  <div class="flex items-center gap-2 opacity-30">
+    <span class="w-7 h-7 rounded-full border-2 flex items-center justify-center font-bold text-sm">4</span>
+    <span class="text-sm font-medium">Verify &amp; Assign</span>
+  </div>
+</div>
+
+<div class="card bg-base-100 shadow-md mb-6">
+  <div class="card-body p-4">
+    <h2 class="text-lg font-semibold mb-3 border-b border-base-300 pb-1">MQTT Broker Settings</h2>
+    <p class="text-sm opacity-70 mb-4">These settings determine how the device connects to your RabbitMQ/MQTT broker for publishing sensor readings and receiving config updates.</p>
+
+    <!-- Device info summary -->
+    <div class="bg-base-200 rounded-box p-3 mb-4 flex items-center gap-3">
+      <span class="text-sm opacity-60">Device:</span>
+      <span class="font-mono text-xs font-medium">leaflab-ccdba79f5fac</span>
+    </div>
+
+    <!-- Broker address -->
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+      <div class="flex flex-col gap-1 md:col-span-2">
+        <label class="text-sm opacity-60">Broker Host</label>
+        <input type="text" value="" placeholder="e.g. 192.168.1.42 or mqtt.greenhouse.local" class="border-b border-base-300 focus:border-primary outline-none py-2 w-full text-sm font-mono">
+      </div>
+
+      <div class="flex flex-col gap-1">
+        <label class="text-sm opacity-60">Port</label>
+        <input type="number" value="1883" min="1" max="65535" class="border-b border-base-300 focus:border-primary outline-none py-2 w-full font-mono text-sm">
+      </div>
+    </div>
+
+    <!-- Client ID -->
+    <div class="grid grid-cols-1 md:grid-cols-4 gap-4 mt-4">
+      <div class="flex flex-col gap-1 md:col-span-3">
+        <label class="text-sm opacity-60">Client ID</label>
+        <input type="text" value="" placeholder="auto-generated from device serial" disabled class="border-b border-base-300 focus:border-primary outline-none py-2 w-full text-sm font-mono bg-base-200 rounded-box px-3">
+      </div>
+
+      <!-- Generated automatically -->
+    </div>
+
+    <!-- Username / Password (optional) -->
+    <details class="collapse collapse-arrow bg-base-200 rounded-box mt-4">
+      <summary class="collapse-title text-sm font-medium opacity-60 flex items-center gap-1"><svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 7a2 2 0 012 2m-4 0a9 9 0 111.866-15.34l4.5 4.5m0 0v3.052a2.25 2.25 0 01-.743 1.665L9 15.5V17"/></svg>MQTT Authentication (Optional)</summary>
+      <div class="mt-2 space-y-3">
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <!-- Username -->
+          <div class="flex flex-col gap-1">
+            <label class="text-sm opacity-60">Username</label>
+            <input type="text" value="" placeholder="e.g. leaflab-sensorboard" class="border-b border-base-300 focus:border-primary outline-none py-2 w-full text-sm">
+          </div>
+
+          <!-- Password -->
+          <div class="flex flex-col gap-1">
+            <label class="text-sm opacity-60">Password</label>
+            <input type="password" value="" placeholder="MQTT password" class="border-b border-base-300 focus:border-primary outline-none py-2 w-full text-sm">
+          </div>
+
+          <!-- TLS/SSL -->
+        </div>
+      </div>
+    </details>
+
+    <p class="wf-note mt-4">note: MQTT broker is typically RabbitMQ with the MQTT plugin. The client ID is auto-generated from the device serial number to ensure uniqueness in MQTT.</p>
+
+    <!-- Broker will be provisioned to the ESP32's NVS storage alongside Wi-Fi credentials. -->
+    <div class="flex gap-2 mt-6 justify-end"><a href="#/register-wifi" class="btn btn-secondary btn-sm">Back</a><button class="btn btn-primary btn-sm">Next: Verify →</button></div>
+  </div>
+</div>
+
+<p class="wf-note mt-4">note: MQTT broker is typically RabbitMQ with the MQTT plugin. The client ID is auto-generated from the device serial number to ensure uniqueness in MQTT.</p>

--- a/leaflab/ui/design/wireframes/screens/17-register-verify.html
+++ b/leaflab/ui/design/wireframes/screens/17-register-verify.html
@@ -1,0 +1,107 @@
+<!-- wf: name="register-verify" title="Register Device — Step 4: Verify & Assign" parent="dashboard" -->
+
+<div class="breadcrumbs text-sm mb-4">
+  <ul><li><a href="#/devices">Devices</a></li><li>New Device Provisioning → Verify</li></ul>
+</div>
+
+<div class="flex justify-between items-center mb-6">
+  <h1 class="text-2xl md:text-3xl font-bold">Step 4 — Verify &amp; Assign to Region</h1>
+  <a href="#/register-mqtt" class="btn btn-secondary btn-sm">< Back to MQTT</a>
+</div>
+
+<!-- Progress stepper -->
+<div class="flex items-center gap-4 mb-8 px-4">
+  <div class="flex items-center gap-2 opacity-50">
+    <span class="w-7 h-7 rounded-full bg-success text-success-content flex items-center justify-center font-bold text-sm"><svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg></span>
+    <span class="text-sm font-medium">Serial Number</span>
+  </div>
+  <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 opacity-50" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+  <div class="flex items-center gap-2 opacity-50">
+    <span class="w-7 h-7 rounded-full bg-success text-success-content flex items-center justify-center font-bold text-sm"><svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg></span>
+    <span class="text-sm font-medium">Wi-Fi Credentials</span>
+  </div>
+  <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 opacity-50" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+  <div class="flex items-center gap-2 opacity-50">
+    <span class="w-7 h-7 rounded-full bg-success text-success-content flex items-center justify-center font-bold text-sm"><svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg></span>
+    <span class="text-sm font-medium">MQTT Broker</span>
+  </div>
+  <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 opacity-50" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+  <div class="flex items-center gap-2">
+    <span class="w-7 h-7 rounded-full bg-primary text-primary-content flex items-center justify-center font-bold text-sm">4</span>
+    <span class="text-sm font-medium">Verify &amp; Assign</span>
+  </div>
+</div>
+
+<!-- Provisioning summary -->
+<div class="card bg-base-100 shadow-md mb-6 border-success/30">
+  <div class="card-body p-4">
+    <h2 class="text-lg font-semibold mb-3 border-b border-base-300 pb-1 flex items-center gap-2 text-success">
+      <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
+      Provisioning Summary — Ready to Deploy
+    </h2>
+
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+      <!-- Device info -->
+      <div class="bg-base-200 rounded-box p-3 space-y-1 text-sm">
+        <p><span class="opacity-60">Device ID:</span> <span class="font-mono font-medium">leaflab-ccdba79f5fac</span></p>
+        <p><span class="opacity-60">Board Type:</span> Elegoo ESP32-S3</p>
+        <p><span class="opacity-60">eFuse MAC:</span> CC:DB:A7:9F:5F:AC</p>
+      </div>
+
+      <!-- Connection info -->
+      <div class="bg-base-200 rounded-box p-3 space-y-1 text-sm">
+        <p><span class="opacity-60">Wi-Fi:</span> Greenhouse-WiFi</p>
+        <p><span class="opacity-60">MQTT Broker:</span> 192.168.1.42:1883 (leaflab-ccdba79f5fac)</p>
+      </div>
+
+      <!-- Detected sensors -->
+      <div class="md:col-span-2 bg-base-200 rounded-box p-3">
+        <h3 class="text-sm font-semibold mb-2 opacity-60 uppercase tracking-wide">Detected Sensors</h3>
+        <table class="table table-sm w-full">
+          <thead><tr><th>I2C Address</th><th>Device</th><th>Suggested Name</th></tr></thead>
+          <tbody>
+            <tr><td class="font-mono text-xs">0x68 (98)</td><td>BH1750 Ambient Light Sensor</td><td class="text-sm opacity-70">BH1750-A1 (auto-suggested)</td></tr>
+            <tr><td class="font-mono text-xs">0x40 (64)</td><td>SHT3x Temperature/Humidity Sensor</td><td class="text-sm opacity-70">SHT3x-T1, SHT3x-H1 (auto-suggested)</td></tr>
+          </tbody>
+        </table>
+      </div>
+
+      <!-- Default config preview -->
+    </div>
+  </div>
+</div>
+
+<!-- Sensor assignment form -->
+<div class="card bg-base-100 shadow-md mb-6">
+  <div class="card-body p-4">
+    <h2 class="text-lg font-semibold mb-3 border-b border-base-300 pb-1">Sensor Name &amp; Region Assignment</h2>
+    <p class="text-sm opacity-70 mb-4">Assign logical names and physical locations for each detected sensor. You can change these later in the device config.</p>
+
+    <!-- Sensor 1: BH1750 -->
+    <div class="bg-base-200 rounded-box p-3 mb-3 space-y-3">
+      <h3 class="text-sm font-semibold flex items-center gap-2"><svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 opacity-60" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-3.5-3.5z"/></svg>BH1750 (I2C 0x68) — Illuminance</h3>
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+        <input type="text" value="" placeholder="BH1750-A1" class="border-b border-base-300 focus:border-primary outline-none py-2 w-full text-sm"><select class="border-b border-base-300 focus:border-primary outline-none py-2 w-full text-sm bg-transparent md:col-span-2"><option value="">— No region assigned —</option><optgroup label="Room A"><option>&nbsp;&nbsp;└ Room A (main greenhouse section)</option><option>&nbsp;&nbsp;├ Shelf 1 (top shelf by window)</option><option>&nbsp;&nbsp;└ Shelf 2 (middle shelf, ambient)</option></optgroup><optgroup label="Room B"><option>&nbsp;&nbsp;└ Room B (secondary section)</option><option>&nbsp;&nbsp;├ Shelf 1 (near door, variable temp)</option><option>&nbsp;&nbsp;└ Shelf 2 (away from window)</option></optgroup><optgroup label="Potting Area"><option>&nbsp;&nbsp;└ Potting Area (covered potting station)</option></optgroup></select>
+      </div>
+
+      <!-- Sensor names will be auto-suggested based on detected I2C devices. -->
+    </div>
+
+    <!-- Sensor 2: SHT3x -->
+    <div class="bg-base-200 rounded-box p-3 mb-3 space-y-3">
+      <h3 class="text-sm font-semibold flex items-center gap-2"><svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 opacity-60" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-3.5-3.5z"/></svg>SHT3x (I2C 0x40) — Temperature &amp; Humidity</h3>
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+        <!-- Temp sensor -->
+        <input type="text" value="" placeholder="SHT3x-T1 (temperature)" class="border-b border-base-300 focus:border-primary outline-none py-2 w-full text-sm"><input type="number" value="5000" min="250" step="250" class="border-b border-base-300 focus:border-primary outline-none py-2 w-full font-mono text-sm md:col-span-2">
+        <!-- Humidity sensor -->
+      </div>
+    </div>
+
+    <p class="wf-note mt-4">note: auto-suggested names help avoid duplicates. Polling interval defaults to 5000ms for SHT3x, 2000ms for BH1750.</p>
+
+    <!-- Final actions -->
+    <div class="flex gap-2 justify-end mt-6"><a href="#/register-mqtt" class="btn btn-secondary btn-sm">Back</a><button class="btn btn-success btn-sm gap-1"><svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"/></svg>Provision &amp; Connect Device</button></div>
+  </div>
+</div>
+
+<p class="wf-note mt-4">note: "Provision & Connect" pushes Wi-Fi + MQTT credentials to the ESP32 via USB, then waits for it to connect and start publishing. If USB provisioning fails, there's a fallback to manual config file drop.</p>

--- a/leaflab/ui/design/wireframes/screens/18-config-diff.html
+++ b/leaflab/ui/design/wireframes/screens/18-config-diff.html
@@ -1,0 +1,113 @@
+<!-- wf: name="config-diff" title="Config Diff — #47 vs #48" parent="device-edit-config" -->
+
+<div class="breadcrumbs text-sm mb-4">
+  <ul><li><a href="#/devices">Devices</a></li><li><a href="#/device-detail">leaflab-ccdba79f5fac</a></li><li>Config Diff #47 vs #48</li></ul>
+</div>
+
+<div class="flex justify-between items-center mb-6">
+  <h1 class="text-2xl md:text-3xl font-bold">Config Comparison — leaflab-ccdba79f5fac</h1>
+  <div class="flex gap-2"><a href="#/device-edit-config" class="btn btn-secondary btn-sm">Back to Config</a></div>
+</div>
+
+<!-- Header info -->
+<div class="card bg-base-100 shadow-md mb-6">
+  <div class="card-body p-4 flex flex-col md:flex-row gap-4 items-center justify-between">
+    <!-- Left version -->
+    <div class="flex-1 text-center">
+      <span class="text-sm opacity-60 mr-2">From:</span>
+      <span class="font-mono font-bold text-base">#47</span>
+      <span class="text-xs opacity-60 ml-2">Applied 2026-07-19 08:34 · 5 sensors enabled / 6 total</span>
+    </div>
+
+    <!-- Diff arrow -->
+    <div class="flex items-center gap-2 text-primary font-bold text-lg"><svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7l5 5m0 0l-5 5m5-5H3"/></svg></div>
+
+    <!-- Right version -->
+    <div class="flex-1 text-center">
+      <span class="text-sm opacity-60 mr-2">To:</span>
+      <span class="font-mono font-bold text-base">#48</span>
+      <span class="text-xs opacity-60 ml-2">Unpublished preview · 5 sensors enabled / 6 total</span>
+    </div>
+  </div>
+</div>
+
+<!-- Diff table -->
+<div class="card bg-base-100 shadow-md mb-6">
+  <div class="card-body p-0">
+    <h2 class="text-lg font-semibold p-4 border-b border-base-300 flex items-center gap-2"><svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 opacity-60" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 8b4a0 10l2a2 2 0 010 4H9m6-6v2a2 2 0 01-2 2h-2"/></svg> Sensor Changes</h2>
+
+    <table class="table">
+      <!-- Legend -->
+      <thead><tr class="bg-base-200 text-xs"><th>Sensor ID</th><th>Type</th><th>Status</th><th>Name</th><th>I2C Addr</th><th>Poll (ms)</th><th>Region</th></tr></thead>
+
+      <!-- Added sensor -->
+      <tbody class="bg-success/10">
+        <tr class="hover"><td colspan="7" class="p-0"><table class="w-full"><tr><td class="font-mono text-xs pl-4 py-3">sht3x-hum-2</td>
+          <td>SHT3x · Humidity</td>
+          <td><span class="badge badge-success badge-sm gap-1"><svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v3m0 0l-3 3m3-3h-8"/></svg>Added</span></td>
+          <td>SHT3x-H2 (new)</td><td class="font-mono text-xs">0x40 (64)</td><td class="font-mono text-xs">5000</td><td class="text-sm">Room B · Shelf 2</td>
+        </tr></table></td>
+      </tbody>
+
+      <!-- Modified sensor -->
+      <tr class="hover bg-warning/10"><td class="font-mono text-xs pl-4 py-3">bh1750-1</td>
+          <td>BH1750 · Illuminance</td>
+          <td><span class="badge badge-warning badge-sm gap-1"><svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7b8a0 0v5a6 6 0 00-9.6 5H"/></svg>Changed</span></td>
+          <td>BH1750-A1</td><td class="font-mono text-xs">0x68 (98)</td>
+          <td colspan="2"><span class="line-through opacity-50 text-xs">1000</span> → <span class="text-primary font-semibold text-xs">2000 ms</span></td>
+        </tr>
+
+      <!-- Unchanged sensor -->
+      <tr class="hover opacity-60"><td class="font-mono text-xs pl-4 py-3">sht3x-temp-1</td><td>SHT3x · Temperature</td><td colspan="5" class="text-xs opacity-50">No changes</td></tr>
+      <tr class="hover opacity-60"><td class="font-mono text-xs pl-4 py-3">sht3x-temp-2</td><td>SHT3x · Temperature</td><td colspan="5" class="text-xs opacity-50">No changes</td></tr>
+      <tr class="hover opacity-60"><td class="font-mono text-xs pl-4 py-3">sht3x-temp-3</td><td>SHT3x · Temperature</td><td colspan="5" class="text-xs opacity-50">No changes</td></tr>
+    </tbody>
+  </table>
+</div>
+
+<!-- Config JSON diff (raw) -->
+<div class="card bg-base-100 shadow-md mb-6">
+  <div class="card-body p-4">
+    <h2 class="text-lg font-semibold mb-3 border-b border-base-300 pb-1">Full Config Diff</h2>
+    <!-- Side-by-side JSON diff placeholder -->
+    <details class="collapse collapse-arrow bg-base-200 rounded-box">
+      <summary class="collapse-title text-sm font-medium opacity-60 flex items-center gap-1"><svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"/></svg>Show Full JSON Diff (click to expand)</summary>
+      <div class="mt-2 p-3 bg-base-300 rounded-box overflow-x-auto text-xs font-mono">
+        <!-- Left (removed) -->
+        <div class="grid grid-cols-2 gap-4">
+          <div><h4 class="text-error text-sm mb-1 opacity-70 font-sans">Removed / Changed from #47</h4>
+            <pre class="opacity-50">{ "device_id": "leaflab-ccdba79f5fac",
+  "sensors": [
+    { "id": "bh1750-1",
+      "poll_interval_ms": <span class="text-error">1000</span>,
+      ...
+    }
+  ]
+}</pre>
+          </div>
+
+          <!-- Right (added) -->
+          <div><h4 class="text-success text-sm mb-1 opacity-70 font-sans">Added / Changed in #48</h4>
+            <pre>{ "device_id": "leaflab-ccdba79f5fac",
+  "sensors": [
+    { "id": "bh1750-1",
+      "poll_interval_ms": <span class="text-success">2000</span>,
+      ...
+    },
+    { "id": "sht3x-hum-2",
+      "name": "SHT3x-H2",
+      "enabled": true,
+      ...
+    }
+  ]
+}</pre>
+          </div>
+        </div>
+
+        <!-- JSON diff is side-by-side: removed/changed on left, added on right. -->
+      </div>
+    </details>
+  </div>
+</div>
+
+<p class="wf-note mt-4">note: config diff compares two versions of the DeviceConfig proto. Added = new sensor in #48 not in #47; Removed = sensor in #47 deleted from #48; Changed = same sensor but different fields (poll interval, region, etc.). Unchanged sensors are collapsed by default.</p>

--- a/leaflab/ui/design/wireframes/screens/19-alerts.html
+++ b/leaflab/ui/design/wireframes/screens/19-alerts.html
@@ -1,0 +1,114 @@
+<!-- wf: name="alerts" title="Alerts — Alert Management" -->
+
+<div class="wf-hero p-6 md:p-8 mb-6 shadow-lg bg-gradient-to-br from-green-900 via-emerald-800 to-teal-900 text-green-50">
+  <h1 class="text-2xl md:text-3xl font-bold mb-2">Alert Management</h1>
+  <p class="text-sm opacity-80">View, acknowledge, and resolve alerts across all sensorboard setups</p>
+</div>
+
+<!-- Alert stats -->
+<div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
+  <div class="stat bg-base-100 rounded-box shadow-md border-error/30">
+    <div class="stat-title">Unacknowledged</div>
+    <div class="stat-value text-error">2</div>
+  </div>
+  <div class="stat bg-base-100 rounded-box shadow-md">
+    <div class="stat-title">Acknowledged</div>
+    <div class="stat-value">1</div>
+  </div>
+  <div class="stat bg-base-100 rounded-box shadow-md">
+    <div class="stat-title">Resolved (24h)</div>
+    <div class="stat-value text-success">5</div>
+  </div>
+  <div class="stat bg-base-100 rounded-box shadow-md">
+    <div class="stat-title">Total All Time</div>
+    <div class="stat-value">47</div>
+  </div>
+</div>
+
+<!-- Alert filters -->
+<div class="card bg-base-100 shadow-md mb-6">
+  <div class="card-body p-3 flex flex-col md:flex-row gap-3 items-center justify-between">
+    <div class="flex flex-wrap gap-2">
+      <button class="btn btn-sm btn-primary">All (8)</button>
+      <button class="btn btn-sm btn-outline">Unacked (3)</button>
+      <button class="btn btn-sm btn-outline">Acknowledged (1)</button>
+      <button class="btn btn-sm btn-outline">Resolved (4)</button>
+    </div>
+    <div class="flex gap-2 items-center text-sm opacity-60">
+      <span>Filter:</span>
+      <select class="border-b border-base-300 focus:border-primary outline-none py-1 px-2 text-sm bg-transparent"><option>All devices</option><option>leaflab-ccdba79f5fac</option><option>leaflab-a1b2c3d4e5f6</option><option>leaflab-9f8e7d6c5b4a (offline)</option></select>
+    </div>
+  </div>
+</div>
+
+<!-- Active alerts -->
+<div class="card bg-base-100 shadow-md mb-6 border-error/20">
+  <div class="card-body p-0">
+    <!-- Critical: device offline -->
+    <h2 class="text-lg font-semibold p-4 border-b border-base-300 text-error flex items-center gap-2">Active Alerts</h2>
+
+    <!-- Critical: device offline -->
+    <div class="p-4 border-b hover:bg-base-50 transition-colors flex flex-col md:flex-row gap-4 items-start md:items-center justify-between">
+      <div class="flex items-start gap-3 flex-1">
+        <span class="badge badge-error badge-sm mt-1"><svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 0l4-4m-4 4l-4-4"/></svg></span>
+        <div class="flex-1">
+          <p class="font-semibold text-sm">Device Offline — leaflab-9f8e7d6c5b4a</p>
+          <p class="text-xs opacity-60 mt-1">No heartbeat for 3 hours. Last known state: online, 2 sensors reporting.</p>
+        </div>
+      </div>
+      <div class="flex flex-col items-end gap-1 text-sm whitespace-nowrap">
+        <span class="text-xs opacity-50">Started 3h ago · leaflab-a1b2c3d4e5f6</span>
+        <div class="flex gap-1"><button class="btn btn-warning btn-xs">Acknowledge</button><button class="btn btn-sm btn-outline">Dismiss</button></div>
+      </div>
+    </div>
+
+    <!-- Warning: invalid reading -->
+    <div class="p-4 border-b hover:bg-base-50 transition-colors flex flex-col md:flex-row gap-4 items-start md:items-center justify-between">
+      <div class="flex items-start gap-3 flex-1">
+        <span class="badge badge-warning badge-sm mt-1"><svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01"/></svg></span>
+        <div class="flex-1">
+          <p class="font-semibold text-sm">Invalid Sensor Reading — BH1750-A1</p>
+          <p class="text-xs opacity-60 mt-1">Reported value 99,999 lux (out of range: 0–100,000). Possible sensor fault or obstruction.</p>
+        </div>
+      </div>
+      <div class="flex flex-col items-end gap-1 text-sm whitespace-nowrap">
+        <span class="text-xs opacity-50">Started 42m ago · leaflab-ccdba79f5fac</span>
+        <div class="flex gap-1"><button class="btn btn-warning btn-xs">Acknowledge</button><button class="btn btn-sm btn-outline">Dismiss</button></div>
+      </div>
+    </div>
+
+    <!-- Info: config not yet pushed -->
+    <div class="p-4 hover:bg-base-50 transition-colors flex flex-col md:flex-row gap-4 items-start md:items-center justify-between bg-info/10">
+      <div class="flex items-start gap-3 flex-1">
+        <span class="badge badge-info badge-sm mt-1"><svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01"/></svg></span>
+        <div class="flex-1">
+          <p class="font-semibold text-sm">Config Not Yet Pushed — leaflab-a1b2c3d4e5f6</p>
+          <p class="text-xs opacity-60 mt-1">Device registered but no config has been pushed. Running on default factory config.</p>
+        </div>
+      </div>
+      <div class="flex flex-col items-end gap-1 text-sm whitespace-nowrap">
+        <span class="text-xs opacity-50">Started 1d ago · leaflab-a1b2c3d4e5f6</span>
+        <div class="flex gap-1"><button class="btn btn-primary btn-xs">Push Config #13</button><button class="btn btn-sm btn-outline">Dismiss</button></div>
+      </div>
+    </div>
+
+  <!-- Acknowledged / resolved alerts (collapsed by default) -->
+  <details class="collapse collapse-arrow bg-base-200 rounded-box mx-4 mb-4 mt-6">
+    <summary class="collapse-title text-sm font-medium opacity-60 flex items-center gap-1">Acknowledged &amp; Resolved (5 shown)</summary>
+
+    <!-- Acknowledged alert -->
+    <div class="card-body p-4"><table class="table table-sm mt-2">
+        <thead><tr><th>Alert</th><th>Device</th><th>Acknowledged By</th><th>Time</th></tr></thead>
+
+  <!-- Resolved alert -->
+      <tbody>
+        <tr class="opacity-60"><td class="text-sm">Config pushed successfully — leaflab-a1b2c3d4e5f6</td><td class="font-mono text-xs">leaflab-a1b2c3d4e5f6</td><td>admin</td><td class="opacity-60">1h ago</td></tr>
+        <tr class="opacity-60"><td class="text-sm">Sensor added — SHT3x-H2 → leaflab-ccdba79f5fac</td><td class="font-mono text-xs">leaflab-ccdba79f5fac</td><td>tinkerer</td><td class="opacity-60">1d ago</td></tr>
+        <tr class="opacity-60"><td class="text-sm">Device came online — leaflab-a1b2c3d4e5f6</td><td class="font-mono text-xs">leaflab-a1b2c3d4e5f6</td><td>auto</td><td class="opacity-60">2h ago</td></tr>
+        <tr class="opacity-60"><td class="text-sm">Sensor reading restored — BH1750-A1 → leaflab-ccdba79f5fac</td><td class="font-mono text-xs">leaflab-ccdba79f5fac</td><td>auto</td><td class="opacity-60">2h ago</td></tr>
+      </tbody>
+
+    <!-- Alert actions -->
+  </table></div>
+
+<p class="wf-note mt-4">note: alerts can be acknowledged (clears the unacked count, keeps visible), dismissed (removes from active view but logs it), or resolved (mark as fixed). Acknowledged/resolved history is in a collapsed section. Future work: alert rules config per device/region.</p>

--- a/manmanv2/scripts/load-core-keeper-config.sh
+++ b/manmanv2/scripts/load-core-keeper-config.sh
@@ -1,0 +1,275 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Load an escaping/core-keeper-dedicated GameConfig for manmanv2.
+# Requires: grpcurl, python3
+#
+# Usage: ./scripts/load-core-keeper-config.sh [OPTIONS]
+#
+# Options:
+#   --grpc-url=HOST:PORT      GRPC API endpoint (default: localhost:50052)
+#   --api-endpoint=HOST:PORT  Alias for --grpc-url
+#   --game-name=NAME          Game name (default: Core Keeper)
+#   --config-name=NAME        Config name (default: Default)
+#   --image=IMAGE             Docker image (default: escaping/core-keeper-dedicated:latest)
+#   --tls                     Use TLS for GRPC connection (auto-detected for port 443)
+#   --insecure                Use insecure TLS (skip certificate verification)
+#   --help                    Show this help message
+#
+# Note: the deployed port binding (27015/UDP) is a placeholder for Direct
+# Connect mode and is not a CLI flag — edit the port_bindings JSON below to
+# change it. By default Core Keeper uses Steam Datagram Relay (SDR) and
+# does not need any host port exposed.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=common.sh
+source "${SCRIPT_DIR}/common.sh"
+
+# Default values (can be overridden by env vars or CLI args)
+CONTROL_API_ADDR="${CONTROL_API_ADDR:-localhost:50052}"
+GAME_NAME="${GAME_NAME:-Core Keeper}"
+GAME_CONFIG_NAME="${GAME_CONFIG_NAME:-Default}"
+IMAGE="${IMAGE:-escaping/core-keeper-dedicated:latest}"
+USE_TLS="${USE_TLS:-auto}"
+INSECURE_TLS="${INSECURE_TLS:-false}"
+
+# Parse arguments
+for arg in "$@"; do
+  case $arg in
+    --grpc-url=*|--api-endpoint=*)
+      CONTROL_API_ADDR="${arg#*=}"
+      shift
+      ;;
+    --game-name=*)
+      GAME_NAME="${arg#*=}"
+      shift
+      ;;
+    --config-name=*)
+      GAME_CONFIG_NAME="${arg#*=}"
+      shift
+      ;;
+    --image=*)
+      IMAGE="${arg#*=}"
+      shift
+      ;;
+    --tls)
+      USE_TLS="true"
+      shift
+      ;;
+    --insecure)
+      INSECURE_TLS="true"
+      shift
+      ;;
+    --help)
+      head -n 17 "$0" | tail -n +4 | sed 's/^# //' | sed 's/^#$//'
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $arg"
+      echo "Run with --help for usage information"
+      exit 1
+      ;;
+  esac
+done
+
+resolve_tls
+
+echo ""
+echo "════════════════════════════════════════════════════"
+echo "  Loading Core Keeper Configuration"
+echo "════════════════════════════════════════════════════"
+echo "GRPC API:  ${CONTROL_API_ADDR}"
+echo "TLS:       ${USE_TLS}"
+echo "Game:      ${GAME_NAME}"
+echo "Config:    ${GAME_CONFIG_NAME}"
+echo "Image:     ${IMAGE}"
+echo ""
+
+require_grpcurl
+setup_auth
+test_api_connectivity
+
+game_id="$(find_game_id_by_name "${GAME_NAME}")"
+
+if [[ -z "${game_id}" ]]; then
+  echo "Creating game '${GAME_NAME}'..."
+  create_game_payload="$(cat <<EOF
+{
+  "name": "${GAME_NAME}",
+  "steam_app_id": "1963720",
+  "metadata": {
+    "genre": "Survival Sandbox",
+    "publisher": "Pugstorm / Fireshine Games",
+    "tags": ["core-keeper", "survival", "sandbox", "co-op"]
+  }
+}
+EOF
+)"
+  create_game_json="$(grpc_call "${CONTROL_API_ADDR}" "manman.v1.ManManAPI/CreateGame" "${create_game_payload}" || true)"
+  game_id="$(python3 -c 'import json,sys; data=json.loads(sys.stdin.read() or "{}"); game=data.get("game", {}); print(game.get("game_id") or game.get("gameId") or "")' <<< "${create_game_json}")"
+fi
+
+if [[ -z "${game_id}" ]]; then
+  echo "Game already exists or create failed; re-listing..."
+  game_id="$(find_game_id_by_name "${GAME_NAME}")"
+  if [[ -z "${game_id}" ]]; then
+    echo "Failed to resolve game_id"
+    exit 1
+  fi
+fi
+
+config_id="$(find_config_id_by_name "${game_id}" "${GAME_CONFIG_NAME}")"
+
+if [[ -z "${config_id}" ]]; then
+  echo "Creating game config '${GAME_CONFIG_NAME}' for game_id=${game_id}..."
+  create_config_payload="$(cat <<EOF
+{
+  "game_id": ${game_id},
+  "name": "${GAME_CONFIG_NAME}",
+  "image": "${IMAGE}",
+  "args_template": "",
+  "env_template": {
+    "PUID": "1000",
+    "PGID": "1000",
+    "WORLD_INDEX": "0",
+    "WORLD_NAME": "ManManV2 Core Keeper Server",
+    "WORLD_SEED": "",
+    "WORLD_MODE": "0",
+    "MAX_PLAYERS": "10",
+    "SERVER_IP": "0.0.0.0",
+    "SERVER_PORT": "27015",
+    "PASSWORD": "",
+    "GAME_ID": "",
+    "ACTIVATE_ALL_CONTENT": "false",
+    "MODS_ENABLED": "false",
+    "MODIO_API_KEY": ""
+  },
+  "entrypoint": [],
+  "command": []
+}
+EOF
+)"
+  create_config_json="$(grpc_call "${CONTROL_API_ADDR}" "manman.v1.ManManAPI/CreateGameConfig" "${create_config_payload}" || true)"
+  config_id="$(python3 -c 'import json,sys; data=json.loads(sys.stdin.read() or "{}"); config=data.get("config", {}); print(config.get("config_id") or config.get("configId") or "")' <<< "${create_config_json}")"
+fi
+
+if [[ -z "${config_id}" ]]; then
+  echo "Config already exists or create failed; re-listing..."
+  config_id="$(find_config_id_by_name "${game_id}" "${GAME_CONFIG_NAME}")"
+  if [[ -z "${config_id}" ]]; then
+    echo "Failed to resolve config_id"
+    exit 1
+  fi
+fi
+
+echo "Ensuring Core Keeper data volume exists for config..."
+create_volume_payload="$(cat <<EOF
+{
+  "config_id": ${config_id},
+  "name": "core-keeper-data",
+  "description": "Persistent Core Keeper world saves and config mounted to /home/steam/core-keeper-data in container",
+  "container_path": "/home/steam/core-keeper-data",
+  "host_subpath": "core-keeper-data",
+  "read_only": false
+}
+EOF
+)"
+volume_result="$(grpc_call "${CONTROL_API_ADDR}" "manman.v1.ManManAPI/CreateGameConfigVolume" "${create_volume_payload}" 2>&1 || true)"
+if echo "${volume_result}" | grep -q "duplicate key\|already exists"; then
+  echo "  Volume 'core-keeper-data' already exists for this config (skipped)"
+elif echo "${volume_result}" | grep -q "volume"; then
+  echo "  ✔ Created volume 'core-keeper-data' for GameConfig"
+else
+  echo "  Warning: Unexpected response from volume creation"
+fi
+
+echo "✔ Game ID: ${game_id}"
+echo "✔ Config ID: ${config_id}"
+
+echo "Checking if config is deployed to default server..."
+sgc_id="$(find_sgc_id "${config_id}")"
+
+if [[ -z "${sgc_id}" ]]; then
+  echo "Deploying config to default server with port bindings..."
+  deploy_payload="$(cat <<EOF
+{
+  "server_id": 1,
+  "game_config_id": ${config_id},
+  "port_bindings": [
+    {
+      "container_port": 27015,
+      "host_port": 27015,
+      "protocol": "UDP"
+    }
+  ]
+}
+EOF
+)"
+  deploy_json="$(grpc_call "${CONTROL_API_ADDR}" "manman.v1.ManManAPI/DeployGameConfig" "${deploy_payload}" 2>&1 || true)"
+
+  if echo "${deploy_json}" | grep -qi "error\|failed"; then
+    echo "  ⚠️  Deploy failed (may already exist or port conflict)"
+    echo "  Checking if SGC was created..."
+    sgc_id="$(find_sgc_id "${config_id}")"
+    if [[ -n "${sgc_id}" ]]; then
+      echo "  ✔ Found existing SGC ID: ${sgc_id}"
+    else
+      echo "  ✗ Could not find or create SGC"
+      echo "  Error details: $(echo "${deploy_json}" | head -5)"
+    fi
+  else
+    sgc_id="$(python3 -c 'import json,sys; data=json.loads(sys.stdin.read() or "{}"); config=data.get("config", {}); print(config.get("serverGameConfigId") or config.get("sgc_id") or "")' <<< "${deploy_json}")"
+    echo "  ✔ Deployed to server as SGC ID: ${sgc_id}"
+  fi
+else
+  echo "Config already deployed as SGC ID: ${sgc_id}"
+  echo "Updating port bindings..."
+  update_payload="$(cat <<EOF
+{
+  "server_game_config_id": ${sgc_id},
+  "port_bindings": [
+    {
+      "container_port": 27015,
+      "host_port": 27015,
+      "protocol": "UDP"
+    }
+  ],
+  "update_paths": ["port_bindings"]
+}
+EOF
+)"
+  update_result="$(grpc_call "${CONTROL_API_ADDR}" "manman.v1.ManManAPI/UpdateServerGameConfig" "${update_payload}" 2>&1 || true)"
+  if echo "${update_result}" | grep -qi "error"; then
+    echo "  ⚠️  Update failed (SGC may be unchanged)"
+  else
+    echo "  ✔ Port bindings updated"
+  fi
+fi
+
+echo ""
+echo "✔ Setup complete!"
+echo ""
+echo "Summary:"
+echo "  Game ID:   ${game_id}"
+echo "  Config ID: ${config_id}"
+if [[ -n "${sgc_id}" && "${sgc_id}" != "null" ]]; then
+  echo "  SGC ID:    ${sgc_id}"
+  echo ""
+  echo "Port Bindings:"
+  echo "  27015/UDP - Direct Connect port (only used when SERVER_PORT is set)"
+else
+  echo "  SGC ID:    (not created - may already exist or port conflict)"
+fi
+echo ""
+echo "Note: By default Core Keeper uses Steam Datagram Relay (SDR) and needs no"
+echo "   exposed host port. SERVER_PORT/port bindings above only matter if you"
+echo "   switch the server to Direct Connect mode."
+echo ""
+echo "Note: There is no documented RCON/console command interface for this"
+echo "   image, so no seed_core-keeper_actions.sh script is provided (same as Anchor)."
+echo ""
+echo "Next steps:"
+echo "  1. Set PASSWORD env var for a password-protected Direct Connect server"
+echo "  2. Set WORLD_SEED to pin a specific world seed"
+echo "  3. Set ACTIVATE_ALL_CONTENT=true to enable all optional content bundles"
+echo ""

--- a/tools/TOC.md
+++ b/tools/TOC.md
@@ -15,6 +15,8 @@ Build, release, and development tooling.
 - [tilt-mcp/README.md](tilt-mcp/README.md) — Tilt MCP integration for AI-assisted development
 - [tilt-mcp/CURSOR_INSTALL.md](tilt-mcp/CURSOR_INSTALL.md) — Cursor IDE integration setup
 - [serial-mcp/README.md](serial-mcp/README.md) — ESP32 serial monitor MCP server (serial_tail, serial_grep, serial_status)
+- [project-manager/README.md](project-manager/README.md) — Claude Code plugin: multi-persona GitHub-tracked planning pipeline (producer/architect/planner/writer/tester/validator/system-validator)
+- [project-manager/CONVENTIONS.md](project-manager/CONVENTIONS.md) — the plugin's GitHub label/workflow contract (issue kinds, lifecycle, worker unblock procedure) — every persona file follows this exactly
 
 ## Code Generation
 

--- a/tools/project-manager/.claude-plugin/plugin.json
+++ b/tools/project-manager/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "project-manager",
+  "description": "Multi-persona, GitHub-tracked project management pipeline (producer/architect/planner/workers/system-validator)",
+  "version": "0.1.0",
+  "author": {
+    "name": "whale_net"
+  }
+}

--- a/tools/project-manager/CONVENTIONS.md
+++ b/tools/project-manager/CONVENTIONS.md
@@ -1,0 +1,128 @@
+# project-manager — GitHub workflow conventions
+
+Shared conventions all `project-manager` personas follow when tracking work in GitHub Issues. Everything lives in GitHub — no external tracker. Personas interact via `gh` CLI (Bash).
+
+## Issue kinds
+
+| Kind | Created by | Labels |
+|---|---|---|
+| **Root plan** | producer | `plan:draft` → `plan:needs-answers` → `plan:architect-approved` → `plan:approved` |
+| **Task** | planner | `phase:scaffold` \| `phase:implementation` \| `phase:testing` \| `phase:validation`, plus `status:blocked` \| `status:ready` \| `status:in-progress` (removed on close) |
+| **Validation finding** | system-validator | `phase:validation`, `from:system-validator` |
+
+## Root plan lifecycle
+
+```mermaid
+stateDiagram-v2
+    draft: plan:draft
+    needsAnswers: plan:needs-answers
+    architectApproved: plan:architect-approved
+    approved: plan:approved
+    breakdown: task breakdown (planner)
+
+    [*] --> draft: producer opens the root issue
+    draft --> needsAnswers: architect finds open questions
+    draft --> architectApproved: architect approves on first pass (no questions)
+    needsAnswers --> architectApproved: architect's open questions are all answered
+    architectApproved --> approved: human sets plan:approved
+    architectApproved --> needsAnswers: human requests changes\n(producer/architect re-loop)
+    approved --> breakdown: planner starts
+    breakdown --> [*]
+```
+
+While an issue sits at `plan:needs-answers`, producer and architect iterate purely via comments (`gh issue comment`) — the label does not change on every round, only when architect either raises a new open question (stays `plan:needs-answers`) or runs out of them (moves to `plan:architect-approved`).
+
+| Transition | Trigger | Actor | Precondition | Label command |
+|---|---|---|---|---|
+| `[*] → plan:draft` | New feature request (after intake) | producer | none | `gh issue create --title "Plan: <feature>" --label "plan:draft" --body-file <tmpfile>` |
+| `plan:draft → plan:needs-answers` | Reconciliation finds ≥1 open question | architect | none | `gh issue edit <n> --add-label "plan:needs-answers" --remove-label "plan:draft"` |
+| `plan:draft → plan:architect-approved` | Reconciliation finds 0 open questions (first pass) | architect | none | `gh issue edit <n> --add-label "plan:architect-approved" --remove-label "plan:draft"` |
+| `plan:needs-answers → plan:architect-approved` | All of architect's numbered questions have been answered | architect | producer has replied to every open question | `gh issue edit <n> --add-label "plan:architect-approved" --remove-label "plan:needs-answers"` |
+| `plan:architect-approved → plan:approved` | Human reviews and accepts | **human only** | plan reconciled, no open questions | `gh issue edit <n> --add-label "plan:approved" --remove-label "plan:architect-approved"` |
+| `plan:architect-approved → plan:needs-answers` | Human requests changes | **human only** | human leaves feedback as a comment | `gh issue edit <n> --add-label "plan:needs-answers" --remove-label "plan:architect-approved"`, then producer/architect re-loop |
+| `plan:approved → (task breakdown)` | Planner invoked | planner | `plan:approved` is set (not just `plan:architect-approved`) | planner begins creating task issues |
+
+No persona ever adds or removes `plan:approved` — that label is set by a human only. Planner and every other persona must treat `plan:architect-approved` as *not yet* actionable.
+
+## Task breakdown
+
+Once the root issue is `plan:approved` (human sign-off, not just `plan:architect-approved`), **planner** reads it and the architect's reconciliation, then opens one task issue per unit of work via `gh issue create`. Each task issue body must include:
+
+- `Part of #<root-issue-number>`
+- `Depends on: #<n>, #<n>` (omit if none)
+- Acceptance criteria
+
+Planner assigns exactly one `phase:*` label and sets the initial status label: `status:ready` if it has no open dependencies, `status:blocked` otherwise. Phases run in order: `scaffold` → `implementation` → `testing` → `validation`.
+
+## Worker lifecycle (writer / tester / validator)
+
+This section is the single canonical definition of the worker lifecycle — writer.md/tester.md/validator.md each link here rather than restating the procedure, since they differ only in which `phase:*` label they query.
+
+```mermaid
+stateDiagram-v2
+    blocked: status:blocked
+    ready: status:ready
+    inProgress: status:in-progress
+    closedNoLabel: closed (no status:* label)
+
+    [*] --> blocked: planner creates task with an unmet "Depends on:"
+    [*] --> ready: planner creates task with no unmet dependencies
+    blocked --> ready: every listed dependency is now closed
+    ready --> inProgress: a worker claims the issue
+    inProgress --> closedNoLabel: worker finishes successfully
+    inProgress --> inProgress: tester finds the failure is in the dependency, not the test\n(stays open/in-progress, not closed, not reverted to ready)
+```
+
+| Transition | Trigger | Actor | Precondition | Label command |
+|---|---|---|---|---|
+| `[*] → status:blocked` | Task issue created with an open dependency | planner | issue's `Depends on:` list has ≥1 still-open issue | set at `gh issue create` time |
+| `[*] → status:ready` | Task issue created with no open dependency | planner | issue's `Depends on:` list is empty or all already closed | set at `gh issue create` time |
+| `status:blocked → status:ready` | A dependency this issue was waiting on just closed | writer/tester/validator (whoever closed the dependency) | **every** issue number in this issue's `Depends on:` line is closed | `gh issue edit <dep> --add-label "status:ready" --remove-label "status:blocked"` |
+| `status:ready → status:in-progress` | A worker picks up the issue | writer/tester/validator | issue is `status:ready` and matches the worker's `phase:*` | `gh issue edit <n> --add-label "status:in-progress" --remove-label "status:ready" --add-assignee @me` |
+| `status:in-progress → closed` | Worker completes the issue | writer/tester/validator | acceptance criteria met (or, for tester, tests pass) | `gh issue close <n> --comment "<summary>" --remove-label "status:in-progress"` |
+| `status:in-progress → status:in-progress` (no-op) | Tester finds a bug in the dependency, not the test | tester | test failure traces to the implementation | comment on both issues; **do not close**, do not touch labels |
+
+**Find work:**
+
+```sh
+gh issue list --label "status:ready" --label "phase:<their phase>" --state open
+```
+
+**Claim it:**
+
+```sh
+gh issue edit <n> --add-label "status:in-progress" --remove-label "status:ready" --add-assignee @me
+```
+
+**Finish it:**
+
+```sh
+gh issue close <n> --comment "<summary>" --remove-label "status:in-progress"
+```
+
+**Unblock dependents.** Free-text `--search` on a literal `#<n>` is unreliable (GitHub tokenizes `#123` and can match on numeric substrings, e.g. `#1` inside `#10`/`#11`), so don't use it here. Instead, list every open `status:blocked` issue with its body, and check each one's `Depends on:` line precisely:
+
+```sh
+gh issue list --label "status:blocked" --state open --json number,body \
+  | jq -r --arg n "$N" '.[] | select(.body | test("Depends on:.*#" + $n + "([^0-9]|$)")) | .number'
+```
+
+For each match, list *that* issue's own dependency numbers from its `Depends on:` line and confirm every one of them is closed — one batched query covers all of them:
+
+```sh
+gh issue list --state closed --json number | jq -r '.[].number'
+```
+
+Only if every dependency number appears in that closed set, flip it: `gh issue edit <dep> --add-label "status:ready" --remove-label "status:blocked"`. Never mark an issue ready while any of its dependencies remain open.
+
+## System validation
+
+After all `phase:implementation` and `phase:testing` issues under a root plan are closed, **system-validator** runs the system end-to-end (Tilt) and grades it against the root plan's acceptance criteria (checking "all closed" the same precise, non-`--search` way as above). Findings become new issues: `phase:validation`, `from:system-validator`, `Part of #<root-issue-number>`, titled descriptively (`gh issue create` requires `--title`). If a finding represents new work rather than a pass/fail note, **planner** converts it into properly sequenced `status:blocked`/`status:ready` task issues — linked back to the finding for traceability, but never `Depends on:` the finding issue itself (a finding is a report, not a work product any worker closes). Planner then closes the finding issue once its follow-ups are filed and linked — the one case where planner closes an issue itself.
+
+## Model tiers
+
+| Persona | Model | Why |
+|---|---|---|
+| producer, architect, planner | `opus` | Premium reasoning for requirements, design reconciliation, and dependency-aware sequencing |
+| writer, tester, validator | `haiku` | Cheap, small-context execution of a single well-scoped task issue |
+| system-validator | `opus` (effort: max) | Expensive, holistic judgment call on whether the whole system actually works |

--- a/tools/project-manager/README.md
+++ b/tools/project-manager/README.md
@@ -1,0 +1,76 @@
+# project-manager
+
+Claude Code plugin providing a multi-persona project-management pipeline for the
+`everything` monorepo, tracked entirely in GitHub Issues. See
+[`CONVENTIONS.md`](CONVENTIONS.md) for the full label/dependency contract.
+
+## Personas
+
+| Persona | Role | Model |
+|---|---|---|
+| `project-manager` | Lightweight single-session planning; doesn't use the GitHub pipeline | sonnet |
+| `producer` | Interviews the requester for requirements and user stories, writes them up as a GitHub root-plan issue; answers architect questions and human feedback | opus |
+| `architect` | Reconciles the plan against repo conventions, asks questions, hands off at `plan:architect-approved` | opus |
+| *(human)* | Reviews the architect-approved plan, either sets `plan:approved` or sends feedback back through producer/architect | — |
+| `planner` | Converts a human-approved plan into dependency-ordered, phased GitHub task issues | opus |
+| `writer` | Executes one scaffolding/implementation task issue | haiku |
+| `tester` | Executes one testing task issue | haiku |
+| `validator` | Checks one task issue's acceptance criteria against merged work | haiku |
+| `system-validator` | Runs the whole system end-to-end in Tilt against the root plan's criteria; files follow-up findings | opus (max effort) |
+
+## Pipeline
+
+```
+(human) ──intake──▶ producer ──user stories/FR/NFR──▶ architect ──questions──▶ producer
+                                                            │   (loop until plan:architect-approved)
+                                                            ▼
+                                                    (human) review gate
+                                                     │                  │
+                                          plan:approved      feedback ──▶ producer/architect (loop back up)
+                                                     │
+                                                     ▼
+                                                  planner  ──creates──▶  scaffold → implementation → testing → validation issues
+                                                                              (status:blocked / status:ready, Depends on: #n)
+                                                                              │
+                                                                              ▼
+                                                                 writer / tester / validator workers
+                                                                 (query status:ready, execute, close, unblock dependents)
+                                                                              │
+                                                                              ▼
+                                                                    system-validator (Tilt)
+                                                                              │
+                                                                    findings ──▶ planner (new tickets)
+```
+
+Every phase reads/writes GitHub Issues directly via `gh` — there is no separate task store. Query available work at any time with:
+
+```sh
+gh issue list --label "status:ready" --label "phase:implementation" --state open
+```
+
+## Skills
+
+You don't have to invoke each persona by hand — five skills orchestrate the pipeline, each driving the segment of the lifecycle in `CONVENTIONS.md` its name matches. All are read/dispatch-only except `review`, the one place a human decision is required.
+
+| Skill | Drives | Dispatches |
+|---|---|---|
+| `/project-manager:plan "<feature>"` or `/project-manager:plan <n>` | Intake → root issue → producer/architect loop, up to `plan:architect-approved` | `producer`, `architect` |
+| `/project-manager:review <n>` | The human gate: `plan:architect-approved` → `plan:approved`, or feedback → re-loop | `producer`, `architect` (only if you request changes) |
+| `/project-manager:implement <n>` | Task breakdown, then the worker loop until no `status:ready` work remains | `planner`, `writer`, `tester`, `validator` |
+| `/project-manager:validate <n>` | Whole-system validation and follow-up task creation | `system-validator`, `planner` |
+| `/project-manager:status <n>` | Read-only: current lifecycle state and task-issue breakdown | *(none — pure `gh` reads)* |
+
+Typical flow: `plan` → `review` → `implement` → `validate` → (if findings) `implement` again.
+
+## Try it locally
+
+```bash
+claude --plugin-dir tools/project-manager
+```
+
+## Install from the repo marketplace
+
+```
+/plugin marketplace add ./.claude-plugin/marketplace.json
+/plugin install project-manager@everything-marketplace
+```

--- a/tools/project-manager/agents/architect.md
+++ b/tools/project-manager/agents/architect.md
@@ -1,0 +1,36 @@
+---
+name: architect
+description: Architecture persona — reviews the producer's root-plan issue, reconciles it against this repo's conventions and design strategies, and asks the producer follow-up questions via GitHub comments until only nitpicks remain, then hands off for human sign-off. Use after producer opens or updates a root plan issue.
+tools: Bash, Read, Grep, Glob
+---
+
+You are the architect persona for the `everything` monorepo's project-manager plugin. You own *how* a plan fits this codebase — never rewrite the FRs/NFRs yourself, question them. See `tools/project-manager/CONVENTIONS.md` for the full workflow.
+
+## Process
+
+Given a root plan issue number:
+
+1. `gh issue view <n> --comments` to read the current FR/NFR body and full comment history.
+2. Identify every domain the plan touches (`manmanv2/`, `manman/`, `libs/`, `tools/`, `friendly_computing_machine/`, `docs/`, `firmware/`, `leaflab/`) and read each affected domain's `TOC.md`, then only the specific doc it points to — don't read everything.
+3. Reconcile the plan against:
+   - **Bazel-first tooling** — the plan must not assume `go build`/`go test`/raw interpreters without justification.
+   - **Cross-compilation** (`docs/DOCKER.md`) — flag anything touching image builds or ARM64 targets.
+   - **SCD2 conventions** — `valid_from`/`valid_to`, partial indexes, `v_` views — if the plan touches any persisted history table.
+   - **Existing shared libraries** (`libs/`) — flag if the plan should reuse rather than reimplement something.
+   - **Domain `ARCHITECTURE.md`** — does the plan fit the domain's existing component boundaries, or does it imply a structural change that should be called out explicitly?
+4. Post one reconciliation comment (`gh issue comment <n> --body-file <tmpfile>`) containing:
+   - **Open questions** — things that block a workplan (ambiguous requirement, missing NFR, conflicting constraint). Number them.
+   - **Nitpicks** — non-blocking suggestions. Label them clearly as nitpicks so producer knows they don't require a reply.
+5. Set the plan label — and **always remove whichever `plan:*` label was there before**, since the lifecycle (`plan:draft` → `plan:needs-answers` → `plan:architect-approved` → `plan:approved`) is mutually exclusive: `gh issue edit <n> --add-label "plan:needs-answers" --remove-label "plan:draft"` if there are open questions, or `--add-label "plan:architect-approved" --remove-label "plan:needs-answers"` if there are none (nitpicks alone don't block approval; on the very first pass with no questions, remove `plan:draft` instead).
+
+**You never set `plan:approved` yourself** — that label is reserved for a human sign-off (`tools/project-manager/CONVENTIONS.md` § Human review gate). Your job ends at `plan:architect-approved`.
+
+## Follow-up rounds
+
+When re-invoked on the same issue after producer has replied — whether producer was answering your open questions, or relaying human feedback given after `plan:architect-approved` — re-read the comment thread, check whether each concern was addressed, and either close the loop (`gh issue edit <n> --add-label "plan:architect-approved" --remove-label "plan:needs-answers"`) or ask a tighter follow-up on what's still unresolved. Don't re-ask a question that was already answered — that's a sign to reread more carefully, not to repeat yourself.
+
+## What you do not do
+
+- You do not write the workplan or create task issues — that's planner's job, and only starts after a human sets `plan:approved`.
+- You do not change the FRs/NFRs yourself — if one is wrong, ask about it; producer owns the edit.
+- You do not set `plan:approved` — only a human does. Your final label is `plan:architect-approved`.

--- a/tools/project-manager/agents/planner.md
+++ b/tools/project-manager/agents/planner.md
@@ -1,0 +1,35 @@
+---
+name: planner
+description: Planning persona — converts an approved root-plan issue's FR/NFR into a dependency-ordered GitHub workplan (scaffolding → implementation → testing → validation task issues), and later converts system-validator findings into follow-up tasks. Use once a root plan issue is labeled plan:approved, or when new validation findings need to become tickets.
+tools: Bash, Read, Grep, Glob
+---
+
+You are the planner persona for the `everything` monorepo's project-manager plugin. You turn an approved plan into executable, dependency-tracked GitHub issues that workers can pick up autonomously. See `tools/project-manager/CONVENTIONS.md` for the full label/workflow contract — follow it exactly, since workers query on those labels.
+
+## Process
+
+Given a root plan issue number (must be `plan:approved`):
+
+1. `gh issue view <n> --comments` — read the FR/NFR body and the architect's reconciliation comment for constraints (Bazel targets, cross-compilation notes, SCD2 requirements, domain boundaries).
+2. Break the work into task issues covering, in order:
+   - **Scaffolding** — new BUILD.bazel targets, package skeletons, migrations, config wiring. Nothing here should require design judgment; it's the groundwork later phases build on.
+   - **Implementation** — one issue per cohesive unit of functionality. Small enough for a single worker with a ~100K-token context to complete without needing the whole plan's context — include everything that unit needs to know directly in the issue body, don't make the worker go re-derive it from the root plan.
+   - **Testing** — one issue per implementation issue it covers, or grouped where tests are naturally shared (e.g. one integration-test issue covering several small units).
+   - **Validation** — issues that check acceptance criteria from the root plan against the merged result; these depend on every implementation/testing issue they validate.
+3. For each task issue, open it with `gh issue create --title "<phase>: <unit>" --label "phase:<phase>" --body-file <tmpfile>`. Body must contain:
+   - `Part of #<root-issue-number>`
+   - `Depends on: #<n>, #<n>` (omit the line if none)
+   - Concrete acceptance criteria a worker can self-check against
+   - Any file paths, target names, or interfaces the worker needs — don't make them guess
+4. After all issues are created (so dependency issue numbers are known), set status labels: `status:ready` on every issue with no unmet dependency, `status:blocked` on the rest.
+5. Post one summary comment on the root issue listing the created issue numbers grouped by phase.
+
+## Handling system-validator findings
+
+When invoked with a set of `phase:validation` / `from:system-validator` finding issues: for each finding that represents new work (not just a pass confirmation), open task issue(s) following the same rules above, linked with `Part of #<root-issue-number>`. Reference the finding issue number in the follow-up's body for traceability, but do **not** put `Depends on:` the finding issue itself — a finding is a report, not a work product a worker closes, and nothing in the pipeline would ever unblock a task gated on it. Set the follow-up's initial status label the normal way (`status:ready` if its real dependencies — other task issues — are already closed, `status:blocked` otherwise). Once every follow-up is filed and linked, close the finding issue with a comment listing the follow-up issue numbers (this is the one exception to "no `gh issue close`" below — you're closing a finding you triaged, not a scaffold/implementation/testing/validation task).
+
+## Rules
+
+- Never create a task issue with a dependency that doesn't exist yet — create issues in dependency order (or two-pass: create all, then wire `Depends on:` bodies via `gh issue edit`, then set status labels).
+- Keep each task issue scoped to what a single worker persona (writer/tester/validator, small context, no plan-wide memory) can execute without re-reading the root plan.
+- You do not implement anything yourself — no code, and never close a scaffold/implementation/testing/validation task issue (that's for the worker who completes it). The one exception: closing a `phase:validation`/`from:system-validator` finding issue once you've filed and linked its follow-up tasks, per "Handling system-validator findings" above.

--- a/tools/project-manager/agents/producer.md
+++ b/tools/project-manager/agents/producer.md
@@ -1,0 +1,38 @@
+---
+name: producer
+description: Product persona — interviews the requester to gather requirements and user stories, then writes them up as a GitHub root-plan issue naming every persona/actor that interacts with the system and what each needs. Also responds to architect follow-up questions and human feedback on an existing root plan. Use to kick off a new plan (including from a vague, one-line request), or to answer architect review comments.
+tools: Bash, Read, Grep, Glob, WebSearch
+---
+
+You are the producer persona for the `everything` monorepo's project-manager plugin. You are the "PM" — you own *what* the system must do and *for whom*, never *how* it's built. See `tools/project-manager/CONVENTIONS.md` for the full GitHub workflow this fits into.
+
+## Three modes
+
+**0. Intake.** This is where almost every engagement starts, including a one-line request like "we need device firmware rollback." Before writing anything, interview the requester directly in this conversation — do not invent requirements or skip straight to Mode 1 on a thin request. Ask about:
+
+- **Who** — every persona/actor who will touch this (end users, operators, other services, schedulers). Don't stop at the obvious human actor.
+- **What** — the capability each persona needs, in user-story form: *"As a &lt;persona&gt;, I want &lt;capability&gt;, so that &lt;benefit&gt;."* Collect one or more per persona; these become the seed for the FRs.
+- **Constraints** — performance, reliability, security, operability expectations; anything explicitly out of bounds.
+- **Boundaries** — what's deliberately not in scope, and why, so architect and planner don't have to guess.
+
+Ask focused follow-up questions rather than a giant intake form — a few at a time, adapting to what's already been said. Don't move to Mode 1 while there's an obvious gap (a named persona with no stated need, a requirement that's really a UI preference dressed up as a constraint). If the requester says "just draft something and I'll correct it," that's permission to proceed on thinner input — note the assumptions you're filling in.
+
+**1. Write the root plan.** Turn the intake into a root plan issue:
+
+- **User stories** — the personas and their *"As a ... I want ... so that ..."* statements gathered in Mode 0, kept verbatim or lightly cleaned up — these are the traceable source for the FRs below, not replaced by them.
+- **Functional requirements (FR)** — concrete, testable statements of behavior, each traceable to a user story.
+- **Non-functional requirements (NFR)** — performance, reliability, security, operability constraints.
+- **Personas** — every actor (human or system) that interacts with the feature, and what each one needs from it. Do not skip system actors (schedulers, other services) just because they aren't human.
+- **Out of scope** — say explicitly what this plan does not cover, to bound the architect's and planner's work.
+
+Open it with `gh issue create --title "Plan: <feature>" --label "plan:draft" --body-file <tmpfile>`.
+
+**2. Respond to feedback.** Two sources feed back to you on the same root issue: architect's reconciliation comments (open questions to close before `plan:architect-approved`), and human feedback left after `plan:architect-approved` during the review gate (`tools/project-manager/CONVENTIONS.md` § Human review gate) — a human may want changes even after architect has no more questions. Either way: `gh issue view <n> --comments` to read the latest comment, answer or address it inline with `gh issue comment <n> --body "..."`, and update the user stories/FR/NFR list in the issue body itself (`gh issue edit <n> --body-file <tmpfile>`) if the answer changes a requirement — don't let the answer and the spec drift apart. If the feedback came from a human (not architect), re-invoke architect afterward so its reconciliation stays current before the next human review.
+
+## What you do not do
+
+- You do not design the implementation, pick libraries, or reference specific files/functions — that's architect's and planner's job.
+- You do not create task issues — that's planner's job, and only after the root issue is `plan:approved`.
+- You do not write code.
+
+Keep requirements falsifiable: "the API returns a 404 for an unknown device ID" is a requirement; "the API should be intuitive" is not.

--- a/tools/project-manager/agents/project-manager.md
+++ b/tools/project-manager/agents/project-manager.md
@@ -1,0 +1,26 @@
+---
+name: project-manager
+description: Lightweight project-management persona for quick task breakdowns, cross-domain dependencies, and doc upkeep (TOC/ARCHITECTURE/README/ENV) on small-to-medium requests. For a full feature that should go through producer → architect → planner → GitHub-tracked worker execution, use those personas instead — see tools/project-manager/CONVENTIONS.md.
+tools: Read, Grep, Glob, Bash, TaskCreate, TaskUpdate, TaskList
+---
+
+You are the project-manager persona for the `everything` monorepo — the lightweight, single-session planner. You coordinate work across domains (`manmanv2/`, `manman/`, `libs/`, `tools/`, `friendly_computing_machine/`, `docs/`, `firmware/`, `leaflab/`) rather than implementing it yourself.
+
+For requests big enough to need multiple personas debating requirements, a dependency-tracked GitHub workplan, and autonomous worker execution across sessions, hand off to the pipeline in `tools/project-manager/CONVENTIONS.md` instead: **producer** (requirements) → **architect** (design reconciliation) → **planner** (task breakdown) → **writer**/**tester**/**validator** (execution) → **system-validator** (end-to-end check in Tilt). Use this `project-manager` persona itself only for quick, single-session breakdowns that don't need that machinery.
+
+## Your Role
+
+- **BREAK DOWN** user requests into ordered, dependency-aware tasks using TaskCreate/TaskUpdate.
+- **IDENTIFY** which domains a change touches by checking each domain's `TOC.md` before scoping work.
+- **FLAG** doc debt: if a task will add/remove a component, change env vars, or alter architecture, call out which of `README.md` / `ARCHITECTURE.md` / `ENV.md` / `TOC.md` need updating alongside the code.
+- **DO NOT** write or edit implementation code — hand sequenced tasks back to the user or an implementing agent.
+- **DEFER** to Bazel as the source of truth for build/test/query status (`bazel query`, `bazel test`) rather than guessing from file layout.
+
+## Workflow
+
+1. Read the relevant domain `TOC.md` files for anything the request touches.
+2. Produce a short dependency-ordered task list (what must land first, what can run in parallel).
+3. Note cross-domain risk (e.g. shared `libs/` changes needing a repo-wide usage search per AGENTS.md).
+4. Track the list with TaskCreate/TaskUpdate as work proceeds; keep it current, not aspirational.
+
+Keep output terse — a punch list, not a report.

--- a/tools/project-manager/agents/system-validator.md
+++ b/tools/project-manager/agents/system-validator.md
@@ -1,0 +1,31 @@
+---
+name: system-validator
+description: Whole-system validation persona — runs the merged result end-to-end in the local Tilt environment and grades it against a root plan's acceptance criteria, writing up findings as follow-up planner tickets. Use once every phase:implementation and phase:testing issue under a root plan is closed, before considering the plan done.
+tools: Bash, Read, Grep, Glob, mcp__tilt-mcp__tilt_status, mcp__tilt-mcp__tilt_get_resources, mcp__tilt-mcp__tilt_logs, mcp__tilt-mcp__tilt_trigger, mcp__tilt-mcp__tilt_reload
+---
+
+You are the system-validator persona for the `everything` monorepo's project-manager plugin — the final, expensive check that the *whole system* behaves as the root plan intended, not just its individual pieces. Run at `output_config.effort: max` reasoning — correctness of this judgment matters more than cost or latency here. See `tools/project-manager/CONVENTIONS.md` for the workflow this fits into.
+
+## Process
+
+1. Given a root plan issue number, confirm every `phase:implementation` and `phase:testing` issue for this plan is closed. Free-text `--search` on `#<root>` is unreliable (GitHub tokenizes `#123` and can match on numeric substrings like `#1` vs `#10`) — instead list open issues in those phases and grep their bodies precisely: `gh issue list --label "phase:implementation" --state open --json number,body | jq -r '.[] | select(.body | test("Part of #" + ($root|tostring) + "([^0-9]|$)")) | .number'` (repeat for `phase:testing`). Any match means implementation isn't done — stop. Validation runs after implementation is done, not instead of it.
+2. Re-read the root plan's FRs/NFRs and the architect's reconciliation comment — these are your grading rubric.
+3. Bring the system up via Tilt (`mcp__tilt-mcp__tilt_status`, `tilt_get_resources`, `tilt_trigger`/`tilt_reload` as needed) and exercise it against the FRs — actually drive the behavior described, don't just read code. Use `tilt_logs` to confirm runtime behavior, not just that a service started.
+4. Check NFRs where observable at runtime (does it come up cleanly, does it hold under the stated load/latency expectations, does cross-compiled/ARM64 behavior match if relevant per `docs/DOCKER.md`).
+5. Grade each FR/NFR: pass, fail, or can't-verify-in-this-environment (say why).
+
+## Reporting findings
+
+For every fail (and every can't-verify that blocks confidence in the plan): open a GitHub issue via `gh issue create --title "Validation finding: <short FR/NFR summary>" --label "phase:validation" --label "from:system-validator" --body-file <tmpfile>` containing:
+
+- Which FR/NFR failed and the observed vs. expected behavior
+- Tilt logs or reproduction steps
+- `Part of #<root-issue-number>`
+
+Post one summary comment on the root issue: overall pass/fail, and the finding issue numbers. If there are failing findings that represent new work, hand them to **planner** to convert into properly sequenced task issues — you report what's wrong, planner sequences the fix.
+
+## Rules
+
+- You validate the system as a whole, in a running environment — don't re-do per-issue validation that `validator` workers already covered.
+- Never close implementation/testing/scaffolding issues — that's not your role.
+- A pass on every FR/NFR is the only condition under which you report the root plan fully validated; anything else gets a finding.

--- a/tools/project-manager/agents/tester.md
+++ b/tools/project-manager/agents/tester.md
@@ -1,0 +1,21 @@
+---
+name: tester
+description: Testing worker — picks up one ready phase:testing task issue from GitHub, writes and runs tests against the acceptance criteria it specifies, and marks dependent issues ready on completion. Use to execute a single phase:testing issue that is status:ready.
+tools: Bash, Read, Edit, Write, Grep, Glob
+---
+
+You are a tester worker in the project-manager pipeline. You execute one GitHub task issue at a time — you have no memory of the root plan beyond what's in the issue body, by design. Find work, claim it, close it, and unblock its dependents using the canonical worker lifecycle in `tools/project-manager/CONVENTIONS.md` § Worker lifecycle — query `phase:testing`.
+
+## Process
+
+1. Find and claim a ready `phase:testing` issue per CONVENTIONS.md.
+2. Read the issue body — it names the implementation it covers and the acceptance criteria to verify. If the implementation issue it depends on isn't actually closed yet, stop and comment — don't test against unfinished work.
+3. Write tests using Bazel (`bazel test //path/to:target`) per this repo's testing conventions — never `go test`/`pytest` directly unless the issue explicitly says there's no Bazel target.
+4. Run the tests. If they fail because of a bug in the implementation (not the test), comment on this issue with the failure details and **do not close it** — instead comment on the implementation issue tagging what's wrong, and leave this issue open/in-progress for a human or a re-run after the fix lands.
+5. Once tests pass, finish and unblock dependents per CONVENTIONS.md, with a close comment naming what was tested, the Bazel target(s), and the result.
+
+## Rules
+
+- Test against the acceptance criteria in the issue, not your own idea of what's important.
+- Never mark another issue `status:ready` unless every one of its dependencies is closed.
+- A failing test is a valid outcome to report — don't weaken a test to make it pass.

--- a/tools/project-manager/agents/validator.md
+++ b/tools/project-manager/agents/validator.md
@@ -1,0 +1,20 @@
+---
+name: validator
+description: Validation worker — picks up one ready phase:validation task issue from GitHub and checks its stated acceptance criteria against the merged result of the implementation/testing issues it depends on. Use to execute a single phase:validation issue that is status:ready. For whole-system validation in a running environment, use system-validator instead.
+tools: Bash, Read, Grep, Glob
+---
+
+You are a validator worker in the project-manager pipeline. You check one scoped acceptance-criteria issue at a time against code already merged — you do not run the whole system end-to-end (that's system-validator's job, at the root-plan level, in Tilt). Find work, claim it, close it, and unblock its dependents using the canonical worker lifecycle in `tools/project-manager/CONVENTIONS.md` § Worker lifecycle — query `phase:validation`.
+
+## Process
+
+1. Find and claim a ready `phase:validation` issue per CONVENTIONS.md.
+2. Confirm every issue it depends on is closed. If not, stop and comment.
+3. Check each acceptance criterion in the issue body against the actual repo state — read the relevant code/config, run `bazel build`/`bazel test` where that's the fastest way to confirm, don't just read and assume.
+4. If every criterion holds, finish and unblock dependents per CONVENTIONS.md, with a close comment confirming each criterion.
+5. If a criterion fails: comment with exactly which criterion and why, **do not close the issue**, and comment on the relevant implementation/testing issue linking back.
+
+## Rules
+
+- You validate against the issue's stated criteria, not general code quality — that's not your job here.
+- Never mark another issue `status:ready` unless every one of its dependencies is closed.

--- a/tools/project-manager/agents/writer.md
+++ b/tools/project-manager/agents/writer.md
@@ -1,0 +1,21 @@
+---
+name: writer
+description: Implementation worker — picks up one ready scaffolding or implementation task issue from GitHub, implements exactly what it specifies, and marks dependent issues ready on completion. Use to execute a single phase:scaffold or phase:implementation issue that is status:ready.
+tools: Bash, Read, Edit, Write, Grep, Glob
+---
+
+You are a writer worker in the project-manager pipeline. You execute one GitHub task issue at a time — you have no memory of the root plan beyond what's in the issue body, by design. Find work, claim it, close it, and unblock its dependents using the canonical worker lifecycle in `tools/project-manager/CONVENTIONS.md` § Worker lifecycle — query `phase:scaffold` or `phase:implementation`, whichever matches the issue you pick up.
+
+## Process
+
+1. Find and claim a ready `phase:scaffold` or `phase:implementation` issue per CONVENTIONS.md.
+2. Read the issue body fully — it should contain every file path, target name, and acceptance criterion you need. If it's genuinely missing something you can't infer from the repo (Bazel BUILD files, existing sibling code), say so in a comment and stop rather than guessing at scope not in the issue.
+3. Implement exactly what the issue specifies. Follow this repo's conventions (Bazel targets, no unrequested refactors, no scope beyond the issue).
+4. Verify with `bazel build`/`bazel query` as appropriate for what you touched — this is a build sanity check, not full test coverage (that's the tester's job on a separate issue).
+5. Finish and unblock dependents per CONVENTIONS.md, with a close comment summarizing what changed and which files were touched.
+
+## Rules
+
+- Stay inside the issue's stated scope. Don't fix unrelated things you notice — file a comment on the issue noting it, don't act on it.
+- Never mark another issue `status:ready` unless every one of its dependencies is closed.
+- If you get stuck or the issue is underspecified, comment and stop — don't invent requirements.

--- a/tools/project-manager/skills/implement/SKILL.md
+++ b/tools/project-manager/skills/implement/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: implement
+description: Runs the implementation phase of a project-manager plan — dispatches planner to create the task breakdown (if not already done), then loops writer/tester/validator workers over available status:ready issues until the plan's work is done or nothing more can proceed.
+---
+
+# implement
+
+Drives everything from `plan:approved` through worker execution. See `tools/project-manager/CONVENTIONS.md` § Task breakdown and § Worker lifecycle for the contract this dispatches against.
+
+## Usage
+
+```
+/project-manager:implement 123
+```
+
+## Steps
+
+1. `gh issue view <n>` — confirm the root issue is `plan:approved`. If it's only `plan:architect-approved`, tell the user to run `/project-manager:review <n>` first and stop. If it's an earlier state, point them at `/project-manager:plan <n>`.
+
+2. **Task breakdown (skip if already done).** Check whether task issues already exist for this plan: `gh issue list --search "Part of #<n>" --state all --json number,body | jq -r '.[] | select(.body | test("Part of #" + "<n>" + "([^0-9]|$)")) | .number'` — the `--search` prefilter is just a coarse net here (fine for a one-time existence check, unlike the precise per-dependency logic workers use); if it returns anything, task issues already exist, skip to step 3. Otherwise dispatch `project-manager:planner` (foreground, via Agent tool) with the root issue number to run its Process: read the plan, break it into scaffold/implementation/testing/validation task issues with dependencies and initial `status:ready`/`status:blocked` labels, and post the summary comment.
+
+3. **Work loop.** Repeat until a full pass finds nothing to do:
+   a. For each phase in order — `scaffold`, `implementation`, `testing`, `validation` — list ready work scoped to this plan:
+      ```sh
+      gh issue list --label "status:ready" --label "phase:<phase>" --state open --json number,body \
+        | jq -r '.[] | select(.body | test("Part of #<n>([^0-9]|$)")) | .number'
+      ```
+   b. For every issue found, dispatch the matching worker — `project-manager:writer` for `scaffold`/`implementation`, `project-manager:tester` for `testing`, `project-manager:validator` for `validation` — via the Agent tool. Independent issues within the same phase (no dependency relationship between them) can run in parallel background agents; issues you know depend on each other should run sequentially. You don't have to hand-pick which issue each worker takes — the persona instructions already have it query and claim `status:ready` work itself — but scope the dispatch to this plan by telling the worker the plan's root issue number and, if there are several ready issues, which one to target.
+   c. After a batch of workers finishes, re-run the phase-by-phase listing. If new issues became `status:ready` (unblocked dependents) or a tester left a failure comment needing attention, continue the loop. Stop the loop when a full pass across all four phases finds no `status:ready` work left for this plan.
+
+4. **Report.** Summarize what got closed, what's still `status:blocked` (and why — usually waiting on a tester-flagged implementation bug, which needs a writer re-run, or a genuinely external blocker), and whether every phase is fully closed. If everything under `phase:implementation`/`phase:testing` is closed, tell the user `/project-manager:validate <n>` is the next step. If something is stuck, say what and don't loop forever guessing at a fix.
+

--- a/tools/project-manager/skills/plan/SKILL.md
+++ b/tools/project-manager/skills/plan/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: plan
+description: Start a new project-manager plan — interviews you for requirements/user stories, writes the root-plan GitHub issue, then loops producer/architect until it reaches plan:architect-approved and is ready for your review.
+---
+
+# plan
+
+Orchestrates the project-manager pipeline from a feature idea (or an existing `plan:draft`/`plan:needs-answers` issue) up to `plan:architect-approved`. See `tools/project-manager/CONVENTIONS.md` for the full lifecycle this drives — read it before running this skill if you haven't already.
+
+## Usage
+
+```
+/project-manager:plan "short feature description"
+/project-manager:plan 123        # resume an existing root plan issue
+/project-manager:plan            # no args — ask what the feature is
+```
+
+## Steps
+
+1. **Resolve the issue.**
+   - If given an issue number, `gh issue view <n>` to load its current `plan:*` label and body. If it's already `plan:architect-approved` or later, stop and tell the user to run `/project-manager:review <n>` instead — this skill's job ends before the human gate.
+   - If given a description (or nothing — ask for one), this is a new plan: proceed to intake.
+
+2. **Intake (new plans only).** Conduct the conversational interview yourself, directly in this session — do not delegate this part to a subagent, since it needs live back-and-forth with the user. Follow `tools/project-manager/agents/producer.md` § Mode 0 exactly: ask who's affected (don't stop at the obvious human actor), get "As a `<persona>`, I want `<capability>`, so that `<benefit>`" user stories per persona, ask about constraints and explicit out-of-scope boundaries. A few focused questions at a time, not a giant form. Stop asking once there's no obvious gap, or the user says to just draft it.
+
+3. **Write the root plan.** Dispatch the `project-manager:producer` subagent via the Agent tool (foreground — you need its result before continuing) with the full intake transcript as input, instructing it to run Mode 1: write the root plan issue with user stories, FRs, NFRs, personas, and out-of-scope, labeled `plan:draft`. Capture the returned issue number.
+
+4. **Reconcile.** Dispatch the `project-manager:architect` subagent (foreground) with the issue number, instructing it to run its Process (steps 1–5 in architect.md): reconcile against repo conventions, comment, and set `plan:needs-answers` or `plan:architect-approved`.
+
+5. **Loop until `plan:architect-approved`:**
+   - If architect left `plan:needs-answers`: dispatch `project-manager:producer` (foreground) with the issue number to run Mode 2 (answer the open questions from the comment thread), then dispatch `project-manager:architect` again for a follow-up round.
+   - Repeat until architect sets `plan:architect-approved`, or until you judge the loop isn't converging (e.g. the same question keeps coming back) — if so, stop and summarize the sticking point for the user instead of looping indefinitely. A sane cap is 5 rounds; ask the user how to proceed if you hit it.
+
+6. **Hand off.** Once `plan:architect-approved`, tell the user the plan is ready and that `/project-manager:review <n>` is the next step (don't run it automatically — that's the human gate, it needs the user's explicit attention).

--- a/tools/project-manager/skills/review/SKILL.md
+++ b/tools/project-manager/skills/review/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: review
+description: The human review gate for a project-manager plan — shows a plan:architect-approved root issue and its reconciliation, then either sets plan:approved on your say-so or routes your feedback back through producer/architect.
+---
+
+# review
+
+Drives the one lifecycle transition that only a human may make (`tools/project-manager/CONVENTIONS.md` § Root plan lifecycle: `plan:architect-approved → plan:approved`). Never set that label yourself outside this skill's explicit confirmation step — and never let a persona set it.
+
+## Usage
+
+```
+/project-manager:review 123
+```
+
+## Steps
+
+1. `gh issue view <n> --comments` — fetch the root plan issue. If its label isn't `plan:architect-approved`, tell the user its actual state (e.g. still `plan:needs-answers` — not ready for review yet; or already `plan:approved` — nothing to do) and stop.
+
+2. Summarize for the user: the user stories/FRs/NFRs from the issue body, and the key points of architect's reconciliation comment(s) — what was checked, any nitpicks noted (non-blocking, just surface them for awareness).
+
+3. Use AskUserQuestion to ask how to proceed:
+   - **Approve** — release it to planner.
+   - **Request changes** — leave feedback for producer/architect to address.
+
+4. **If approved:** `gh issue edit <n> --add-label "plan:approved" --remove-label "plan:architect-approved"`. Tell the user `/project-manager:implement <n>` is the next step.
+
+5. **If changes requested:** ask the user for the feedback text, post it as a comment (`gh issue comment <n> --body "..."`), then `gh issue edit <n> --add-label "plan:needs-answers" --remove-label "plan:architect-approved"`. Dispatch `project-manager:producer` (foreground, via Agent tool) with the issue number to address the feedback (Mode 2), then `project-manager:architect` (foreground) for a follow-up reconciliation round — same loop as `/project-manager:plan` step 5. Once architect returns to `plan:architect-approved`, come back to step 2 and show the user the updated state — don't silently loop past them again; the whole point of this skill is that a human looks at every round before it proceeds.

--- a/tools/project-manager/skills/status/SKILL.md
+++ b/tools/project-manager/skills/status/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: status
+description: Read-only status dashboard for a project-manager root plan — shows its plan:* lifecycle state and a breakdown of task issues by phase and status. Use to check where a plan stands before deciding which orchestration skill (plan/review/build/validate) to run next.
+---
+
+# status
+
+Pure read — never edits labels, comments, or dispatches any persona. See `tools/project-manager/CONVENTIONS.md` for what each label means.
+
+## Usage
+
+```
+/project-manager:status 123
+```
+
+## Steps
+
+1. `gh issue view <n>` — report the root issue's title and current `plan:*` label, and tell the user which orchestration skill applies next:
+   - `plan:draft` / `plan:needs-answers` → `/project-manager:plan <n>`
+   - `plan:architect-approved` → `/project-manager:review <n>`
+   - `plan:approved` → `/project-manager:implement <n>`
+
+2. List every task issue for this plan and group by phase and status:
+   ```sh
+   gh issue list --state all --json number,title,state,labels \
+     | jq --arg n "<n>" '[.[] | select(.body // "" | test("Part of #" + $n + "([^0-9]|$)"))]'
+   ```
+   Note: `gh issue list --json` doesn't return `body` by default — add `body` to the `--json` fields, or do a second pass with `gh issue view <candidate> --json body` if filtering by body content this way proves unreliable at scale. Group the result by `phase:*` label, then by `status:*` label (or "closed" if no `status:*` label remains).
+
+3. Report a compact table: phase × (blocked / ready / in-progress / closed count). Call out anything that looks stuck — `status:blocked` issues whose listed dependencies are actually all closed already (a sign the unblock step was missed and needs a manual `gh issue edit --add-label status:ready --remove-label status:blocked`).
+
+4. If every `phase:implementation`/`phase:testing` issue is closed and no `phase:validation` finding issues are open, mention that `/project-manager:validate <n>` is available.

--- a/tools/project-manager/skills/validate/SKILL.md
+++ b/tools/project-manager/skills/validate/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: validate
+description: Runs whole-system validation for a project-manager plan — dispatches system-validator to exercise the merged result in Tilt against the root plan's acceptance criteria, then routes any findings to planner for follow-up tasks.
+---
+
+# validate
+
+Drives `tools/project-manager/CONVENTIONS.md` § System validation. Only meaningful once implementation is actually done.
+
+## Usage
+
+```
+/project-manager:validate 123
+```
+
+## Steps
+
+1. Confirm readiness the same precise way system-validator itself will: every `phase:implementation` and `phase:testing` issue with `Part of #<n>` must be closed.
+   ```sh
+   gh issue list --label "phase:implementation" --state open --json number,body \
+     | jq -r '.[] | select(.body | test("Part of #<n>([^0-9]|$)")) | .number'
+   ```
+   (repeat for `phase:testing`). If either returns issue numbers, implementation isn't done — tell the user to finish `/project-manager:implement <n>` first and stop.
+
+2. Dispatch `project-manager:system-validator` (foreground, via Agent tool) with the root issue number. Let it run its full Process: bring the system up via Tilt, exercise it against the FRs/NFRs, grade each one, and file `phase:validation`/`from:system-validator` finding issues for anything that isn't a clean pass.
+
+3. **If everything passed:** report that the plan is fully validated. Nothing further to do.
+
+4. **If there are findings:** dispatch `project-manager:planner` (foreground) with the set of finding issue numbers to run its "Handling system-validator findings" process — converting blocking findings into properly sequenced follow-up task issues and closing each finding once its follow-ups are linked. Report the new task issue numbers to the user, and tell them `/project-manager:implement <n>` will pick up the new `status:ready` work.


### PR DESCRIPTION
## Summary

Add a view-only LeafLab UI for browsing sensorboard setups and readings. No config editing — just a quick look at what's connected.

## Screens

- **Dashboard** — stat tiles (setups, sensors, regions, readings/min), device list with online/offline status, recent readings table
- **Device Detail** — breadcrumbs, board info (ID, firmware, RSSI, config version), sensor inventory, latest readings per sensor

## Preview

Open [leaflab/ui/design/wireframes/preview.html](file:///home/alex/whale_net/everything/leaflab/ui/design/wireframes/preview.html) in a browser. Use the floating theme button (light/night/oled) to check all three themes. Click `View` buttons on devices to navigate between screens.

## Files

| File | Purpose |
|------|---------|
| `_shell.html` | Shared navbar + theme switcher |
| `screens/01-dashboard.html` | Dashboard tile overview |
| `screens/10-device-detail.html` | Per-device detail view with sensor inventory and readings |

Follows the existing manmanv2 wireframe conventions (daisyUI fragments, `wf:` metadata, semantic badge colors). Assembled via `bazel run //tools/wireframe -- --dir leaflab/ui/design/wireframes --title LeafLab`.
