### PR TITLE
fix(tools/lib32): repin libc6-i386 deb to current Ubuntu security point release

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -102,8 +102,8 @@ http_file(
 
 http_file(
     name = "libc6_i386_deb",
-    sha256 = "a80dfe7331c74bda498aefcd49c20e531977736e287db224d53e9915bdd6d509",
-    urls = ["http://security.ubuntu.com/ubuntu/pool/main/g/glibc/libc6-i386_2.39-0ubuntu8.7_amd64.deb"],
+    sha256 = "7c373e63a02bda5d8da4363a899c24622b1234f658b5fca78a9a4d8b1017b079",
+    urls = ["http://security.ubuntu.com/ubuntu/pool/main/g/glibc/libc6-i386_2.39-0ubuntu8.8_amd64.deb"],
 )
 
 # Python setup with rules_python for interpreter registration

--- a/tools/lib32/BUILD.bazel
+++ b/tools/lib32/BUILD.bazel
@@ -10,7 +10,7 @@ PREREQUISITES:
 
 The libraries are extracted from:
 - lib32gcc-s1_14.2.0-4ubuntu2~24.04_amd64.deb
-- libc6-i386_2.39-0ubuntu8.7_amd64.deb
+- libc6-i386_2.39-0ubuntu8.8_amd64.deb
 """
 
 load("@rules_pkg//:pkg.bzl", "pkg_tar")

--- a/tools/lib32/README.md
+++ b/tools/lib32/README.md
@@ -6,7 +6,7 @@ This package provides 32-bit libraries needed to run SteamCMD (and other 32-bit 
 
 The libraries are **downloaded and extracted at build time** from Ubuntu 24.04 packages:
 - `lib32gcc-s1_14.2.0-4ubuntu2~24.04_amd64.deb`
-- `libc6-i386_2.39-0ubuntu8.7_amd64.deb`
+- `libc6-i386_2.39-0ubuntu8.8_amd64.deb`
 
 No binary artifacts are committed to the repository. The extraction happens during Bazel build using genrules.
 


### PR DESCRIPTION
libc6-i386_2.39-0ubuntu8.7_amd64.deb was superseded by 8.8 and removed from
security.ubuntu.com, so the http_file fetch in MODULE.bazel 404'd on every
CI run. Repin to 2.39-0ubuntu8.8 with its sha256.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>