### PR TITLE
feat(tools/app_registry): add gRPC contracts for the app registry

### DIFF
--- a/tools/app_registry/protos/BUILD.bazel
+++ b/tools/app_registry/protos/BUILD.bazel
@@ -1,0 +1,30 @@
+"""App Registry proto — gRPC service definitions."""
+
+load("@rules_go//proto:def.bzl", "go_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+# Single Go package for all app registry protos, matching the manmanv2 pattern.
+go_proto_library(
+    name = "appregistrypb",
+    compilers = ["@rules_go//proto:go_grpc"],
+    importpath = "github.com/whale-net/everything/tools/app_registry/protos",
+    proto = ":appregistrypb_proto",
+    # The manifest schema is owned by //tools/appmeta/proto, not by the
+    # registry — release_helper_go and the helm composer consume it too.
+    deps = ["//tools/appmeta/proto:appmetapb"],
+    visibility = ["//visibility:public"],
+)
+
+proto_library(
+    name = "appregistrypb_proto",
+    srcs = [
+        "api.proto",
+        "api_messages_app.proto",
+        "api_messages_artifact.proto",
+        "api_messages_environment.proto",
+        "api_messages_promotion.proto",
+        "messages.proto",
+    ],
+    deps = ["//tools/appmeta/proto:appmetapb_proto"],
+    visibility = ["//visibility:public"],
+)

--- a/tools/app_registry/protos/api.proto
+++ b/tools/app_registry/protos/api.proto
@@ -1,0 +1,77 @@
+syntax = "proto3";
+
+package appregistry.v1;
+
+option go_package = "github.com/whale-net/everything/tools/app_registry/protos;appregistrypb";
+
+import "tools/app_registry/protos/api_messages_app.proto";
+import "tools/app_registry/protos/api_messages_artifact.proto";
+import "tools/app_registry/protos/api_messages_environment.proto";
+import "tools/app_registry/protos/api_messages_promotion.proto";
+
+// The registry is split into four services along its authorization boundary,
+// not along its data model. `builder` (the CI service account) may call
+// AppRegistry and ArtifactRegistry. `promoter` (a human, or a
+// human-triggered workflow using an environment-scoped credential) may call
+// PromotionRegistry. `admin` may call EnvironmentRegistry. A credential that
+// can record a build must never be able to promote it.
+
+// ============================================================================
+// AppRegistry — app and chart identity. Role: builder (writes), any (reads).
+// ============================================================================
+service AppRegistry {
+  // Full reconcile from the release_app manifests discovered by bazel query.
+  // Apps absent from the request are marked MISSING, never deleted.
+  rpc ReconcileApps(ReconcileAppsRequest) returns (ReconcileAppsResponse);
+
+  rpc ListApps(ListAppsRequest) returns (ListAppsResponse);
+  rpc GetApp(GetAppRequest) returns (GetAppResponse);
+  rpc ListCharts(ListChartsRequest) returns (ListChartsResponse);
+
+  // Human triage of a MISSING app: archive it or restore it. Role: admin.
+  rpc SetAppStatus(SetAppStatusRequest) returns (SetAppStatusResponse);
+}
+
+// ============================================================================
+// ArtifactRegistry — published builds and artifacts.
+// Role: builder (writes), any (reads).
+// ============================================================================
+service ArtifactRegistry {
+  rpc RecordBuild(RecordBuildRequest) returns (RecordBuildResponse);
+  rpc RecordArtifact(RecordArtifactRequest) returns (RecordArtifactResponse);
+
+  rpc ListArtifacts(ListArtifactsRequest) returns (ListArtifactsResponse);
+  rpc GetArtifact(GetArtifactRequest) returns (GetArtifactResponse);
+
+  // Walk a chart artifact down to the image digests it pins.
+  rpc ResolveArtifact(ResolveArtifactRequest) returns (ResolveArtifactResponse);
+
+  // Phase AR-5: transactional version allocation, replacing git-tag scanning.
+  rpc AllocateVersion(AllocateVersionRequest) returns (AllocateVersionResponse);
+}
+
+// ============================================================================
+// PromotionRegistry — what is deployed where.
+// Role: promoter (writes, environment-scoped), any (reads).
+// ============================================================================
+service PromotionRegistry {
+  rpc Promote(PromoteRequest) returns (PromoteResponse);
+  rpc Rollback(RollbackRequest) returns (RollbackResponse);
+
+  // Current state, or state at any past instant via the SCD2 window. This is
+  // the query the writeback worker and deploy tooling use.
+  rpc GetEnvironmentState(GetEnvironmentStateRequest) returns (GetEnvironmentStateResponse);
+
+  rpc ListPromotions(ListPromotionsRequest) returns (ListPromotionsResponse);
+  rpc ListPromotionEvents(ListPromotionEventsRequest) returns (ListPromotionEventsResponse);
+}
+
+// ============================================================================
+// EnvironmentRegistry — environment definitions. Role: admin.
+// ============================================================================
+service EnvironmentRegistry {
+  rpc UpsertEnvironment(UpsertEnvironmentRequest) returns (UpsertEnvironmentResponse);
+  rpc GetEnvironment(GetEnvironmentRequest) returns (GetEnvironmentResponse);
+  rpc ListEnvironments(ListEnvironmentsRequest) returns (ListEnvironmentsResponse);
+  rpc ArchiveEnvironment(ArchiveEnvironmentRequest) returns (ArchiveEnvironmentResponse);
+}

--- a/tools/app_registry/protos/api_messages_app.proto
+++ b/tools/app_registry/protos/api_messages_app.proto
@@ -1,0 +1,113 @@
+syntax = "proto3";
+
+package appregistry.v1;
+
+option go_package = "github.com/whale-net/everything/tools/app_registry/protos;appregistrypb";
+
+import "tools/app_registry/protos/messages.proto";
+import "tools/appmeta/proto/appmeta.proto";
+
+// ============================================================================
+// Reconciliation
+// ============================================================================
+
+// ReconcileAppsRequest is a FULL replace, not an incremental upsert. The
+// caller sends every manifest in the monorepo; anything the registry knows
+// about that is absent from this set is marked APP_STATUS_MISSING for human
+// triage. Nothing is ever hard-deleted.
+//
+// The payload is the manifest set exactly as `release_helper_go` discovered it
+// from `bazel query` — the registry does not define its own manifest shape, so
+// there is nothing to keep in sync. Adding a field to release_app makes it
+// available here automatically.
+message ReconcileAppsRequest {
+  whalenet.appmeta.v1.AppManifestSet manifests = 1;
+
+  // When true, compute and return the diff without writing anything.
+  bool dry_run = 2;
+
+  // Required. Repeated calls with the same key are a no-op returning the
+  // original result. Use "<workflow_run_id>-<attempt>".
+  string idempotency_key = 3;
+}
+
+message ReconcileAppsResponse {
+  repeated App created_apps = 1;
+  repeated App updated_apps = 2;
+
+  // Apps that fell out of the manifest set and were flagged for triage.
+  repeated App newly_missing_apps = 3;
+
+  // Apps previously MISSING that reappeared; automatically returned to ACTIVE.
+  repeated App recovered_apps = 4;
+
+  repeated Chart created_charts = 5;
+  repeated Chart updated_charts = 6;
+  repeated Chart newly_missing_charts = 7;
+  repeated Chart recovered_charts = 8;
+
+  bool dry_run = 9;
+}
+
+// ============================================================================
+// Reads
+// ============================================================================
+
+message ListAppsRequest {
+  string domain = 1;  // optional filter
+
+  // Defaults to [ACTIVE, MISSING] when empty — archived apps are hidden
+  // unless explicitly asked for.
+  repeated AppStatus statuses = 2;
+
+  whalenet.appmeta.v1.DeployUnit deploy_unit = 3;  // optional filter
+  PageRequest page = 4;
+}
+
+message ListAppsResponse {
+  repeated App apps = 1;
+  PageResponse page = 2;
+}
+
+message GetAppRequest {
+  // Either app_id, or full_name ("<domain>-<name>").
+  string app_id = 1;
+  string full_name = 2;
+}
+
+message GetAppResponse {
+  App app = 1;
+
+  // Charts that compose this app, so a caller can see what it would actually
+  // need to promote.
+  repeated Chart charts = 2;
+}
+
+message ListChartsRequest {
+  string domain = 1;
+  repeated AppStatus statuses = 2;
+  PageRequest page = 3;
+}
+
+message ListChartsResponse {
+  repeated Chart charts = 1;
+  PageResponse page = 2;
+}
+
+// ============================================================================
+// Manual triage of MISSING rows
+// ============================================================================
+
+// SetAppStatusRequest lets a human resolve a MISSING app: archive it if the
+// removal was intentional, or reactivate it if the reconcile was wrong.
+// Transitioning to ACTIVE is only accepted if the app is present in the most
+// recent reconcile.
+message SetAppStatusRequest {
+  string app_id = 1;
+  AppStatus status = 2;
+  string reason = 3;  // required — recorded in the audit log
+}
+
+message SetAppStatusResponse {
+  App app = 1;
+}

--- a/tools/app_registry/protos/api_messages_artifact.proto
+++ b/tools/app_registry/protos/api_messages_artifact.proto
@@ -1,0 +1,152 @@
+syntax = "proto3";
+
+package appregistry.v1;
+
+option go_package = "github.com/whale-net/everything/tools/app_registry/protos;appregistrypb";
+
+import "tools/app_registry/protos/messages.proto";
+
+// ============================================================================
+// Recording builds and artifacts (the CI write path)
+// ============================================================================
+
+message RecordBuildRequest {
+  string git_sha = 1;
+  string git_ref = 2;
+  string workflow_run_id = 3;
+  int32 workflow_attempt = 4;
+  string actor = 5;
+  int64 started_at = 6;
+
+  // Required. "<workflow_run_id>-<attempt>".
+  string idempotency_key = 7;
+}
+
+message RecordBuildResponse {
+  Build build = 1;
+
+  // True when this build was already recorded and the existing row was
+  // returned unchanged.
+  bool already_recorded = 2;
+}
+
+// ContainedImage is one image a chart pins, as resolved by tools/helm at
+// compose time. Charts must be recorded with digests, not floating tags —
+// this is what makes environment state auditable.
+message ContainedImage {
+  // App this image belongs to, as "<domain>-<name>".
+  string app_full_name = 1;
+  string repository = 2;
+  string version = 3;
+  string digest = 4;
+}
+
+message RecordArtifactRequest {
+  string build_id = 1;
+  ArtifactKind kind = 2;
+
+  // For kind == IMAGE: the app's "<domain>-<name>".
+  // For kind == CHART: the chart's "<domain>-<name>".
+  string owner_full_name = 3;
+
+  string repository = 4;
+  string version = 5;  // semver tag, validated as v<major>.<minor>.<patch>
+  string digest = 6;   // "sha256:..." — required
+
+  // Only valid for kind == CHART. Every referenced image must already be
+  // recorded, or the call fails — a chart may not pin an unknown digest.
+  repeated ContainedImage contains = 7;
+
+  int64 published_at = 8;
+
+  // Required. "<workflow_run_id>-<attempt>-<owner_full_name>-<kind>".
+  string idempotency_key = 9;
+}
+
+message RecordArtifactResponse {
+  Artifact artifact = 1;
+  bool already_recorded = 2;
+}
+
+// ============================================================================
+// Reads
+// ============================================================================
+
+message ListArtifactsRequest {
+  // Filter by owner; "<domain>-<name>" of an app or chart.
+  string owner_full_name = 1;
+  ArtifactKind kind = 2;
+
+  // When set, return only artifacts a caller could legally promote. This is
+  // the filter the CLI uses to answer "what can I promote?".
+  bool promotable_only = 3;
+
+  PageRequest page = 4;
+}
+
+message ListArtifactsResponse {
+  repeated Artifact artifacts = 1;
+  PageResponse page = 2;
+}
+
+message GetArtifactRequest {
+  // Identify by artifact_id, by digest (globally unique), or by the
+  // (owner_full_name, kind, version) triple.
+  string artifact_id = 1;
+  string digest = 2;
+  string owner_full_name = 3;
+  ArtifactKind kind = 4;
+  string version = 5;
+}
+
+message GetArtifactResponse {
+  Artifact artifact = 1;
+  Build build = 2;
+}
+
+// ResolveArtifactRequest walks a chart artifact down to the concrete image
+// digests it pins. This is the incident-time query: given what is in prod,
+// what code is actually running.
+message ResolveArtifactRequest {
+  string artifact_id = 1;
+  string digest = 2;
+}
+
+message ResolveArtifactResponse {
+  Artifact artifact = 1;
+
+  // Flattened image artifacts, each with its originating build so a digest
+  // maps straight back to a commit.
+  repeated Artifact images = 2;
+  repeated Build builds = 3;
+}
+
+// ============================================================================
+// Version allocation (phase AR-5)
+// ============================================================================
+
+// AllocateVersionRequest replaces the `git tag --sort=-version:refname` scan
+// in release_helper_go. Allocation is a transactional insert against a unique
+// (owner, version) constraint, so concurrent CI runs cannot collide.
+message AllocateVersionRequest {
+  string owner_full_name = 1;
+  ArtifactKind kind = 2;
+
+  // "major" | "minor" | "patch". Ignored when explicit_version is set.
+  string increment = 3;
+
+  // Bypass auto-increment and reserve this exact version. Fails if taken.
+  string explicit_version = 4;
+
+  // Required. "<workflow_run_id>-<attempt>-<owner_full_name>".
+  string idempotency_key = 5;
+}
+
+message AllocateVersionResponse {
+  string version = 1;
+
+  // Version this was incremented from; empty for a first release.
+  string previous_version = 2;
+
+  bool already_allocated = 3;
+}

--- a/tools/app_registry/protos/api_messages_environment.proto
+++ b/tools/app_registry/protos/api_messages_environment.proto
@@ -1,0 +1,50 @@
+syntax = "proto3";
+
+package appregistry.v1;
+
+option go_package = "github.com/whale-net/everything/tools/app_registry/protos;appregistrypb";
+
+import "tools/app_registry/protos/messages.proto";
+
+// Environments are managed rows rather than a compiled-in enum, so adding
+// prod-eu or a per-PR ephemeral environment is an insert, not a release.
+
+message UpsertEnvironmentRequest {
+  string key = 1;  // immutable identity, e.g. "stage"
+  string display_name = 2;
+  int32 rank = 3;
+  bool requires_approval = 4;
+  string gitops_path = 5;
+  repeated string allowed_principals = 6;
+}
+
+message UpsertEnvironmentResponse {
+  Environment environment = 1;
+  bool created = 2;
+}
+
+message ListEnvironmentsRequest {
+  bool include_archived = 1;
+}
+
+message ListEnvironmentsResponse {
+  // Ordered by rank ascending.
+  repeated Environment environments = 1;
+}
+
+message GetEnvironmentRequest {
+  string key = 1;
+}
+
+message GetEnvironmentResponse {
+  Environment environment = 1;
+}
+
+message ArchiveEnvironmentRequest {
+  string key = 1;
+  string reason = 2;
+}
+
+message ArchiveEnvironmentResponse {
+  Environment environment = 1;
+}

--- a/tools/app_registry/protos/api_messages_promotion.proto
+++ b/tools/app_registry/protos/api_messages_promotion.proto
@@ -1,0 +1,158 @@
+syntax = "proto3";
+
+package appregistry.v1;
+
+option go_package = "github.com/whale-net/everything/tools/app_registry/protos;appregistrypb";
+
+import "tools/app_registry/protos/messages.proto";
+
+// ============================================================================
+// Promotion (the human write path)
+// ============================================================================
+
+message PromoteRequest {
+  string environment_key = 1;
+
+  // The artifact being promoted. Identify by artifact_id, by digest, or by
+  // the (owner_full_name, kind, version) triple — the CLI uses the triple.
+  string artifact_id = 2;
+  string digest = 3;
+  string owner_full_name = 4;
+  ArtifactKind kind = 5;
+  string version = 6;
+
+  // Required for environments with rank above dev. Recorded on the audit log.
+  string reason = 7;
+
+  // Acknowledge that this promotes an image belonging to a DEPLOY_UNIT_CHART
+  // app, bypassing its chart. Without this flag such a request is rejected;
+  // with it, the promotion is stored with is_override = true and reported as
+  // drift.
+  bool allow_override = 8;
+
+  // Compute and return the resulting state transition without writing.
+  bool dry_run = 9;
+
+  // Required. Client-generated; makes retries safe.
+  string idempotency_key = 10;
+}
+
+message PromoteResponse {
+  // The newly current promotion.
+  Promotion promotion = 1;
+
+  // The promotion this superseded, with valid_to now set. Empty on a first
+  // promotion. This is what a rollback would target.
+  Promotion superseded = 2;
+
+  PromotionEvent event = 3;
+
+  // Writeback workflow started for this promotion. Empty on dry_run.
+  string temporal_workflow_id = 4;
+
+  bool dry_run = 5;
+  bool already_promoted = 6;
+}
+
+// RollbackRequest is sugar over Promote: it re-promotes whatever was
+// previously current for this target in this environment. Kept as its own RPC
+// because it records PROMOTION_ACTION_ROLLBACK and needs no artifact lookup.
+message RollbackRequest {
+  string environment_key = 1;
+  string owner_full_name = 2;
+  ArtifactKind kind = 3;
+  string reason = 4;
+  bool dry_run = 5;
+  string idempotency_key = 6;
+}
+
+message RollbackResponse {
+  Promotion promotion = 1;
+  Promotion superseded = 2;
+  PromotionEvent event = 3;
+  string temporal_workflow_id = 4;
+  bool dry_run = 5;
+}
+
+// ============================================================================
+// Environment state — the deploy-tooling read path
+// ============================================================================
+
+message GetEnvironmentStateRequest {
+  string environment_key = 1;
+
+  // Optional Unix timestamp. When 0, returns current state. When set, returns
+  // the state as of that instant, via the SCD2 valid_from/valid_to window.
+  int64 at = 2;
+
+  string domain = 3;  // optional filter
+}
+
+// EnvironmentStateEntry is one deployed thing in one environment.
+message EnvironmentStateEntry {
+  Promotion promotion = 1;
+  Artifact artifact = 2;
+
+  // For chart promotions: the image digests the chart pins.
+  repeated ArtifactLink images = 3;
+
+  // Set when an image belonging to this chart was separately promoted with
+  // allow_override, so the running digest differs from the chart's pin.
+  repeated DriftEntry drift = 4;
+}
+
+// DriftEntry reports a divergence between what a chart pins and what is
+// actually promoted.
+message DriftEntry {
+  string app_id = 1;
+  string app_full_name = 2;
+  string chart_pinned_digest = 3;
+  string promoted_digest = 4;
+  string promotion_id = 5;
+}
+
+message GetEnvironmentStateResponse {
+  Environment environment = 1;
+  repeated EnvironmentStateEntry entries = 2;
+
+  // Timestamp the state is valid as of — echoes `at`, or now.
+  int64 as_of = 3;
+
+  // Stable content hash of this state document. The writeback worker uses it
+  // to skip no-op gitops commits.
+  string state_hash = 4;
+}
+
+// ============================================================================
+// History and audit
+// ============================================================================
+
+message ListPromotionsRequest {
+  string environment_key = 1;   // optional filter
+  string owner_full_name = 2;   // optional filter
+
+  // When true, include superseded rows (the full history). Default false
+  // returns only current promotions.
+  bool include_history = 3;
+
+  PageRequest page = 4;
+}
+
+message ListPromotionsResponse {
+  repeated Promotion promotions = 1;
+  PageResponse page = 2;
+}
+
+message ListPromotionEventsRequest {
+  string promotion_id = 1;      // optional filter
+  string environment_key = 2;   // optional filter
+  string owner_full_name = 3;   // optional filter
+  string actor = 4;             // optional filter
+  int64 since = 5;              // optional Unix timestamp
+  PageRequest page = 6;
+}
+
+message ListPromotionEventsResponse {
+  repeated PromotionEvent events = 1;
+  PageResponse page = 2;
+}

--- a/tools/app_registry/protos/messages.proto
+++ b/tools/app_registry/protos/messages.proto
@@ -1,0 +1,279 @@
+syntax = "proto3";
+
+package appregistry.v1;
+
+option go_package = "github.com/whale-net/everything/tools/app_registry/protos;appregistrypb";
+
+// DeployUnit and the manifest messages are NOT defined here. They belong to
+// //tools/appmeta/proto, the shared schema of record for release_app manifest
+// JSON, so that release_helper_go and the helm composer can consume them
+// without depending on the registry. See ARCHITECTURE.md "Shared manifest
+// schema".
+import "tools/appmeta/proto/appmeta.proto";
+
+// ============================================================================
+// Enums
+// ============================================================================
+
+// ArtifactKind is the type of published, digest-addressable thing.
+enum ArtifactKind {
+  ARTIFACT_KIND_UNSPECIFIED = 0;
+  ARTIFACT_KIND_IMAGE = 1;
+  ARTIFACT_KIND_CHART = 2;
+}
+
+// Promotability is a DERIVED field the server computes from the owning app's
+// or chart's DeployUnit. Clients (CLI, future UI) should filter on this rather
+// than reimplementing the rule. See ARCHITECTURE.md "Promotability".
+enum Promotability {
+  PROMOTABILITY_UNSPECIFIED = 0;
+
+  // A legal, first-class promotion target.
+  PROMOTABILITY_PROMOTABLE = 1;
+
+  // Reaches environments only by being pinned inside a promotable chart.
+  // Promoting directly is possible but is recorded as an override.
+  PROMOTABILITY_VIA_CHART = 2;
+
+  // Never deployed. Promotion is rejected.
+  PROMOTABILITY_NOT_PROMOTABLE = 3;
+}
+
+// AppStatus tracks reconciliation against the release_app manifests in the
+// monorepo. Rows are never hard-deleted — promotion history must stay
+// queryable for apps that no longer exist.
+enum AppStatus {
+  APP_STATUS_UNSPECIFIED = 0;
+
+  // Present in the most recent manifest reconcile.
+  APP_STATUS_ACTIVE = 1;
+
+  // Absent from the most recent reconcile but not yet triaged by a human.
+  // Surfaced as a work queue: either the app was renamed (fix it) or it was
+  // genuinely removed (archive it).
+  APP_STATUS_MISSING = 2;
+
+  // A human confirmed this app is gone. Excluded from default listings.
+  APP_STATUS_ARCHIVED = 3;
+}
+
+// PromotionState allows the approval gate described in ARCHITECTURE.md to be
+// added later without a schema change. Phase AR-3 only ever writes ACTIVE and
+// SUPERSEDED.
+enum PromotionState {
+  PROMOTION_STATE_UNSPECIFIED = 0;
+  PROMOTION_STATE_PENDING_APPROVAL = 1;
+  PROMOTION_STATE_ACTIVE = 2;
+  PROMOTION_STATE_SUPERSEDED = 3;
+  PROMOTION_STATE_FAILED = 4;
+}
+
+// PromotionAction is the human-meaningful verb recorded on the append-only
+// event log. The SCD2 promotion table answers "what"; this answers "why".
+enum PromotionAction {
+  PROMOTION_ACTION_UNSPECIFIED = 0;
+  PROMOTION_ACTION_PROMOTE = 1;
+  PROMOTION_ACTION_ROLLBACK = 2;
+  PROMOTION_ACTION_OVERRIDE = 3;
+  PROMOTION_ACTION_RETIRE = 4;
+  PROMOTION_ACTION_APPROVE = 5;
+  PROMOTION_ACTION_REJECT = 6;
+}
+
+// ============================================================================
+// Core entities
+// ============================================================================
+
+// App mirrors one release_app manifest in the monorepo. Identity is
+// (domain, name); full_name is the "<domain>-<app>" form already used for
+// image repositories and git tags.
+message App {
+  string app_id = 1;      // registry-assigned UUID, stable across renames
+  string domain = 2;      // e.g. "manmanv2"
+  string name = 3;        // e.g. "control-api"
+  string full_name = 4;   // "<domain>-<name>", derived
+
+  string description = 5;
+  string language = 6;    // "go" | "python"
+  string app_type = 7;    // external-api | internal-api | worker | job
+  whalenet.appmeta.v1.DeployUnit deploy_unit = 8;
+
+  // Bazel label the manifest came from, e.g. "//manmanv2/api:control-api".
+  // Makes the registry row traceable back to source.
+  string bazel_label = 9;
+
+  // Image repository this app publishes to, e.g.
+  // "ghcr.io/whale-net/manmanv2-control-api".
+  string image_repository = 10;
+
+  AppStatus status = 11;
+  int64 first_seen_at = 12;  // Unix timestamp
+  int64 last_seen_at = 13;   // Unix timestamp, updated every reconcile
+}
+
+// Chart is a Helm chart composed from one or more apps. Charts are their own
+// registerable identity because tools/helm composes several apps into one
+// chart, and the chart — not the app — is usually the promotion target.
+message Chart {
+  string chart_id = 1;
+  string domain = 2;
+  string name = 3;
+  string full_name = 4;
+
+  string description = 5;
+
+  // app_ids composed into this chart, per its manifest.
+  repeated string app_ids = 6;
+
+  // Helm OCI repository, e.g. "ghcr.io/whale-net/charts".
+  string chart_repository = 7;
+
+  whalenet.appmeta.v1.DeployUnit deploy_unit = 8;  // normally DEPLOY_UNIT_CHART
+  AppStatus status = 9;
+  int64 first_seen_at = 10;
+  int64 last_seen_at = 11;
+}
+
+// Build is one CI run that produced a set of artifacts. Artifacts always hang
+// off a build so that any deployed digest traces back to a commit and a
+// workflow run.
+message Build {
+  string build_id = 1;
+
+  string git_sha = 2;
+  string git_ref = 3;          // e.g. "refs/heads/main"
+
+  string workflow_run_id = 4;  // GitHub Actions run id
+  int32 workflow_attempt = 5;
+  string actor = 6;            // GitHub actor or service account subject
+
+  int64 started_at = 7;
+  int64 recorded_at = 8;
+}
+
+// Artifact is a published, digest-addressable thing. The digest is the
+// identity; the semver tag is a convenience label that may move.
+message Artifact {
+  string artifact_id = 1;
+  ArtifactKind kind = 2;
+
+  // Exactly one of these is set, depending on kind.
+  string app_id = 3;    // set when kind == IMAGE
+  string chart_id = 4;  // set when kind == CHART
+
+  string repository = 5;  // e.g. "ghcr.io/whale-net/manmanv2-control-api"
+  string version = 6;     // semver tag, e.g. "v1.4.0"
+  string digest = 7;      // "sha256:..." — the real identity, globally unique
+
+  string build_id = 8;
+  int64 published_at = 9;
+
+  // DERIVED by the server from the owning app's/chart's deploy_unit.
+  Promotability promotability = 10;
+
+  // For kind == CHART: the image artifacts this chart pins, resolved to
+  // digests at publish time by tools/helm. Empty for kind == IMAGE.
+  repeated ArtifactLink contains = 11;
+}
+
+// ArtifactLink records that a chart artifact pins a specific image digest.
+// This is what makes "which image digest is prod actually running" answerable
+// without rendering a chart.
+message ArtifactLink {
+  string artifact_id = 1;  // the contained image artifact
+  string app_id = 2;
+  string repository = 3;
+  string version = 4;
+  string digest = 5;
+}
+
+// Environment is a row, not an enum, so ephemeral and regional environments
+// can be added later without a schema or proto change.
+message Environment {
+  string environment_id = 1;
+  string key = 2;           // "dev" | "stage" | "prod" | "prod-eu" | ...
+  string display_name = 3;
+
+  // Ordering for promotion-legality rules (e.g. "must be in stage before
+  // prod"). Higher rank == closer to production. Not enforced in AR-3.
+  int32 rank = 4;
+
+  // When true, Promote lands in PROMOTION_STATE_PENDING_APPROVAL instead of
+  // ACTIVE. Not honored until the approval gate ships.
+  bool requires_approval = 5;
+
+  // Path in the gitops repo this environment's rendered state is written to.
+  string gitops_path = 6;
+
+  // Principals permitted to promote here, checked against the caller's OIDC
+  // claims. Empty means "same as builder role" — only acceptable for dev.
+  repeated string allowed_principals = 7;
+
+  bool archived = 8;
+  int64 created_at = 9;
+}
+
+// Promotion is SCD2 state: what is deployed to an environment right now, and
+// what was deployed at any past instant. Follows the repo-wide valid_from /
+// valid_to convention (see AGENTS.md).
+message Promotion {
+  string promotion_id = 1;
+
+  string environment_id = 2;
+  string environment_key = 3;  // denormalized for readability
+
+  // The promotion target. Exactly one of app_id / chart_id is set, matching
+  // artifact.kind.
+  string app_id = 4;
+  string chart_id = 5;
+  string artifact_id = 6;
+
+  // Denormalized artifact identity so a state dump is readable on its own.
+  string repository = 7;
+  string version = 8;
+  string digest = 9;
+
+  PromotionState state = 10;
+
+  // True when an image belonging to a DEPLOY_UNIT_CHART app was promoted
+  // directly, bypassing its chart. Legal, but reported as drift against the
+  // chart's pinned digest.
+  bool is_override = 11;
+
+  int64 valid_from = 12;
+  int64 valid_to = 13;  // 0 == still current
+}
+
+// PromotionEvent is the append-only audit log. One Promote call writes exactly
+// one event; approvals and rollbacks add further events against the same
+// promotion.
+message PromotionEvent {
+  string event_id = 1;
+  string promotion_id = 2;
+
+  PromotionAction action = 3;
+  string actor = 4;    // OIDC subject or GitHub actor
+  string reason = 5;   // free text, required for prod
+
+  // Set when the writeback was orchestrated by Temporal, so an operator can
+  // jump from an audit row to the workflow history.
+  string temporal_workflow_id = 6;
+  string temporal_run_id = 7;
+
+  int64 occurred_at = 8;
+}
+
+// ============================================================================
+// Shared request plumbing
+// ============================================================================
+
+// Pagination is uniform across all List RPCs.
+message PageRequest {
+  int32 page_size = 1;   // server clamps; 0 means server default
+  string page_token = 2;
+}
+
+message PageResponse {
+  string next_page_token = 1;
+  int32 total_size = 2;
+}


### PR DESCRIPTION
Proto definitions for a service that records what CI published and tracks
which artifact is promoted to each environment. Contracts only — no
implementation, no BUILD targets beyond the generated Go library.

The monorepo's release system is already declarative and works well, but
promotion state ("stage is on v1.4.0, prod is two versions behind") has no
home; it lives implicitly in ArgoCD values files. This gives it one, and in
doing so becomes the authoritative index of every artifact CI has published.

Four services, split along the authorization boundary rather than the data
model, so that the credential every build job already holds cannot promote:

  - AppRegistry / ArtifactRegistry  role: builder (GitHub Actions OIDC)
  - PromotionRegistry               role: promoter (environment-scoped)
  - EnvironmentRegistry             role: admin

Notable modelling decisions:

  - Manifest messages are NOT defined here. ReconcileApps takes an
    appmeta.v1.AppManifestSet verbatim, so there is no registry-local copy of
    the manifest shape to drift from release_helper_go and the helm composer.
  - Artifacts are identified by digest; the semver tag is a label that may
    move. Chart artifacts record the image digests they pin, which is what
    makes "which image is prod actually running" answerable without
    rendering a chart.
  - Promotability is derived server-side from the app's declared deploy_unit,
    so clients filter on it rather than reimplementing the rule. Promoting an
    image that belongs to a chart-deployed app requires an explicit override
    and is reported as drift.
  - Promotion is SCD2 (valid_from/valid_to per AGENTS.md), giving "what was
    deployed at time T" for free. An append-only event log carries who and
    why, which SCD2 state does not.
  - Environments are rows, not an enum, so regional and ephemeral
    environments are an insert rather than a release.
  - PENDING_APPROVAL, APPROVE and REJECT exist but are never written; the
    approval gate can ship later without a migration.

Every write RPC requires an idempotency key so CI reruns and activity
retries are safe by construction.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>