### PR TITLE
docs(tools/app_registry): add design record, delivery plan and skeleton

### DIFF
--- a/tools/TOC.md
+++ b/tools/TOC.md
@@ -8,6 +8,7 @@ Build, release, and development tooling.
 - [helm/APP_TYPES.md](helm/APP_TYPES.md) — App type reference (`external-api`, `internal-api`, `worker`, `job`)
 - `//tools:release` — Release automation CLI; see [`docs/RELEASE.md`](../docs/RELEASE.md) for usage
 - [appmeta/README.md](appmeta/README.md) — Proto schema of record for `release_app` manifest JSON, shared by `release_helper_go`, the helm composer, and the app registry (**design stage**, consumers not yet migrated)
+- [app_registry/TOC.md](app_registry/TOC.md) — App Registry: gRPC service indexing published artifacts and tracking per-environment promotion state (**design stage**, not implemented)
 
 ## Local Development
 

--- a/tools/app_registry/ARCHITECTURE.md
+++ b/tools/app_registry/ARCHITECTURE.md
@@ -1,0 +1,263 @@
+# App Registry — Architecture
+
+Design record for `//tools/app_registry`. Read [README.md](README.md) first for
+what the system is and the end-to-end flows.
+
+## Design principles
+
+1. **Manifests stay authoritative.** The registry never invents app metadata.
+   It ingests `release_app` manifests via `bazel query` and reconciles. If the
+   registry and the manifests disagree, the manifests win.
+2. **Digests are identity; tags are labels.** Every artifact is stored by
+   `sha256:` digest. Semver tags are recorded for humans and can move.
+3. **The API is the write path; git is the delivery path.** Deployment tooling
+   reads state from the gitops repo (or an S3 snapshot), never synchronously
+   from the API. The registry being down must not block a deploy.
+4. **Additive before authoritative.** The registry observes releases for a full
+   phase before it is allowed to allocate versions. Git tags remain a redundant
+   record permanently — they cost nothing and are the disaster-recovery path.
+5. **Record, don't act.** The registry mutates rows and emits writeback intents.
+   It never touches a cluster.
+
+## Shared manifest schema
+
+The registry does **not** define its own app-manifest shape. `AppManifest`,
+`ChartManifest`, `AppManifestSet` and `DeployUnit` live in
+[`//tools/appmeta/proto`](../appmeta/README.md), the schema of record for the
+JSON that `app_metadata` and `helm_chart_metadata` emit.
+
+This matters because two Go structs already decode that JSON — one in
+`release_helper_go`, one in `tools/helm/composer.go` — and they had drifted from
+each other and from the Starlark rule. The registry would have been a third.
+Instead it consumes the shared contract, so `ReconcileApps` takes an
+`AppManifestSet` verbatim and adding a field to `release_app` propagates
+everywhere with no per-consumer edit.
+
+Dependency direction is load-bearing: `appmeta` depends on nothing, and the
+schema must not live under `app_registry`, or `tools/helm` would depend on the
+registry in order to build a chart.
+
+Drift is prevented by the contract test described in the appmeta README, not by
+the shared type alone — `protojson` decoding with `DiscardUnknown: false` turns
+any unmodelled Starlark output key into a test failure.
+
+## Data model
+
+```mermaid
+erDiagram
+    APP ||--o{ ARTIFACT : publishes
+    CHART ||--o{ ARTIFACT : publishes
+    CHART }o--o{ APP : composes
+    BUILD ||--o{ ARTIFACT : produced
+    ARTIFACT ||--o{ ARTIFACT_LINK : pins
+    ARTIFACT ||--o{ PROMOTION : promoted_as
+    ENVIRONMENT ||--o{ PROMOTION : hosts
+    PROMOTION ||--o{ PROMOTION_EVENT : audited_by
+    PROMOTION ||--o{ WRITEBACK_OUTBOX : triggers
+```
+
+### Tables
+
+| Table | Shape | Notes |
+|---|---|---|
+| `app` | mutable, reconciled | `(domain, name)` unique. `status` ∈ active/missing/archived. Never hard-deleted. |
+| `chart` | mutable, reconciled | `(domain, name)` unique. |
+| `chart_app` | join | Which apps a chart composes, per its manifest. |
+| `build` | append-only | `(workflow_run_id, workflow_attempt)` unique. |
+| `artifact` | append-only | `digest` globally unique. `(owner, kind, version)` unique. |
+| `artifact_link` | append-only | Chart artifact → pinned image artifact. |
+| `environment` | mutable | `key` unique. `rank` orders promotion legality. |
+| `promotion` | **SCD2** | `valid_from` / `valid_to`. Partial unique index on current rows. |
+| `promotion_event` | append-only | Who, why, when, and the Temporal workflow id. |
+| `writeback_outbox` | append-only + claimed | Transactional outbox, drained by the worker. |
+| `idempotency_key` | append-only | Key → prior response, for safe CI retries. |
+
+### SCD2 on `promotion`
+
+Follows the repo-wide convention in `AGENTS.md` exactly:
+
+```sql
+-- write path: close and open, in one transaction
+UPDATE promotion SET valid_to = NOW()
+ WHERE environment_id = $1 AND target_key = $2 AND valid_to IS NULL;
+INSERT INTO promotion (environment_id, target_key, artifact_id, ...)
+VALUES ($1, $2, $3, ...);
+```
+
+```sql
+-- current state
+SELECT * FROM promotion
+ WHERE environment_id = $1 AND valid_to IS NULL;
+
+-- state at time T (the incident query)
+SELECT * FROM promotion
+ WHERE environment_id = $1
+   AND valid_from <= $t
+   AND (valid_to IS NULL OR valid_to > $t);
+```
+
+Backed by `CREATE UNIQUE INDEX ON promotion(environment_id, target_key) WHERE
+valid_to IS NULL` — this both accelerates the hot query and makes
+double-promotion structurally impossible.
+
+`target_key` is the promoted thing's identity (`<kind>:<owner_full_name>`),
+denormalized so the partial unique index is expressible without a nullable
+two-column target.
+
+A `v_current_promotion` view pre-joins promotion → artifact → app/chart → build
+so the CLI, the writeback worker, and any future UI never re-derive the join.
+
+## Promotability
+
+The rule the whole system hangs on. Each app declares its `deploy_unit` in its
+`release_app` manifest; the registry derives artifact promotability from it.
+
+| App `deploy_unit` | Image artifacts | Chart artifacts |
+|---|---|---|
+| `chart` | `VIA_CHART` | `PROMOTABLE` |
+| `image` | `PROMOTABLE` | n/a |
+| `none` | `NOT_PROMOTABLE` | n/a |
+
+**Override.** Promoting a `VIA_CHART` image directly is rejected unless the
+caller passes `allow_override`. When allowed, the promotion is stored with
+`is_override = true` and `GetEnvironmentState` reports it as a `DriftEntry`
+against the chart's pinned digest. This makes the manmanv2-host-manager style
+of hotfix possible without making it invisible.
+
+**Why this is on the app, not the artifact:** it is a property of how the app is
+deployed, which is declarative and belongs next to the code — the same place
+`app_type` and `port` already live. The registry reads it; it does not own it.
+
+### Required change to `release_app`
+
+`tools/bazel/release.bzl` gains a `deploy_unit` attribute (default `"chart"`),
+mirrored by `DeployUnit` in `//tools/appmeta/proto`. This is one of three
+changes that touch existing code paths rather than being purely additive —
+the others being the chart lockfile below and the manifest-schema
+consolidation.
+
+## Chart → image lockfile
+
+`tools/helm/composer.go` already resolves the exact image tags it bakes into a
+chart. It must additionally resolve them to **digests** and emit a lockfile that
+CI forwards to `RecordArtifact(kind = CHART, contains = [...])`.
+
+Without this, chart promotion cannot answer "which image digest is running",
+and the incident query degrades to rendering charts by hand. This is the
+highest-value part of the recording phase and should not be deferred.
+
+The server rejects a chart artifact that references an image digest it has never
+recorded — a chart may not pin an unknown artifact.
+
+## Writeback: outbox → Temporal
+
+Promotion and the intent to write it back **must** commit atomically. If they
+don't, the registry can believe prod is on v1.4.0 while the gitops repo still
+says v1.3.0, which is the exact failure mode this system exists to prevent.
+
+Since Temporal cannot enlist in a Postgres transaction, the server writes a
+`writeback_outbox` row inside the promotion transaction. The worker drains the
+outbox and starts a `WritebackWorkflow` with the promotion id as its workflow
+id, so Temporal's own dedup makes redelivery harmless.
+
+```mermaid
+graph LR
+    P["Promote RPC<br/>(one tx)"] --> DB[("promotion<br/>+ event<br/>+ outbox")]
+    DB --> D["worker: drain outbox"]
+    D --> W["WritebackWorkflow<br/>id = promotion_id"]
+    W --> A1["activity: render env state"]
+    A1 --> A2["activity: commit to gitops repo"]
+    A2 --> A3["activity: put S3 snapshot"]
+    A3 --> A4["activity: mark outbox done"]
+```
+
+Activities are individually retryable and idempotent. The gitops commit uses
+`state_hash` from `GetEnvironmentState` to skip no-op commits, and retries on
+push conflict by re-reading state — last writer wins on a per-environment file,
+which is correct because the registry is the source of truth for that file.
+
+**Temporal is not yet a Go dependency in this repo.** `friendly_computing_machine`
+uses the Python SDK only. `go.temporal.io/sdk` needs adding to `go.mod` and
+`MODULE.bazel`, and a `libs/go/temporal` helper package (client construction,
+env config, worker bootstrap, logging bridge to `libs/go/logging`) needs to
+exist. This is real scope — see AR-1 in [PLAN.md](PLAN.md).
+
+## Authorization
+
+Enforced with `libs/go/grpcauth` (OIDC), split along the service boundary:
+
+| Role | Services | Credential |
+|---|---|---|
+| `builder` | `AppRegistry` (writes), `ArtifactRegistry` (writes) | GitHub Actions OIDC, unrestricted workflows |
+| `promoter` | `PromotionRegistry` (writes) | **Environment-scoped** GitHub OIDC subject, or a human's token |
+| `admin` | `EnvironmentRegistry`, `SetAppStatus` | Human only |
+| reader | all reads | Any authenticated principal |
+
+**The critical constraint:** the credential every build job already holds must
+not be able to promote. Promotion workflows use a GitHub Environment-scoped OIDC
+subject so the `builder` token cannot self-promote. Per-environment
+`allowed_principals` narrows this further for prod.
+
+`reason` is required on promotions to any environment above rank 0.
+
+## Idempotency
+
+Every write RPC takes a required `idempotency_key`. The server stores key →
+serialized response; a repeat returns the original response with an
+`already_*` flag rather than re-executing. CI reruns and Temporal activity
+retries are therefore safe by construction.
+
+Convention: `<workflow_run_id>-<attempt>[-<owner>-<kind>]` for CI; a
+client-generated UUID for human promotions.
+
+## Availability and bootstrap
+
+The registry is itself a `release_app` in this monorepo, so it deploys itself.
+That circularity is only safe because **nothing in the deploy path calls the
+API synchronously**:
+
+- ArgoCD reads the gitops repo, which the worker writes.
+- The S3 snapshot is an auth-free read path for tooling that has no gRPC client.
+- CI recording is best-effort: a registry outage warns, it does not fail a
+  release.
+
+The registry can be down for hours without blocking a release or a deploy. The
+only thing lost is the ability to *make new promotions* during the outage.
+
+## Rejected alternatives
+
+| Decision | Chosen | Rejected | Why |
+|---|---|---|---|
+| Async durability | Temporal + outbox | River | River was a trial and is being retired repo-wide. |
+| Async durability | Temporal + outbox | RabbitMQ | Cannot enlist in the promotion transaction; would need an outbox anyway, so the outbox is the real mechanism and Temporal is the better executor for a multi-step, retryable git push. |
+| Transport | gRPC + thin Go CLI | grpc-gateway / connect-go | Every CI caller in this repo is already `bazel run` on a Go CLI. A gateway is pure complexity until a browser UI exists. |
+| Environments | table rows | proto enum | Ephemeral and regional environments become an insert, not a release. |
+| Bundling | chart pins image digests | registry-side "release bundle" | Charts already are the bundle. Inventing a parallel grouping would duplicate what `tools/helm` composes. |
+| Missing apps | flag `MISSING` for triage | auto-archive | A rename would silently orphan promotion history. |
+| Version source of truth | registry (AR-5), tags retained | tags only | A unique constraint beats `git tag --sort` plus a CI concurrency group for concurrent allocation. |
+| Manifest schema | shared `//tools/appmeta/proto` | registry-local manifest messages | Two hand-written Go structs already decode the manifest JSON and had drifted; a third would compound it. |
+| Manifest schema | proto + `protojson` | shared hand-written Go struct | `protojson` reads the existing snake_case JSON unchanged, and `DiscardUnknown: false` turns drift into a test failure. |
+
+## Future: approval gate
+
+Deliberately unimplemented, but the schema accommodates it without migration:
+
+- `environment.requires_approval` already exists.
+- `PromotionState.PENDING_APPROVAL` already exists.
+- `PromotionAction.APPROVE` / `REJECT` already exist.
+
+When built, `Promote` against a gated environment writes a promotion in
+`PENDING_APPROVAL` with no outbox row; a later `Approve` transitions it to
+`ACTIVE` and enqueues the writeback. Rollback needs nothing new — it is a
+`Promote` to the artifact that SCD2 history already identifies as previous.
+
+## Open questions
+
+1. **Chart identity source.** `tools/helm` composes charts from Bazel targets;
+   the exact query for enumerating charts and their member apps needs pinning
+   down before AR-1.
+2. **Gitops repo target.** Which repo/branch the worker commits to, and whether
+   per-environment files or one file per app. Blocks AR-3.
+3. **Migration of existing state.** Backfilling historical artifacts from git
+   tags and GHCR is optional. Recommendation: don't. Start recording from AR-2
+   forward and let history accumulate.

