### PR TITLE
feat(tools/appmeta): add proto schema of record for release_app manifests

### DIFF
--- a/tools/TOC.md
+++ b/tools/TOC.md
@@ -7,6 +7,7 @@ Build, release, and development tooling.
 - [helm/README.md](helm/README.md) — Bazel Helm chart generation system (quick start + common patterns)
 - [helm/APP_TYPES.md](helm/APP_TYPES.md) — App type reference (`external-api`, `internal-api`, `worker`, `job`)
 - `//tools:release` — Release automation CLI; see [`docs/RELEASE.md`](../docs/RELEASE.md) for usage
+- [appmeta/README.md](appmeta/README.md) — Proto schema of record for `release_app` manifest JSON, shared by `release_helper_go`, the helm composer, and the app registry (**design stage**, consumers not yet migrated)
 
 ## Local Development
 

--- a/tools/appmeta/README.md
+++ b/tools/appmeta/README.md
@@ -1,0 +1,102 @@
+# appmeta — release manifest schema of record
+
+Proto definition of the JSON emitted by the `app_metadata` and
+`helm_chart_metadata` Starlark rules in [`//tools/bazel:release.bzl`](../bazel/release.bzl).
+
+**Design stage.** The proto exists; consumers have not been migrated yet. See
+[Migration](#migration) and `//tools/app_registry/PLAN.md` (phase AR-2).
+
+## Why this exists
+
+`release_app` manifests are the declarative source of truth for every app in the
+monorepo, and the JSON they produce is a real interface between Starlark and Go.
+That interface had no schema, so each consumer wrote its own struct — and they
+drifted:
+
+| Field | `release.bzl` emits | `release_helper_go` | `helm/composer.go` |
+|---|:---:|:---:|:---:|
+| `description`, `app_type`, `port`, `replicas` | ✅ | ❌ | ✅ |
+| `health_check`, `ingress`, `resources`, `command`, `args` | ✅ | ❌ | ✅ |
+| `version` | ✅ | ❌ | ✅ |
+| `binary_target`, `openapi_spec_target` | ✅ | ✅ | ❌ |
+| `labels`, `annotations`, `dependencies` | ❌ | ❌ | ✅ phantom |
+
+The missing `version` field has already cost something real:
+`tools/release_helper_go/cmd/plan.go` stores the release version in the
+`Language` field and reads it back with `strings.HasPrefix(app.Language, "v")`,
+because the struct it decodes into has nowhere else to put it.
+
+Adding the app registry as a third consumer would have made this worse. Instead
+the registry is the forcing function to collapse to one definition.
+
+## Dependency direction
+
+```
+              //tools/appmeta/proto:appmetapb
+                 (schema of record)
+                  ^      ^       ^
+                  |      |       |
+      release_helper_go  |   app_registry
+                    helm/composer
+```
+
+`appmeta` depends on nothing. In particular the schema must **not** live inside
+`app_registry`, or the helm composer would depend on the registry to build a
+chart.
+
+## Wire format
+
+The Starlark rules write plain `snake_case` JSON. `protojson` accepts proto
+field names as written, so **no change to the emitted format is required** —
+existing manifests parse as-is.
+
+Always decode with:
+
+```go
+protojson.UnmarshalOptions{DiscardUnknown: false}
+```
+
+`DiscardUnknown: false` is the whole point. Any key a Starlark rule emits that
+has no field in `appmeta.proto` becomes a hard error instead of silently
+vanishing — which is exactly how the current drift went unnoticed.
+
+## The contract test
+
+Shared types alone do not prevent drift; a rule attribute can still be added
+without anyone extending the proto. The enforcement is a test:
+
+1. `bazel query 'kind(app_metadata, //...)'`, build every target, and unmarshal
+   each output with `DiscardUnknown: false`. Catches **rule → proto** drift.
+2. A fixture app in `testdata/` sets *every* `release_app` attribute; assert the
+   decoded message has no unset field. Catches **proto → rule** drift, i.e. a
+   field defined here that the rule never populates.
+
+Both directions fail loudly at `bazel test` time.
+
+## Adding a field
+
+Three edits, and the contract test fails until all three are done:
+
+1. Add the attr to `app_metadata` in `release.bzl` and emit it.
+2. Add the field to `AppManifest` in `appmeta.proto`.
+3. Extend the fixture in `testdata/`.
+
+## Migration
+
+Sequenced with AR-2 in `//tools/app_registry/PLAN.md`, which already has to
+touch `release.bzl` (for `deploy_unit`) and `composer.go` (for the chart
+lockfile) — so this rides along rather than being a separate disruption.
+
+1. Land `appmeta.proto` and the contract test against today's rule output.
+2. Replace `helm/composer.go`'s `AppMetadata` with `appmetapb.AppManifest`.
+   Delete the phantom `labels` / `annotations` / `dependencies` fields, or add
+   them to the rule if they were meant to exist.
+3. Replace `release_helper_go`'s `AppMetadata` with `appmetapb.AppManifest`, and
+   **remove the `Language`-as-version hack** in `plan.go` now that `version` is
+   a real field.
+4. Add `deploy_unit` to `release_app` and to the proto.
+5. `release_helper_go` emits `AppManifestSet`; the registry's `ReconcileApps`
+   consumes it directly with no conversion.
+
+Step 3 is the one that changes existing behaviour rather than just types — the
+version-sentinel removal should be its own reviewable commit.

--- a/tools/appmeta/proto/BUILD.bazel
+++ b/tools/appmeta/proto/BUILD.bazel
@@ -1,0 +1,22 @@
+"""Schema of record for release_app manifest JSON.
+
+Consumed by release_helper_go, the helm composer, and the app registry. This
+package must not depend on any of them — it is the shared contract, not a
+component of one consumer.
+"""
+
+load("@rules_go//proto:def.bzl", "go_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+go_proto_library(
+    name = "appmetapb",
+    importpath = "github.com/whale-net/everything/tools/appmeta/proto",
+    proto = ":appmetapb_proto",
+    visibility = ["//visibility:public"],
+)
+
+proto_library(
+    name = "appmetapb_proto",
+    srcs = ["appmeta.proto"],
+    visibility = ["//visibility:public"],
+)

--- a/tools/appmeta/proto/appmeta.proto
+++ b/tools/appmeta/proto/appmeta.proto
@@ -1,0 +1,134 @@
+syntax = "proto3";
+
+package whalenet.appmeta.v1;
+
+option go_package = "github.com/whale-net/everything/tools/appmeta/proto;appmetapb";
+
+// Schema of record for the JSON emitted by the `app_metadata` and
+// `helm_chart_metadata` Starlark rules in //tools/bazel:release.bzl.
+//
+// This package is the single definition of what a release_app manifest
+// contains. Every consumer — release_helper_go, the helm composer, the app
+// registry — decodes into these types instead of maintaining its own struct.
+//
+// WIRE FORMAT: the Starlark rules write plain snake_case JSON. `protojson`
+// accepts proto field names as-is, so no change to the emitted format is
+// required. Always decode with:
+//
+//     protojson.UnmarshalOptions{DiscardUnknown: false}
+//
+// so that any key a Starlark rule emits without a corresponding field here
+// becomes a hard error rather than silent data loss. That check is the
+// anti-drift mechanism; see //tools/appmeta:manifest_contract_test.
+//
+// ADDING A FIELD: add the attr to `app_metadata` in release.bzl, add it to the
+// message below, and extend the fixture in //tools/appmeta/testdata. The
+// contract test fails until all three agree.
+
+// DeployUnit declares how an app reaches an environment. Consumed by the app
+// registry to decide what is legal to promote, and sourced from the
+// `deploy_unit` attribute on release_app.
+enum DeployUnit {
+  DEPLOY_UNIT_UNSPECIFIED = 0;
+
+  // App reaches environments inside a Helm chart. Its images are pinned by the
+  // chart and are not independently promotable.
+  DEPLOY_UNIT_CHART = 1;
+
+  // App is deployed by moving an image reference directly, with no chart in
+  // between (e.g. manmanv2-host-manager).
+  DEPLOY_UNIT_IMAGE = 2;
+
+  // Built and published, but never deployed to an environment.
+  DEPLOY_UNIT_NONE = 3;
+}
+
+// HealthCheck mirrors the "health_check" object in the manifest JSON.
+message HealthCheck {
+  bool enabled = 1;
+  string path = 2;
+}
+
+// Ingress mirrors the "ingress" object in the manifest JSON.
+message Ingress {
+  string host = 1;
+  string tls_secret_name = 2;
+}
+
+// Resources mirrors the "resources" object in the manifest JSON.
+message Resources {
+  string requests_cpu = 1;
+  string requests_memory = 2;
+  string limits_cpu = 3;
+  string limits_memory = 4;
+}
+
+// AppManifest is one `release_app` declaration, as emitted by the
+// `app_metadata` rule. Field numbers are grouped to match the argument groups
+// documented on the release_app macro.
+message AppManifest {
+  // --- identity ---
+  string name = 1;      // app name, dashes only (e.g. "control-api")
+  string domain = 2;    // e.g. "manmanv2"
+  string description = 3;
+  string language = 4;  // "go" | "python"
+
+  // --- image coordinates ---
+  string registry = 10;      // "ghcr.io"
+  string organization = 11;  // "whale-net"
+  string repo_name = 12;     // "<domain>-<name>" unless custom_repo_name is set
+  string version = 13;       // default version from the macro; "latest" normally
+
+  // --- bazel targets ---
+  string binary_target = 20;
+  string image_target = 21;
+  string openapi_spec_target = 22;
+
+  // --- deployment shape ---
+  string app_type = 30;  // external-api | internal-api | worker | job
+  int32 port = 31;
+  int32 replicas = 32;
+  repeated string command = 33;
+  repeated string args = 34;
+
+  HealthCheck health_check = 40;
+  Ingress ingress = 41;
+  Resources resources = 42;
+
+  // --- release/promotion policy ---
+  // Added for the app registry. Defaults to DEPLOY_UNIT_CHART when the
+  // Starlark attr is unset, since charts are the normal delivery path.
+  DeployUnit deploy_unit = 50;
+}
+
+// ChartManifest is one `helm_chart` declaration, as emitted by the
+// `helm_chart_metadata` rule.
+message ChartManifest {
+  string name = 1;
+  string domain = 2;
+  string version = 3;
+  string namespace = 4;
+  string environment = 5;
+
+  // App names composed into this chart. Not "<domain>-<name>" — these are bare
+  // app names, matching what the Starlark rule extracts from the app_metadata
+  // target labels.
+  repeated string apps = 6;
+
+  string chart_target = 7;
+}
+
+// AppManifestSet is the full set of manifests discovered by a `bazel query`
+// sweep. This is what `release_helper_go` produces and what the app registry's
+// ReconcileApps consumes — the registry performs a full replace against it, so
+// partial sets must never be sent.
+message AppManifestSet {
+  repeated AppManifest apps = 1;
+  repeated ChartManifest charts = 2;
+
+  // Commit the sweep was taken at.
+  string git_sha = 3;
+
+  // Unix timestamp of the sweep.
+  int64 discovered_at = 4;
+}


### PR DESCRIPTION
The JSON emitted by the app_metadata and helm_chart_metadata Starlark rules
is a real interface between Starlark and Go, but it had no schema. Each
consumer wrote its own struct, and they drifted:

  - release_helper_go's AppMetadata omits description, app_type, port,
    replicas, health_check, ingress, resources, command, args and version
  - helm/composer.go's AppMetadata omits binary_target and
    openapi_spec_target, and declares labels/annotations/dependencies that
    the Starlark rule never emits

The missing version field has already cost something concrete: plan.go
stores the release version in the Language field and reads it back with
strings.HasPrefix(app.Language, "v"), because the struct it decodes into
has nowhere else to put it.

Introduce //tools/appmeta/proto as the single definition. It depends on
nothing, so release_helper_go, the helm composer and the app registry can
all consume it without depending on each other — in particular the schema
must not live under app_registry, or the helm composer would depend on the
registry in order to build a chart.

The Starlark rules write plain snake_case JSON, which protojson accepts as
written, so no change to the emitted format is required. Decoding with
DiscardUnknown:false turns any unmodelled key into a hard error, which is
the mechanism that keeps this from drifting again.

Also adds DeployUnit, which the app registry uses to decide what is legal to
promote, sourced from a release_app attribute rather than invented by the
registry.

Schema only — consumers are migrated in a follow-up, see AR-M in
//tools/app_registry/PLAN.md.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>