### PR TITLE
fix(manmanv2): exempt running sessions' consumers from idle-viewer reap

### DIFF
--- a/manmanv2/log-processor/consumer/manager.go
+++ b/manmanv2/log-processor/consumer/manager.go
@@ -37,6 +37,13 @@ type SessionConsumer struct {
 	// Zero value means the consumer has active subscribers.
 	idleSince time.Time
 
+	// lifecycleManaged is true if the session was "running" at consumer-creation
+	// time. Such consumers are exempt from reapIdleConsumers: they are only
+	// removed via the explicit DeleteConsumerForSession call on session end,
+	// so the RabbitMQ queue is always being actively drained while the game
+	// session is alive, regardless of whether any UI viewer is subscribed.
+	lifecycleManaged bool
+
 	// Ring buffer for recent logs
 	logBuffer       []*manmanpb.LogMessage
 	bufferSize      int
@@ -54,7 +61,7 @@ type Manager struct {
 	config        *ConsumerConfig
 	grpcClient    manmanpb.ManManAPIClient
 	archiver      Archiver
-	logsProcessed int64      // Total logs processed (atomic)
+	logsProcessed int64 // Total logs processed (atomic)
 	statsCtx      context.Context
 	statsCancel   context.CancelFunc
 	statsWg       sync.WaitGroup
@@ -208,18 +215,19 @@ func (m *Manager) createConsumer(ctx context.Context, sessionID int64) (*Session
 
 	bufferSize := 500 // Keep last 500 log messages in memory
 	sc := &SessionConsumer{
-		sessionID:     sessionID,
-		sgcID:         sessionResp.Session.ServerGameConfigId,
-		queueName:     queueName,
-		consumer:      consumer,
-		subscribers:   make(map[chan *manmanpb.LogMessage]struct{}),
-		cancel:        cancel, // This cancel is for the consumerCtx
-		done:          make(chan struct{}),
-		logsProcessed: &m.logsProcessed,
-		logBuffer:     make([]*manmanpb.LogMessage, bufferSize),
-		bufferSize:    bufferSize,
-		bufferIndex:   0,
-		bufferFull:    false,
+		sessionID:        sessionID,
+		sgcID:            sessionResp.Session.ServerGameConfigId,
+		queueName:        queueName,
+		consumer:         consumer,
+		subscribers:      make(map[chan *manmanpb.LogMessage]struct{}),
+		cancel:           cancel, // This cancel is for the consumerCtx
+		done:             make(chan struct{}),
+		logsProcessed:    &m.logsProcessed,
+		lifecycleManaged: sessionResp.Session.Status == "running",
+		logBuffer:        make([]*manmanpb.LogMessage, bufferSize),
+		bufferSize:       bufferSize,
+		bufferIndex:      0,
+		bufferFull:       false,
 	}
 
 	// Seed with any logs retained from a previous consumer reap so reconnecting
@@ -228,7 +236,6 @@ func (m *Manager) createConsumer(ctx context.Context, sessionID int64) (*Session
 		sc.seedBuffer(retained)
 		delete(m.retainedLogs, sessionID)
 	}
-
 
 	// Start consuming in background using the detached context
 	go sc.consumeLoop(consumerCtx, m.config.DebugLogOutput, m.archiver)
@@ -541,6 +548,9 @@ func (m *Manager) reapIdleConsumers() {
 
 	now := time.Now()
 	for sessionID, c := range m.consumers {
+		if c.lifecycleManaged {
+			continue
+		}
 		c.mu.RLock()
 		idle := !c.idleSince.IsZero() && now.Sub(c.idleSince) > idleConsumerTTL
 		c.mu.RUnlock()

--- a/manmanv2/log-processor/consumer/manager.go
+++ b/manmanv2/log-processor/consumer/manager.go
@@ -37,11 +37,16 @@ type SessionConsumer struct {
 	// Zero value means the consumer has active subscribers.
 	idleSince time.Time
 
-	// lifecycleManaged is true if the session was "running" at consumer-creation
-	// time. Such consumers are exempt from reapIdleConsumers: they are only
-	// removed via the explicit DeleteConsumerForSession call on session end,
-	// so the RabbitMQ queue is always being actively drained while the game
-	// session is alive, regardless of whether any UI viewer is subscribed.
+	// lifecycleManaged is true if the session was in a live (non-terminal) status
+	// at consumer-creation time. Such consumers are exempt from reapIdleConsumers:
+	// they are only removed via the explicit DeleteConsumerForSession call on
+	// session end, so the RabbitMQ queue is always being actively drained while
+	// the game session is alive, regardless of whether any UI viewer is
+	// subscribed. This must match (or be broader than) the set of statuses
+	// recoverActiveSessions treats as live (see isLiveSessionStatus): since
+	// CreateConsumerForSession is idempotent, a consumer created while a
+	// session is still starting/stopping never gets a second chance to set
+	// this flag once the session reaches "running".
 	lifecycleManaged bool
 
 	// Ring buffer for recent logs
@@ -181,6 +186,22 @@ func (m *Manager) Subscribe(ctx context.Context, sessionID int64, afterSequence 
 	}, nil
 }
 
+// isLiveSessionStatus reports whether a session status means the session is
+// still expected to produce logs. Mirrors the status set the API's LiveOnly
+// filter treats as live (postgres session repository), so a session recovered
+// mid-startup/mid-shutdown (main.go's recoverActiveSessions uses LiveOnly) is
+// marked lifecycleManaged from the start rather than only once it reaches
+// "running" — CreateConsumerForSession is idempotent and won't get a second
+// chance to set the flag on the running transition.
+func isLiveSessionStatus(status string) bool {
+	switch status {
+	case "pending", "starting", "running", "stopping":
+		return true
+	default:
+		return false
+	}
+}
+
 // createConsumer creates a new RabbitMQ consumer for a session
 func (m *Manager) createConsumer(ctx context.Context, sessionID int64) (*SessionConsumer, error) {
 	queueName := fmt.Sprintf("logs.session.%d", sessionID)
@@ -223,7 +244,7 @@ func (m *Manager) createConsumer(ctx context.Context, sessionID int64) (*Session
 		cancel:           cancel, // This cancel is for the consumerCtx
 		done:             make(chan struct{}),
 		logsProcessed:    &m.logsProcessed,
-		lifecycleManaged: sessionResp.Session.Status == "running",
+		lifecycleManaged: isLiveSessionStatus(sessionResp.Session.Status),
 		logBuffer:        make([]*manmanpb.LogMessage, bufferSize),
 		bufferSize:       bufferSize,
 		bufferIndex:      0,

--- a/manmanv2/log-processor/consumer/manager_test.go
+++ b/manmanv2/log-processor/consumer/manager_test.go
@@ -248,6 +248,26 @@ func TestLifecycleManagedConsumerNotReaped(t *testing.T) {
 	}
 }
 
+// TestIsLiveSessionStatus verifies the status set treated as "still expected to
+// produce logs" matches what recoverActiveSessions' LiveOnly filter trusts as
+// live (pending/starting/running/stopping), since createConsumer only gets one
+// chance to set lifecycleManaged and CreateConsumerForSession is idempotent.
+func TestIsLiveSessionStatus(t *testing.T) {
+	live := []string{"pending", "starting", "running", "stopping"}
+	for _, s := range live {
+		if !isLiveSessionStatus(s) {
+			t.Errorf("status %q should be treated as live", s)
+		}
+	}
+
+	terminal := []string{"stopped", "crashed", "completed", "lost", ""}
+	for _, s := range terminal {
+		if isLiveSessionStatus(s) {
+			t.Errorf("status %q should not be treated as live", s)
+		}
+	}
+}
+
 // TestRingBufferWrapAround verifies that when the buffer is full the oldest
 // messages are overwritten and getBufferedLogs returns messages in chronological
 // order (oldest surviving → newest).

--- a/manmanv2/log-processor/consumer/manager_test.go
+++ b/manmanv2/log-processor/consumer/manager_test.go
@@ -10,6 +10,12 @@ import (
 
 // newTestConsumer builds a SessionConsumer without RabbitMQ for unit testing.
 func newTestConsumer(sessionID int64, bufferSize int) *SessionConsumer {
+	return newTestConsumerWithLifecycle(sessionID, bufferSize, false)
+}
+
+// newTestConsumerWithLifecycle builds a SessionConsumer without RabbitMQ, allowing
+// the lifecycleManaged flag to be set explicitly for reap-exemption tests.
+func newTestConsumerWithLifecycle(sessionID int64, bufferSize int, lifecycleManaged bool) *SessionConsumer {
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
 	go func() {
@@ -17,12 +23,13 @@ func newTestConsumer(sessionID int64, bufferSize int) *SessionConsumer {
 		close(done)
 	}()
 	return &SessionConsumer{
-		sessionID:   sessionID,
-		subscribers: make(map[chan *manmanpb.LogMessage]struct{}),
-		cancel:      cancel,
-		done:        done,
-		logBuffer:   make([]*manmanpb.LogMessage, bufferSize),
-		bufferSize:  bufferSize,
+		sessionID:        sessionID,
+		subscribers:      make(map[chan *manmanpb.LogMessage]struct{}),
+		cancel:           cancel,
+		done:             done,
+		logBuffer:        make([]*manmanpb.LogMessage, bufferSize),
+		bufferSize:       bufferSize,
+		lifecycleManaged: lifecycleManaged,
 	}
 }
 
@@ -217,6 +224,27 @@ func TestReapIdleConsumers(t *testing.T) {
 	}
 	if _, exists := m.consumers[3]; !exists {
 		t.Error("active consumer should not have been reaped")
+	}
+}
+
+// TestLifecycleManagedConsumerNotReaped verifies that a consumer created for a
+// still-running session is never reaped on viewer idleness alone, even when
+// idle far beyond idleConsumerTTL. Lifecycle-managed consumers are only
+// removed via the explicit DeleteConsumerForSession call on session end, so
+// the RabbitMQ queue stays actively drained (and its TTL never races a
+// reconnect) for as long as the session is alive.
+func TestLifecycleManagedConsumerNotReaped(t *testing.T) {
+	m := newTestManager()
+
+	longIdle := newTestConsumerWithLifecycle(1, 10, true)
+	longIdle.idleSince = time.Now().Add(-24 * time.Hour)
+
+	m.consumers[1] = longIdle
+
+	m.reapIdleConsumers()
+
+	if _, exists := m.consumers[1]; !exists {
+		t.Error("lifecycle-managed consumer should not have been reaped regardless of idle duration")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Diagnosed via Grafana (Loki logs for `log-processor`, prod, session 97): the log viewer showed bursty, non-contiguous logs for an app logging every 30s, even on a single page load.
- Root cause: `reapIdleConsumers` tore down a session's RabbitMQ consumer + ring buffer + archiver feed after 5 idle viewer-minutes, regardless of whether the game session was still running. RabbitMQ's own queue TTL (180s default) is shorter than that 5-minute window, so any reconnect gap beyond ~3 minutes caused permanent, silent log loss once the consumer was torn down and nothing was draining the queue.
- Fix: derive a `lifecycleManaged` flag from the session's actual status (`GetSession().Status == "running"`, already fetched in `createConsumer`) and skip lifecycle-managed consumers entirely in `reapIdleConsumers`. They're now only removed via the explicit `DeleteConsumerForSession` call at session end (stopped/crashed lifecycle event), so a running session's queue is always actively drained in real time and never races the broker's TTL.
- Derived from status rather than caller identity because `Subscribe()` (on-demand, viewer-triggered) and `CreateConsumerForSession` (lifecycle-driven) can race to create the same consumer; status-based detection is correct regardless of which one wins.

## Test plan
- [x] `bazel test //manmanv2/log-processor/consumer/...` — full existing suite + new `TestLifecycleManagedConsumerNotReaped` pass
- [x] `bazel build //manmanv2/log-processor/...` — builds clean
- [ ] Post-deploy: confirm `[consumer-manager] reaped idle consumer for session <id>` no longer appears in Loki for sessions with status `running`, even after 5+ idle viewer-minutes
- [ ] Post-deploy: open a live session's log viewer, close it for 10+ minutes, reopen — confirm contiguous history with no truncated-to-50 backlog

🤖 Generated with [Claude Code](https://claude.com/claude-code)