--- a/tools/app_registry/PLAN.md
+++ b/tools/app_registry/PLAN.md
@@ -1,0 +1,236 @@
+# App Registry — Delivery Plan
+
+Phased build-out of `//tools/app_registry`. Each phase has a **plan ID**; worker
+agents track execution in a `TODO-<PLAN_ID>.md` alongside this file (e.g.
+`TODO-AR-2.md`). Those TODO files are created when a phase starts, not up front.
+
+Read [ARCHITECTURE.md](ARCHITECTURE.md) before executing any phase.
+
+## Sequencing rationale
+
+Promotion tracking is additive and low-risk; replacing git-tag version
+allocation moves an existing working source of truth into a stateful service.
+Do the first, prove it, then do the second. Shipping AR-5 before AR-3 would put
+a registry outage in the path of every release before the registry has delivered
+anything.
+
+```mermaid
+graph LR
+    AR0["AR-0<br/>Design"] --> ARM["AR-M<br/>Manifest schema"]
+    ARM --> AR1["AR-1<br/>Foundations"]
+    AR1 --> AR2["AR-2<br/>Observe"]
+    AR2 --> AR3["AR-3<br/>Promote"]
+    AR3 --> AR4["AR-4<br/>Writeback"]
+    AR4 --> AR5["AR-5<br/>Allocate versions"]
+    AR2 -. "soak period" .-> AR3
+    style AR0 fill:#e8f5e8
+    style ARM fill:#fff4e0
+    style AR5 fill:#ffe9e9
+```
+
+AR-M stands alone and delivers value with or without the registry — it fixes
+drift that exists today. It is sequenced first because AR-2 otherwise adds a
+third manifest representation to the two that already disagree.
+
+---
+
+## AR-0 — Design and contracts
+
+**Status:** complete (this document, `ARCHITECTURE.md`, `README.md`, `protos/`).
+
+**Delivered**
+- Proto contracts for all four services, compiling under
+  `//tools/app_registry/protos:appregistrypb`.
+- Data model, promotability rule, authorization split, writeback mechanism.
+
+**Exit criteria** — met when the promotability model and the chart→image
+lockfile approach are agreed, since both touch existing code.
+
+---
+
+## AR-M — Manifest schema consolidation
+
+**Goal:** one definition of what a `release_app` manifest contains. Independent
+of the registry — this repays itself immediately by removing existing drift.
+
+**Why first:** `release_helper_go` and `tools/helm/composer.go` both decode the
+manifest JSON into their own structs, and they disagree with each other and with
+the Starlark rule (see the table in [`../appmeta/README.md`](../appmeta/README.md)).
+Adding the registry as a third consumer before fixing this compounds the
+problem.
+
+**Scope**
+- `//tools/appmeta/proto` — `AppManifest`, `ChartManifest`, `AppManifestSet`,
+  `DeployUnit`. *(done in AR-0; consumers not yet migrated)*
+- Contract test `//tools/appmeta:manifest_contract_test`, both directions:
+  every `app_metadata` target decodes with `DiscardUnknown: false`, and a
+  full-coverage fixture app leaves no proto field unset.
+- Migrate `tools/helm/composer.go` to `appmetapb.AppManifest`. Resolve the
+  phantom `labels` / `annotations` / `dependencies` fields — either emit them
+  from the rule or delete them.
+- Migrate `tools/release_helper_go` to `appmetapb.AppManifest`.
+- **Remove the `Language`-as-version hack** in `cmd/plan.go` (`apps[i].Language
+  = version`, read back via `strings.HasPrefix(app.Language, "v")`), now that
+  `version` is a real field. Separate reviewable commit — this changes
+  behaviour, not just types.
+- Add `deploy_unit` to `release_app` and set it on standalone-image apps
+  (e.g. `manmanv2-host-manager`).
+
+**Exit criteria**
+- No hand-written manifest struct remains in `tools/`.
+- Contract test fails when a rule attr is added without a proto field, verified
+  by deliberately breaking it once.
+- `bazel test //tools/...` green; a release dry-run produces byte-identical
+  charts and plans to before the migration.
+
+**Risk:** the helm composer is on the critical path for every chart build.
+Migrate it behind a golden-output test comparing rendered charts pre/post.
+
+---
+
+## AR-1 — Foundations
+
+**Goal:** everything the service needs to exist, with no business logic.
+
+**Scope**
+- `libs/go/temporal` — client construction, env-driven config, worker bootstrap,
+  logging bridge to `libs/go/logging`. Add `go.temporal.io/sdk` to `go.mod` and
+  `MODULE.bazel`. **This does not exist yet in Go anywhere in the repo** and is
+  the largest unknown in this phase.
+- `tools/app_registry/migrate` — `golang-migrate` runner over embedded SQL,
+  following `manmanv2/migrate`. Schema per ARCHITECTURE.md, including the SCD2
+  partial unique index and `v_current_promotion`.
+- `tools/app_registry/server` — gRPC server skeleton: `libs/go/db` pool,
+  `libs/go/grpcauth` interceptors, otelgrpc, reflection, health check. All RPCs
+  return `UNIMPLEMENTED`.
+- `tools/app_registry/cli` — Cobra skeleton with a thin gRPC client.
+- `release_app` manifests for `app-registry-api` and `app-registry-migration`.
+- Tilt wiring for local development.
+
+**Exit criteria**
+- `bazel test //tools/app_registry/...` green.
+- Migrations apply and roll back cleanly.
+- Server starts in Tilt and answers reflection + health.
+
+**Risks** — Temporal Go SDK under Bazel with cross-compilation. Read
+`docs/DOCKER.md` before touching image builds; ARM64 breakage is silent at build
+time.
+
+---
+
+## AR-2 — Observe (additive recording)
+
+**Goal:** the registry knows everything CI published. Git tags stay
+authoritative. Nothing depends on the registry yet.
+
+**Scope**
+- Implement `AppRegistry.ReconcileApps`, `ListApps`, `GetApp`, `ListCharts`,
+  `SetAppStatus`.
+- Implement `ArtifactRegistry.RecordBuild`, `RecordArtifact`, `ListArtifacts`,
+  `GetArtifact`, `ResolveArtifact`.
+- Idempotency-key storage and replay.
+- **`tools/helm/composer.go`: emit a chart lockfile** resolving pinned images to
+  digests.
+- `release_helper_go`: emit an `AppManifestSet` from `plan` output. No
+  conversion code — AR-M made this the same type the registry accepts.
+- `.github/workflows/release.yml`: call `app-registry` CLI after image and chart
+  pushes. **Best-effort — `continue-on-error`, must never fail a release.**
+- CLI: `apps list`, `apps get`, `artifacts list`, `artifacts resolve`.
+
+**Exit criteria**
+- Every release for a soak period appears in the registry.
+- A parity check confirms registry artifacts match git tags with zero drift.
+- `artifacts resolve` on a chart returns correct image digests.
+
+**Soak:** run for several weeks of real releases before starting AR-3. Do not
+compress this — it is the phase that earns the trust AR-5 spends.
+
+---
+
+## AR-3 — Promotion
+
+**Goal:** promotion state is recorded and queryable. Still nothing consumes it.
+
+**Scope**
+- Implement `EnvironmentRegistry` (all RPCs); seed `dev`/`stage`/`prod`.
+- Implement `PromotionRegistry.Promote`, `Rollback`, `GetEnvironmentState`,
+  `ListPromotions`, `ListPromotionEvents`.
+- SCD2 close-and-open in one transaction; promotion event log.
+- Promotability enforcement, including `allow_override` and drift reporting.
+- Environment-scoped authorization; `reason` required above rank 0.
+- CLI: `promote`, `rollback`, `status <env>`, `history`, `diff <env> <env>`.
+- A human-triggered `promote.yml` GitHub workflow using an
+  **environment-scoped OIDC subject**, distinct from the builder credential.
+
+**Exit criteria**
+- Promote/rollback round-trips correctly; `GetEnvironmentState --at <T>` returns
+  correct historical state.
+- Attempting to promote a `VIA_CHART` image without `allow_override` is
+  rejected; with it, drift is reported.
+- The builder credential is verifiably unable to promote.
+
+---
+
+## AR-4 — Writeback
+
+**Goal:** promotion state reaches ArgoCD without anything reading the API
+synchronously.
+
+**Scope**
+- `writeback_outbox` written inside the promotion transaction.
+- `tools/app_registry/worker` — Temporal worker draining the outbox.
+- `WritebackWorkflow` (workflow id = promotion id) with activities: render state
+  → commit to gitops repo → put S3 snapshot → mark outbox done.
+- `state_hash` no-op detection; push-conflict retry.
+- `release_app` for `app-registry-worker`.
+- Point **one non-critical app's** ArgoCD source at registry-written state.
+
+**Exit criteria**
+- A promotion produces a gitops commit and an S3 snapshot within seconds.
+- Killing the worker mid-writeback and restarting completes exactly once.
+- The pilot app deploys end-to-end from a promotion.
+- Registry downtime demonstrably does not block an ArgoCD sync.
+
+**Blocked on** open question 2 in ARCHITECTURE.md (gitops repo target and file
+layout).
+
+---
+
+## AR-5 — Version allocation
+
+**Goal:** the registry becomes the version source of truth. Highest risk —
+CI now depends on the registry being up.
+
+**Scope**
+- Implement `ArtifactRegistry.AllocateVersion` against a unique
+  `(owner, kind, version)` constraint.
+- Replace `autoIncrementVersion` in `tools/release_helper_go/cmd/plan.go`.
+- **Keep writing git tags** as a redundant record and disaster-recovery path.
+- Backfill allocated versions from existing tags at cutover so numbering is
+  continuous.
+- Remove the release workflow's version-allocation concurrency group, now
+  redundant.
+
+**Exit criteria**
+- Concurrent releases of the same app cannot receive the same version.
+- Allocated versions match what tag-scanning would have produced, verified
+  against the AR-2 soak data.
+- A documented, rehearsed fallback to tag-based allocation exists.
+
+**Do not start** until AR-2's parity check has been clean across a meaningful
+number of real releases.
+
+---
+
+## Explicitly out of scope
+
+Not in any phase above; the schema accommodates them without migration.
+
+- Approval gates (`PENDING_APPROVAL` state exists but is never written).
+- Ephemeral / per-PR environments (an environment row insert, when wanted).
+- Automatic rollback on failed deploy — needs deploy-health signal the registry
+  does not have.
+- Web UI. The CLI stays thin specifically so this can be added without
+  reimplementing rules.
+- Backfilling historical artifacts from GHCR. Recommendation in
+  ARCHITECTURE.md: don't.

--- a/tools/app_registry/README.md
+++ b/tools/app_registry/README.md
@@ -1,0 +1,146 @@
+# App Registry
+
+A gRPC service that records what CI published and tracks which artifact is
+promoted to each environment.
+
+Today the monorepo's release system is declarative and works well: `release_app`
+manifests describe apps, `tools/release_helper_go` builds images and charts from
+them, and git tags track versions. What has no home is **promotion state** —
+"stage is running `manmanv2-control-api v1.4.0`, prod is two versions behind".
+That currently lives implicitly in ArgoCD values files and in people's heads.
+
+The App Registry gives that state a home, and along the way becomes the
+authoritative index of every artifact CI has published.
+
+**The registry records and answers questions. It does not deploy anything.**
+Deployment stays with ArgoCD, reading state the registry writes back to the
+gitops repo.
+
+## What it is not
+
+- Not a deployer. It never talks to a cluster.
+- Not a replacement for GHCR. The OCI registry still holds the bits; this holds
+  the metadata and the promotion state.
+- Not an approval workflow engine (yet). The schema leaves room — see
+  [ARCHITECTURE.md](ARCHITECTURE.md#future-approval-gate) — but AR-3 promotes
+  immediately.
+
+## Core concepts
+
+| Concept | What it means |
+|---|---|
+| **App** | One `release_app` manifest. Identity is `<domain>-<name>`. |
+| **Chart** | A Helm chart composing one or more apps. Usually the real deploy unit. |
+| **Deploy unit** | Declared per app: does it reach an environment via a `chart`, as a standalone `image`, or `none` (build-only)? This is what makes "what can I promote?" answerable. |
+| **Build** | One CI run. Every artifact traces back to a commit and workflow run. |
+| **Artifact** | A published image or chart, identified by **digest**. The semver tag is a label; the digest is the identity. |
+| **Environment** | A row (`dev`/`stage`/`prod`/…), not an enum, so new environments are an insert. |
+| **Promotion** | SCD2 state: which artifact is current in an environment, and what was current at any past instant. |
+
+### Promotability
+
+The single most useful thing the registry encodes. Each artifact carries a
+derived `promotability`, computed from its owning app's declared deploy unit:
+
+- `PROMOTABLE` — a legal, first-class promotion target.
+- `VIA_CHART` — reaches environments only by being pinned inside a chart.
+  Promoting it directly is possible but recorded as an **override** and reported
+  as drift.
+- `NOT_PROMOTABLE` — never deployed; promotion is rejected.
+
+So `app-registry promote --list` shows exactly the things you can legally
+promote, rather than every image ever pushed.
+
+## Flows
+
+### Recording (CI, additive and non-blocking)
+
+```mermaid
+sequenceDiagram
+    participant GHA as GitHub Actions
+    participant RH as release_helper_go
+    participant REG as app-registry-api
+    participant DB as Postgres
+    participant GHCR as GHCR / Helm OCI
+
+    GHA->>RH: plan (bazel query release_app)
+    RH->>REG: ReconcileApps(manifests, git_sha)
+    REG->>DB: upsert apps/charts, flag absent as MISSING
+    GHA->>REG: RecordBuild(git_sha, run_id, attempt)
+    GHA->>GHCR: push image
+    GHCR-->>GHA: digest
+    GHA->>REG: RecordArtifact(IMAGE, version, digest)
+    GHA->>GHCR: push chart (image digests pinned by tools/helm)
+    GHA->>REG: RecordArtifact(CHART, version, digest, contains:[image digests])
+    Note over GHA,REG: best-effort — a registry failure warns,<br/>it does not fail the release
+    GHA->>GHA: git tag (still authoritative until AR-5)
+```
+
+### Promotion and writeback
+
+```mermaid
+sequenceDiagram
+    actor H as Human
+    participant CLI as app-registry CLI
+    participant REG as app-registry-api
+    participant DB as Postgres
+    participant TW as app-registry-worker (Temporal)
+    participant GIT as gitops repo
+    participant S3 as S3 snapshot
+    participant ARGO as ArgoCD
+
+    H->>CLI: promote manmanv2-api v1.4.0 --env prod --reason "..."
+    CLI->>REG: Promote(...)
+    REG->>REG: authz(env) + promotability check
+    rect rgb(238,244,255)
+    Note over REG,DB: one transaction
+    REG->>DB: close current promotion (valid_to = now)
+    REG->>DB: insert promotion (valid_from = now)
+    REG->>DB: insert promotion_event (actor, reason)
+    REG->>DB: insert outbox row (writeback intent)
+    end
+    REG-->>CLI: promotion + superseded (rollback target)
+    TW->>DB: poll outbox, start WritebackWorkflow
+    TW->>REG: GetEnvironmentState(env)
+    TW->>GIT: commit rendered values (retry on conflict)
+    TW->>S3: put env-state.json
+    TW->>DB: record workflow id on the event
+    ARGO->>GIT: sync
+```
+
+The transactional outbox matters: the promotion row and the intent to write
+back commit together, so the registry can never believe something was promoted
+without a writeback eventually happening. See
+[ARCHITECTURE.md](ARCHITECTURE.md#writeback-outbox--temporal).
+
+### Incident-time query
+
+```mermaid
+graph LR
+    Q["what is prod running?"] --> P["promotion (SCD2)<br/>valid_to IS NULL"]
+    P --> C["chart artifact v1.4.0<br/>digest sha256:..."]
+    C -->|contains| I["image artifact<br/>digest sha256:..."]
+    I --> B["build: git_sha, run_id, actor"]
+    P -. "deploy_unit = image" .-> I
+    T["what was prod running at time T?"] --> P2["promotion where<br/>valid_from &lt;= T &lt; valid_to"]
+    P2 --> C
+```
+
+## Components
+
+| Target | What it is |
+|---|---|
+| `//tools/app_registry/protos:appregistrypb` | Proto definitions and generated Go |
+| `//tools/app_registry/server` | gRPC server (`app-registry-api`) |
+| `//tools/app_registry/worker` | Temporal worker (`app-registry-worker`) — gitops writeback |
+| `//tools/app_registry/cli` | Thin gRPC client (`app-registry`) |
+| `//tools/app_registry/migrate` | Schema migrations (`app-registry-migration`) |
+
+The CLI is deliberately **thin** — no version math, no promotion-legality
+checks. All rules live server-side so a future UI cannot drift from it.
+
+## Status
+
+Design stage. No implementation yet. See [PLAN.md](PLAN.md) for phasing and
+[ARCHITECTURE.md](ARCHITECTURE.md) for the data model and the decisions behind
+it.

--- a/tools/app_registry/TOC.md
+++ b/tools/app_registry/TOC.md
@@ -1,0 +1,33 @@
+# App Registry — TOC
+
+gRPC service that records published artifacts and tracks per-environment
+promotion state. Design stage — no implementation yet.
+
+## Documents
+
+| File | When to read it |
+|------|-----------------|
+| [README.md](README.md) | Starting point — what the registry is, core concepts, end-to-end flow diagrams |
+| [ARCHITECTURE.md](ARCHITECTURE.md) | Before changing the data model, promotability rules, auth split, or writeback mechanism. Contains rejected alternatives and open questions. |
+| [PLAN.md](PLAN.md) | Before starting work — phase definitions (AR-0 … AR-5), scope, and exit criteria |
+| `TODO-<PLAN_ID>.md` | Execution tracking for an in-flight phase; created when that phase starts |
+| `ENV.md` | Not yet written — add when the server gains runtime configuration (AR-1) |
+
+## Components
+
+| Path | Purpose |
+|------|---------|
+| [protos/](protos/) | Proto contracts for all four services (`AppRegistry`, `ArtifactRegistry`, `PromotionRegistry`, `EnvironmentRegistry`) |
+| [server/](server/) | gRPC server — `app-registry-api` |
+| [worker/](worker/) | Temporal worker — gitops writeback (`app-registry-worker`) |
+| [cli/](cli/) | Thin gRPC client — `app-registry` |
+| [migrate/](migrate/) | Schema migrations — `app-registry-migration` |
+
+## Related
+
+- [`../../docs/RELEASE.md`](../../docs/RELEASE.md) — the existing release system this registry indexes
+- [`../appmeta/README.md`](../appmeta/README.md) — **shared manifest schema** (`AppManifest`, `DeployUnit`); the registry consumes it rather than defining its own
+- [`../bazel/release.bzl`](../bazel/release.bzl) — `release_app` manifests, the source of app identity
+- [`../helm/README.md`](../helm/README.md) — chart composition; source of the chart→image lockfile
+- [`../release_helper_go/`](../release_helper_go/) — release CLI that will call the registry
+- [`../../AGENTS.md`](../../AGENTS.md) — SCD2 conventions used by the `promotion` table

--- a/tools/app_registry/cli/README.md
+++ b/tools/app_registry/cli/README.md
@@ -1,0 +1,51 @@
+# app-registry (CLI)
+
+Thin gRPC client for the App Registry. Skeleton in **AR-1**, commands added
+alongside the RPCs they call in **AR-2** / **AR-3**.
+
+Not yet implemented.
+
+## Thin means thin
+
+**No business logic lives here.** No version math, no promotability rules, no
+promotion-legality checks — those are server-side so a future UI cannot drift
+from the CLI. This file exists mostly to state that constraint.
+
+The CLI validates argument shape, calls one RPC, and formats the response.
+
+## Intended commands
+
+```
+app-registry apps list [--domain D] [--status S] [--deploy-unit U]
+app-registry apps get <domain-name>
+app-registry apps set-status <domain-name> --status archived --reason "..."
+app-registry apps reconcile --from-plan <file> [--dry-run]     # CI
+
+app-registry artifacts list <domain-name> [--kind image|chart] [--promotable]
+app-registry artifacts get <domain-name> --version vX.Y.Z
+app-registry artifacts resolve <digest|artifact-id>            # chart -> images
+app-registry artifacts record ...                              # CI
+
+app-registry promote <domain-name> <version> --env prod --reason "..."
+                     [--allow-override] [--dry-run]
+app-registry rollback <domain-name> --env prod --reason "..."
+app-registry status <env> [--domain D] [--at <RFC3339>]
+app-registry history <domain-name> [--env E]
+app-registry diff <env-a> <env-b>
+
+app-registry env list | upsert | archive                       # admin
+```
+
+`--promotable` on `artifacts list` is the answer to "what can I actually
+promote?" — it filters by the derived promotability described in
+[`../ARCHITECTURE.md`](../ARCHITECTURE.md#promotability).
+
+## Conventions
+
+- Cobra, matching `tools/release_helper_go`.
+- Invoked in CI as `bazel run //tools/app_registry/cli:app-registry -- ...`,
+  the same pattern as `release_helper_go` in `.github/workflows/release.yml`.
+- `--format json|table`; JSON output is what CI parses.
+- Client auth via `libs/go/grpcauth` client credentials. Promotion commands use
+  a different credential than recording commands — see the auth split in
+  [`../ARCHITECTURE.md`](../ARCHITECTURE.md#authorization).

--- a/tools/app_registry/migrate/README.md
+++ b/tools/app_registry/migrate/README.md
@@ -1,0 +1,54 @@
+# app-registry-migration
+
+Schema migration runner for the App Registry database. Built in **AR-1**.
+
+Not yet implemented.
+
+## Pattern
+
+Follows `manmanv2/migrate` exactly — embedded SQL plus `libs/go/migrate`:
+
+```go
+//go:embed migrations/*.sql
+var migrations embed.FS
+
+func main() { migrate.RunCLI(migrations, "migrations") }
+```
+
+Deployed as a Helm pre-sync job (`app_type: job`), ordered ahead of the API via
+ArgoCD sync waves. See `friendly_computing_machine/docs/argocd-integration.md`.
+
+## Planned migrations
+
+| File | Contents |
+|---|---|
+| `001_initial_schema` | `app`, `chart`, `chart_app`, `build`, `artifact`, `artifact_link`, `idempotency_key` |
+| `002_environments_promotions` | `environment`, `promotion` (SCD2), `promotion_event`, `v_current_promotion` |
+| `003_writeback_outbox` | `writeback_outbox` |
+
+Split this way so AR-2 needs only `001`, AR-3 adds `002`, and AR-4 adds `003` —
+each phase ships an independently applicable migration.
+
+## Required indexes
+
+Do not omit these; they are load-bearing, not optimizations.
+
+```sql
+-- makes double-promotion structurally impossible, and is the hot read path
+CREATE UNIQUE INDEX promotion_current_idx
+  ON promotion (environment_id, target_key)
+  WHERE valid_to IS NULL;
+
+-- historical "state at time T" queries
+CREATE INDEX promotion_window_idx
+  ON promotion (environment_id, target_key, valid_from DESC);
+
+-- digest is the real artifact identity
+CREATE UNIQUE INDEX artifact_digest_idx ON artifact (digest);
+
+-- version allocation collision guard (AR-5 depends on this)
+CREATE UNIQUE INDEX artifact_version_idx ON artifact (owner_id, kind, version);
+```
+
+See the SCD2 section of [`../ARCHITECTURE.md`](../ARCHITECTURE.md#scd2-on-promotion)
+and the repo-wide convention in `AGENTS.md`.

--- a/tools/app_registry/server/README.md
+++ b/tools/app_registry/server/README.md
@@ -1,0 +1,40 @@
+# app-registry-api
+
+gRPC server implementing all four services in
+[`../protos/api.proto`](../protos/api.proto). Built in **AR-1** (skeleton) and
+filled in across **AR-2** / **AR-3**.
+
+Not yet implemented.
+
+## Intended layout
+
+```
+server/
+  main.go             # wiring: config, db pool, auth interceptors, grpc.Serve
+  handlers/           # one file per service, thin — validation + delegation
+    app.go            # AppRegistry
+    artifact.go       # ArtifactRegistry
+    promotion.go      # PromotionRegistry
+    environment.go    # EnvironmentRegistry
+  repository/         # interfaces
+    postgres/         # pgx implementations, SCD2 transactions
+  promotability/      # deploy_unit -> Promotability rules + override checks
+  idempotency/        # key storage and response replay
+```
+
+## Conventions
+
+- Follows `manmanv2/api` for structure: `go_binary` + `release_app`, otelgrpc
+  interceptors, reflection enabled.
+- `libs/go/db` for the pgx pool, `libs/go/grpcauth` for OIDC, `libs/go/logging`
+  for structured logs.
+- Business rules live here, never in the CLI — see
+  [`../ARCHITECTURE.md`](../ARCHITECTURE.md).
+- Every write RPC requires an `idempotency_key` and replays stored responses.
+- Promotion writes close-and-open SCD2 rows plus the audit event plus the
+  writeback outbox row in **one transaction**.
+
+## Release metadata
+
+`app_type: internal-api`, `port: 50051`. Only reachable in-cluster and by CI —
+it is not an external API.

--- a/tools/app_registry/worker/README.md
+++ b/tools/app_registry/worker/README.md
@@ -1,0 +1,49 @@
+# app-registry-worker
+
+Temporal worker that drains the `writeback_outbox` and propagates promotion
+state to the gitops repo and the S3 snapshot. Built in **AR-4**.
+
+Not yet implemented.
+
+## Why a worker at all
+
+The API must never push to git inside a promotion RPC — a git push is slow,
+fails transiently, and cannot participate in the promotion transaction. Instead
+the API writes an outbox row atomically with the promotion, and this worker
+turns that intent into durable, retryable work.
+
+Temporal cannot enlist in a Postgres transaction, so the outbox — not Temporal —
+is what guarantees a promotion is never lost. Temporal is the executor.
+
+## Intended layout
+
+```
+worker/
+  main.go             # temporal worker bootstrap via libs/go/temporal
+  poller/             # outbox drain loop -> StartWorkflow(id = promotion_id)
+  workflows/
+    writeback.go      # WritebackWorkflow
+  activities/
+    render.go         # GetEnvironmentState -> rendered values document
+    gitops.go         # clone/commit/push, retry on conflict
+    snapshot.go       # put env-state.json to S3 (libs/go/s3)
+    complete.go       # mark outbox row done, stamp workflow id on the event
+```
+
+## Guarantees
+
+- Workflow id is the promotion id, so Temporal dedups redelivered outbox rows.
+- Every activity is idempotent and independently retryable.
+- `state_hash` from `GetEnvironmentState` short-circuits no-op commits.
+- Push conflicts retry by re-reading current state — last writer wins per
+  environment file, which is correct since the registry owns that file.
+
+## Dependencies not yet in the repo
+
+`go.temporal.io/sdk` is not in `go.mod`/`MODULE.bazel`, and `libs/go/temporal`
+does not exist (`friendly_computing_machine` uses the Python SDK only). Both
+land in **AR-1**.
+
+## Release metadata
+
+`app_type: worker`.


### PR DESCRIPTION
Documents the app registry ahead of implementation, so the modelling and
sequencing decisions are reviewable before any code is written.

  - README.md        concepts and mermaid flows: CI recording, promotion and
                     writeback, and the incident-time query
  - ARCHITECTURE.md  data model, SCD2 usage, promotability rules, auth split,
                     writeback mechanism, rejected alternatives, open questions
  - PLAN.md          phases AR-M and AR-0..AR-5 with scope and exit criteria
  - TOC.md           domain index per the repo doc conventions

Component directories carry a README stating intended layout and the
constraints that are easy to violate later — notably that the CLI stays a
thin client with no business logic, so a future UI cannot drift from it.

Sequencing rationale, since it is the part most likely to be argued with:
promotion tracking is additive and low-risk, while replacing git-tag version
allocation moves a working source of truth into a stateful service. Do the
first, soak it against real releases, then do the second. Shipping AR-5
before AR-3 would put a registry outage in the path of every release before
the registry had delivered anything.

AR-M (manifest schema consolidation) is sequenced first because it repays
itself independently of whether the registry ever ships.

Two design points worth reviewer attention:

  - Nothing in the deploy path calls the API synchronously. ArgoCD reads the
    gitops repo that the worker writes, and CI recording is best-effort. This
    is what makes it safe for the registry to be a release_app in this repo
    that deploys itself.
  - Promotion and the intent to write it back must commit atomically, so the
    server writes a transactional outbox row inside the promotion
    transaction and Temporal executes from it. Without that the registry can
    believe prod moved while the gitops repo disagrees — the exact failure
    this system exists to prevent.

Temporal is not yet a Go dependency anywhere in this repo (fcm uses the
Python SDK), so libs/go/temporal and the MODULE.bazel wiring are called out
as the largest unknown in AR-1.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>