### PR TITLE
App Registry: design record, gRPC contracts, and shared manifest schema

### DIFF
--- a/tools/TOC.md
+++ b/tools/TOC.md
@@ -8,6 +8,7 @@ Build, release, and development tooling.
 - [helm/APP_TYPES.md](helm/APP_TYPES.md) — App type reference (`external-api`, `internal-api`, `worker`, `job`)
 - `//tools:release` — Release automation CLI; see [`docs/RELEASE.md`](../docs/RELEASE.md) for usage
 - [appmeta/README.md](appmeta/README.md) — Proto schema of record for `release_app` manifest JSON, shared by `release_helper_go`, the helm composer, and the app registry (**design stage**, consumers not yet migrated)
+- [app_registry/TOC.md](app_registry/TOC.md) — App Registry: gRPC service indexing published artifacts and tracking per-environment promotion state (**design stage**, not implemented)
 
 ## Local Development
 

--- a/tools/TOC.md
+++ b/tools/TOC.md
@@ -7,6 +7,7 @@ Build, release, and development tooling.
 - [helm/README.md](helm/README.md) — Bazel Helm chart generation system (quick start + common patterns)
 - [helm/APP_TYPES.md](helm/APP_TYPES.md) — App type reference (`external-api`, `internal-api`, `worker`, `job`)
 - `//tools:release` — Release automation CLI; see [`docs/RELEASE.md`](../docs/RELEASE.md) for usage
+- [appmeta/README.md](appmeta/README.md) — Proto schema of record for `release_app` manifest JSON, shared by `release_helper_go`, the helm composer, and the app registry (**design stage**, consumers not yet migrated)
 
 ## Local Development
 

--- a/tools/app_registry/ARCHITECTURE.md
+++ b/tools/app_registry/ARCHITECTURE.md
@@ -1,0 +1,263 @@
+# App Registry — Architecture
+
+Design record for `//tools/app_registry`. Read [README.md](README.md) first for
+what the system is and the end-to-end flows.
+
+## Design principles
+
+1. **Manifests stay authoritative.** The registry never invents app metadata.
+   It ingests `release_app` manifests via `bazel query` and reconciles. If the
+   registry and the manifests disagree, the manifests win.
+2. **Digests are identity; tags are labels.** Every artifact is stored by
+   `sha256:` digest. Semver tags are recorded for humans and can move.
+3. **The API is the write path; git is the delivery path.** Deployment tooling
+   reads state from the gitops repo (or an S3 snapshot), never synchronously
+   from the API. The registry being down must not block a deploy.
+4. **Additive before authoritative.** The registry observes releases for a full
+   phase before it is allowed to allocate versions. Git tags remain a redundant
+   record permanently — they cost nothing and are the disaster-recovery path.
+5. **Record, don't act.** The registry mutates rows and emits writeback intents.
+   It never touches a cluster.
+
+## Shared manifest schema
+
+The registry does **not** define its own app-manifest shape. `AppManifest`,
+`ChartManifest`, `AppManifestSet` and `DeployUnit` live in
+[`//tools/appmeta/proto`](../appmeta/README.md), the schema of record for the
+JSON that `app_metadata` and `helm_chart_metadata` emit.
+
+This matters because two Go structs already decode that JSON — one in
+`release_helper_go`, one in `tools/helm/composer.go` — and they had drifted from
+each other and from the Starlark rule. The registry would have been a third.
+Instead it consumes the shared contract, so `ReconcileApps` takes an
+`AppManifestSet` verbatim and adding a field to `release_app` propagates
+everywhere with no per-consumer edit.
+
+Dependency direction is load-bearing: `appmeta` depends on nothing, and the
+schema must not live under `app_registry`, or `tools/helm` would depend on the
+registry in order to build a chart.
+
+Drift is prevented by the contract test described in the appmeta README, not by
+the shared type alone — `protojson` decoding with `DiscardUnknown: false` turns
+any unmodelled Starlark output key into a test failure.
+
+## Data model
+
+```mermaid
+erDiagram
+    APP ||--o{ ARTIFACT : publishes
+    CHART ||--o{ ARTIFACT : publishes
+    CHART }o--o{ APP : composes
+    BUILD ||--o{ ARTIFACT : produced
+    ARTIFACT ||--o{ ARTIFACT_LINK : pins
+    ARTIFACT ||--o{ PROMOTION : promoted_as
+    ENVIRONMENT ||--o{ PROMOTION : hosts
+    PROMOTION ||--o{ PROMOTION_EVENT : audited_by
+    PROMOTION ||--o{ WRITEBACK_OUTBOX : triggers
+```
+
+### Tables
+
+| Table | Shape | Notes |
+|---|---|---|
+| `app` | mutable, reconciled | `(domain, name)` unique. `status` ∈ active/missing/archived. Never hard-deleted. |
+| `chart` | mutable, reconciled | `(domain, name)` unique. |
+| `chart_app` | join | Which apps a chart composes, per its manifest. |
+| `build` | append-only | `(workflow_run_id, workflow_attempt)` unique. |
+| `artifact` | append-only | `digest` globally unique. `(owner, kind, version)` unique. |
+| `artifact_link` | append-only | Chart artifact → pinned image artifact. |
+| `environment` | mutable | `key` unique. `rank` orders promotion legality. |
+| `promotion` | **SCD2** | `valid_from` / `valid_to`. Partial unique index on current rows. |
+| `promotion_event` | append-only | Who, why, when, and the Temporal workflow id. |
+| `writeback_outbox` | append-only + claimed | Transactional outbox, drained by the worker. |
+| `idempotency_key` | append-only | Key → prior response, for safe CI retries. |
+
+### SCD2 on `promotion`
+
+Follows the repo-wide convention in `AGENTS.md` exactly:
+
+```sql
+-- write path: close and open, in one transaction
+UPDATE promotion SET valid_to = NOW()
+ WHERE environment_id = $1 AND target_key = $2 AND valid_to IS NULL;
+INSERT INTO promotion (environment_id, target_key, artifact_id, ...)
+VALUES ($1, $2, $3, ...);
+```
+
+```sql
+-- current state
+SELECT * FROM promotion
+ WHERE environment_id = $1 AND valid_to IS NULL;
+
+-- state at time T (the incident query)
+SELECT * FROM promotion
+ WHERE environment_id = $1
+   AND valid_from <= $t
+   AND (valid_to IS NULL OR valid_to > $t);
+```
+
+Backed by `CREATE UNIQUE INDEX ON promotion(environment_id, target_key) WHERE
+valid_to IS NULL` — this both accelerates the hot query and makes
+double-promotion structurally impossible.
+
+`target_key` is the promoted thing's identity (`<kind>:<owner_full_name>`),
+denormalized so the partial unique index is expressible without a nullable
+two-column target.
+
+A `v_current_promotion` view pre-joins promotion → artifact → app/chart → build
+so the CLI, the writeback worker, and any future UI never re-derive the join.
+
+## Promotability
+
+The rule the whole system hangs on. Each app declares its `deploy_unit` in its
+`release_app` manifest; the registry derives artifact promotability from it.
+
+| App `deploy_unit` | Image artifacts | Chart artifacts |
+|---|---|---|
+| `chart` | `VIA_CHART` | `PROMOTABLE` |
+| `image` | `PROMOTABLE` | n/a |
+| `none` | `NOT_PROMOTABLE` | n/a |
+
+**Override.** Promoting a `VIA_CHART` image directly is rejected unless the
+caller passes `allow_override`. When allowed, the promotion is stored with
+`is_override = true` and `GetEnvironmentState` reports it as a `DriftEntry`
+against the chart's pinned digest. This makes the manmanv2-host-manager style
+of hotfix possible without making it invisible.
+
+**Why this is on the app, not the artifact:** it is a property of how the app is
+deployed, which is declarative and belongs next to the code — the same place
+`app_type` and `port` already live. The registry reads it; it does not own it.
+
+### Required change to `release_app`
+
+`tools/bazel/release.bzl` gains a `deploy_unit` attribute (default `"chart"`),
+mirrored by `DeployUnit` in `//tools/appmeta/proto`. This is one of three
+changes that touch existing code paths rather than being purely additive —
+the others being the chart lockfile below and the manifest-schema
+consolidation.
+
+## Chart → image lockfile
+
+`tools/helm/composer.go` already resolves the exact image tags it bakes into a
+chart. It must additionally resolve them to **digests** and emit a lockfile that
+CI forwards to `RecordArtifact(kind = CHART, contains = [...])`.
+
+Without this, chart promotion cannot answer "which image digest is running",
+and the incident query degrades to rendering charts by hand. This is the
+highest-value part of the recording phase and should not be deferred.
+
+The server rejects a chart artifact that references an image digest it has never
+recorded — a chart may not pin an unknown artifact.
+
+## Writeback: outbox → Temporal
+
+Promotion and the intent to write it back **must** commit atomically. If they
+don't, the registry can believe prod is on v1.4.0 while the gitops repo still
+says v1.3.0, which is the exact failure mode this system exists to prevent.
+
+Since Temporal cannot enlist in a Postgres transaction, the server writes a
+`writeback_outbox` row inside the promotion transaction. The worker drains the
+outbox and starts a `WritebackWorkflow` with the promotion id as its workflow
+id, so Temporal's own dedup makes redelivery harmless.
+
+```mermaid
+graph LR
+    P["Promote RPC<br/>(one tx)"] --> DB[("promotion<br/>+ event<br/>+ outbox")]
+    DB --> D["worker: drain outbox"]
+    D --> W["WritebackWorkflow<br/>id = promotion_id"]
+    W --> A1["activity: render env state"]
+    A1 --> A2["activity: commit to gitops repo"]
+    A2 --> A3["activity: put S3 snapshot"]
+    A3 --> A4["activity: mark outbox done"]
+```
+
+Activities are individually retryable and idempotent. The gitops commit uses
+`state_hash` from `GetEnvironmentState` to skip no-op commits, and retries on
+push conflict by re-reading state — last writer wins on a per-environment file,
+which is correct because the registry is the source of truth for that file.
+
+**Temporal is not yet a Go dependency in this repo.** `friendly_computing_machine`
+uses the Python SDK only. `go.temporal.io/sdk` needs adding to `go.mod` and
+`MODULE.bazel`, and a `libs/go/temporal` helper package (client construction,
+env config, worker bootstrap, logging bridge to `libs/go/logging`) needs to
+exist. This is real scope — see AR-1 in [PLAN.md](PLAN.md).
+
+## Authorization
+
+Enforced with `libs/go/grpcauth` (OIDC), split along the service boundary:
+
+| Role | Services | Credential |
+|---|---|---|
+| `builder` | `AppRegistry` (writes), `ArtifactRegistry` (writes) | GitHub Actions OIDC, unrestricted workflows |
+| `promoter` | `PromotionRegistry` (writes) | **Environment-scoped** GitHub OIDC subject, or a human's token |
+| `admin` | `EnvironmentRegistry`, `SetAppStatus` | Human only |
+| reader | all reads | Any authenticated principal |
+
+**The critical constraint:** the credential every build job already holds must
+not be able to promote. Promotion workflows use a GitHub Environment-scoped OIDC
+subject so the `builder` token cannot self-promote. Per-environment
+`allowed_principals` narrows this further for prod.
+
+`reason` is required on promotions to any environment above rank 0.
+
+## Idempotency
+
+Every write RPC takes a required `idempotency_key`. The server stores key →
+serialized response; a repeat returns the original response with an
+`already_*` flag rather than re-executing. CI reruns and Temporal activity
+retries are therefore safe by construction.
+
+Convention: `<workflow_run_id>-<attempt>[-<owner>-<kind>]` for CI; a
+client-generated UUID for human promotions.
+
+## Availability and bootstrap
+
+The registry is itself a `release_app` in this monorepo, so it deploys itself.
+That circularity is only safe because **nothing in the deploy path calls the
+API synchronously**:
+
+- ArgoCD reads the gitops repo, which the worker writes.
+- The S3 snapshot is an auth-free read path for tooling that has no gRPC client.
+- CI recording is best-effort: a registry outage warns, it does not fail a
+  release.
+
+The registry can be down for hours without blocking a release or a deploy. The
+only thing lost is the ability to *make new promotions* during the outage.
+
+## Rejected alternatives
+
+| Decision | Chosen | Rejected | Why |
+|---|---|---|---|
+| Async durability | Temporal + outbox | River | River was a trial and is being retired repo-wide. |
+| Async durability | Temporal + outbox | RabbitMQ | Cannot enlist in the promotion transaction; would need an outbox anyway, so the outbox is the real mechanism and Temporal is the better executor for a multi-step, retryable git push. |
+| Transport | gRPC + thin Go CLI | grpc-gateway / connect-go | Every CI caller in this repo is already `bazel run` on a Go CLI. A gateway is pure complexity until a browser UI exists. |
+| Environments | table rows | proto enum | Ephemeral and regional environments become an insert, not a release. |
+| Bundling | chart pins image digests | registry-side "release bundle" | Charts already are the bundle. Inventing a parallel grouping would duplicate what `tools/helm` composes. |
+| Missing apps | flag `MISSING` for triage | auto-archive | A rename would silently orphan promotion history. |
+| Version source of truth | registry (AR-5), tags retained | tags only | A unique constraint beats `git tag --sort` plus a CI concurrency group for concurrent allocation. |
+| Manifest schema | shared `//tools/appmeta/proto` | registry-local manifest messages | Two hand-written Go structs already decode the manifest JSON and had drifted; a third would compound it. |
+| Manifest schema | proto + `protojson` | shared hand-written Go struct | `protojson` reads the existing snake_case JSON unchanged, and `DiscardUnknown: false` turns drift into a test failure. |
+
+## Future: approval gate
+
+Deliberately unimplemented, but the schema accommodates it without migration:
+
+- `environment.requires_approval` already exists.
+- `PromotionState.PENDING_APPROVAL` already exists.
+- `PromotionAction.APPROVE` / `REJECT` already exist.
+
+When built, `Promote` against a gated environment writes a promotion in
+`PENDING_APPROVAL` with no outbox row; a later `Approve` transitions it to
+`ACTIVE` and enqueues the writeback. Rollback needs nothing new — it is a
+`Promote` to the artifact that SCD2 history already identifies as previous.
+
+## Open questions
+
+1. **Chart identity source.** `tools/helm` composes charts from Bazel targets;
+   the exact query for enumerating charts and their member apps needs pinning
+   down before AR-1.
+2. **Gitops repo target.** Which repo/branch the worker commits to, and whether
+   per-environment files or one file per app. Blocks AR-3.
+3. **Migration of existing state.** Backfilling historical artifacts from git
+   tags and GHCR is optional. Recommendation: don't. Start recording from AR-2
+   forward and let history accumulate.

--- a/tools/app_registry/ARCHITECTURE.md
+++ b/tools/app_registry/ARCHITECTURE.md
@@ -254,11 +254,19 @@ When built, `Promote` against a gated environment writes a promotion in
 ## Resolved questions
 
 **1. Chart identity source — already solved, reuse it.**
-`ListAllHelmCharts` in `tools/release_helper_go/cmd/plan_helm.go` runs
-`bazel query "kind(helm_chart_metadata, //...)"` and reads each target's
-`*_chart_metadata.json`, exactly mirroring app discovery. Chart identity comes
-from that existing path; `ChartManifest` in `//tools/appmeta/proto` is the typed
-form of the JSON it already reads. No new discovery mechanism.
+`ListAllHelmCharts` in `tools/release_helper_go/cmd/plan_helm.go` mirrors
+`ListAllApps` exactly: a loading-phase `bazel query` lists the metadata target
+labels, then a `bazel cquery --output=starlark` scoped to those labels reads
+the `HelmChartMetadataInfo` provider. Chart identity comes from that existing
+path. No new discovery mechanism.
+
+Note this changed in #444: discovery reads Starlark **providers**
+(`AppMetadataInfo` / `HelmChartMetadataInfo`) rather than building each
+target's `*_metadata.json`, so no actions run. The provider carries the same
+dict the JSON file does — the cquery expression is literally
+`json.encode(...metadata)` — so `//tools/appmeta/proto` remains the correct
+schema for both delivery mechanisms, and the contract test gets cheaper
+(analysis-only).
 
 **2. Writeback is interface-only for now.**
 Wiring the gitops repo requires changes in another repository that are out of

--- a/tools/app_registry/ARCHITECTURE.md
+++ b/tools/app_registry/ARCHITECTURE.md
@@ -251,13 +251,58 @@ When built, `Promote` against a gated environment writes a promotion in
 `ACTIVE` and enqueues the writeback. Rollback needs nothing new — it is a
 `Promote` to the artifact that SCD2 history already identifies as previous.
 
+## Resolved questions
+
+**1. Chart identity source — already solved, reuse it.**
+`ListAllHelmCharts` in `tools/release_helper_go/cmd/plan_helm.go` runs
+`bazel query "kind(helm_chart_metadata, //...)"` and reads each target's
+`*_chart_metadata.json`, exactly mirroring app discovery. Chart identity comes
+from that existing path; `ChartManifest` in `//tools/appmeta/proto` is the typed
+form of the JSON it already reads. No new discovery mechanism.
+
+**2. Writeback is interface-only for now.**
+Wiring the gitops repo requires changes in another repository that are out of
+scope. AR-4 therefore delivers the *contract* — outbox, workflow, and a
+`Writeback` activity interface — with a stub implementation that renders state
+and writes it locally without publishing anywhere. The real gitops and S3
+activities plug in behind that interface later with no schema or API change.
+
+Consequence: nothing before AR-4 needs Temporal, so the `libs/go/temporal`
+work moves out of AR-1 and into AR-4. That removes the largest unknown from
+the foundations phase.
+
+Consequence: until the real writeback lands, `GetEnvironmentState` is the only
+way to consume promotion state. That is acceptable because no deploy tooling
+depends on it yet — but it means the "registry can be down without blocking a
+deploy" property is untested until AR-4 completes for real.
+
+**3. No backfill; adopt by per-domain cutover.**
+Historical artifacts are not backfilled from git tags or GHCR — history
+accumulates from AR-2 forward.
+
+Adoption is **per domain**, not global. A domain can publish through the
+registry while every other domain stays on the existing tag-based path, which
+allows a fast, low-blast-radius rollout instead of one repo-wide switch.
+
+This needs a `domain_adoption` table keyed by domain, recording which
+capabilities the registry is authoritative for:
+
+| Stage | Meaning |
+|---|---|
+| `observe` | Registry records builds and artifacts. Git tags remain authoritative. Default for every domain from AR-2. |
+| `promote` | Promotion state for this domain is tracked and consumed. |
+| `allocate` | Registry allocates versions for this domain; tag scanning is bypassed. |
+
+Recording (AR-2) is deliberately **not** gated — recording every domain is
+harmless and builds the parity evidence AR-5 depends on. The gate matters from
+AR-3 onward, and most of all at AR-5, where the source of truth actually
+changes hands.
+
+`AllocateVersion` must reject a domain not yet at `allocate`, so a
+misconfigured CI job fails loudly rather than silently allocating from the
+wrong source of truth.
+
 ## Open questions
 
-1. **Chart identity source.** `tools/helm` composes charts from Bazel targets;
-   the exact query for enumerating charts and their member apps needs pinning
-   down before AR-1.
-2. **Gitops repo target.** Which repo/branch the worker commits to, and whether
-   per-environment files or one file per app. Blocks AR-3.
-3. **Migration of existing state.** Backfilling historical artifacts from git
-   tags and GHCR is optional. Recommendation: don't. Start recording from AR-2
-   forward and let history accumulate.
+None blocking. The gitops repo layout is deferred rather than unresolved — it
+is answered when the writeback stub is replaced with the real implementation.

--- a/tools/app_registry/PLAN.md
+++ b/tools/app_registry/PLAN.md
@@ -65,9 +65,10 @@ problem.
 - Contract test `//tools/appmeta:manifest_contract_test`, both directions:
   every `app_metadata` target decodes with `DiscardUnknown: false`, and a
   full-coverage fixture app leaves no proto field unset.
-- Migrate `tools/helm/composer.go` to `appmetapb.AppManifest`. Resolve the
-  phantom `labels` / `annotations` / `dependencies` fields — either emit them
-  from the rule or delete them.
+- Migrate `tools/helm/composer.go` to `appmetapb.AppManifest`. The dead
+  `labels` / `annotations` / `dependencies` fields are already gone, as is the
+  map-iteration nondeterminism that would have made the golden-output test
+  below impossible.
 - Migrate `tools/release_helper_go` to `appmetapb.AppManifest`.
 - **Remove the `Language`-as-version hack** in `cmd/plan.go` (`apps[i].Language
   = version`, read back via `strings.HasPrefix(app.Language, "v")`), now that

--- a/tools/app_registry/PLAN.md
+++ b/tools/app_registry/PLAN.md
@@ -94,10 +94,6 @@ Migrate it behind a golden-output test comparing rendered charts pre/post.
 **Goal:** everything the service needs to exist, with no business logic.
 
 **Scope**
-- `libs/go/temporal` — client construction, env-driven config, worker bootstrap,
-  logging bridge to `libs/go/logging`. Add `go.temporal.io/sdk` to `go.mod` and
-  `MODULE.bazel`. **This does not exist yet in Go anywhere in the repo** and is
-  the largest unknown in this phase.
 - `tools/app_registry/migrate` — `golang-migrate` runner over embedded SQL,
   following `manmanv2/migrate`. Schema per ARCHITECTURE.md, including the SCD2
   partial unique index and `v_current_promotion`.
@@ -113,9 +109,11 @@ Migrate it behind a golden-output test comparing rendered charts pre/post.
 - Migrations apply and roll back cleanly.
 - Server starts in Tilt and answers reflection + health.
 
-**Risks** — Temporal Go SDK under Bazel with cross-compilation. Read
-`docs/DOCKER.md` before touching image builds; ARM64 breakage is silent at build
-time.
+**Risks** — Read `docs/DOCKER.md` before touching image builds; ARM64 breakage
+is silent at build time.
+
+**Note:** Temporal moved out of this phase into AR-4. Nothing before the
+writeback needs it, and it was the largest unknown here.
 
 ---
 
@@ -172,28 +170,40 @@ compress this — it is the phase that earns the trust AR-5 spends.
 
 ---
 
-## AR-4 — Writeback
+## AR-4 — Writeback interface (stub implementation)
 
-**Goal:** promotion state reaches ArgoCD without anything reading the API
-synchronously.
+**Goal:** establish the contract that carries promotion state out of the
+registry, without wiring it to anything. Publishing targets live in another
+repo and are out of scope.
 
 **Scope**
 - `writeback_outbox` written inside the promotion transaction.
+- `libs/go/temporal` — client construction, env-driven config, worker
+  bootstrap, logging bridge to `libs/go/logging`. Add `go.temporal.io/sdk` to
+  `go.mod` and `MODULE.bazel`. **Not present in Go anywhere in this repo yet**
+  (fcm uses the Python SDK) — the largest unknown in the project, moved here
+  from AR-1 because nothing earlier needs it.
 - `tools/app_registry/worker` — Temporal worker draining the outbox.
-- `WritebackWorkflow` (workflow id = promotion id) with activities: render state
-  → commit to gitops repo → put S3 snapshot → mark outbox done.
-- `state_hash` no-op detection; push-conflict retry.
+- `WritebackWorkflow` (workflow id = promotion id) over a `Writeback`
+  activity interface, with a **stub implementation** that renders environment
+  state and writes it to a local path or object store — publishing nowhere.
+- `state_hash` no-op detection, so the real implementation inherits it.
 - `release_app` for `app-registry-worker`.
-- Point **one non-critical app's** ArgoCD source at registry-written state.
 
 **Exit criteria**
-- A promotion produces a gitops commit and an S3 snapshot within seconds.
-- Killing the worker mid-writeback and restarting completes exactly once.
-- The pilot app deploys end-to-end from a promotion.
-- Registry downtime demonstrably does not block an ArgoCD sync.
+- A promotion enqueues an outbox row in the same transaction and the workflow
+  drains it exactly once, verified by killing the worker mid-run.
+- Rendered state matches `GetEnvironmentState` output.
+- The activity interface is documented well enough that swapping the stub for a
+  gitops committer needs no schema, proto, or workflow change.
 
-**Blocked on** open question 2 in ARCHITECTURE.md (gitops repo target and file
-layout).
+**Explicitly not in scope:** committing to the gitops repo, S3 publication,
+pointing ArgoCD at registry-written state. Those land when the other repo's
+changes are ready.
+
+**Consequence to track:** the "registry can be down without blocking a deploy"
+property is not actually exercised until the real writeback ships. Do not claim
+it as verified before then.
 
 ---
 
@@ -205,18 +215,25 @@ CI now depends on the registry being up.
 **Scope**
 - Implement `ArtifactRegistry.AllocateVersion` against a unique
   `(owner, kind, version)` constraint.
-- Replace `autoIncrementVersion` in `tools/release_helper_go/cmd/plan.go`.
+- Replace `autoIncrementVersion` in `tools/release_helper_go/cmd/plan.go`,
+  gated on the calling domain's adoption stage.
+- **Per-domain cutover.** `AllocateVersion` serves only domains at stage
+  `allocate` and rejects the rest, so a misconfigured CI job fails loudly
+  rather than silently allocating against the wrong source of truth. Cut over
+  one low-traffic domain first, then widen.
 - **Keep writing git tags** as a redundant record and disaster-recovery path.
-- Backfill allocated versions from existing tags at cutover so numbering is
-  continuous.
-- Remove the release workflow's version-allocation concurrency group, now
-  redundant.
+- Seed each domain's starting version from its existing tags at the moment it
+  is promoted to `allocate`, so numbering stays continuous.
+- Remove the release workflow's version-allocation concurrency group once every
+  domain has cut over — not before.
 
 **Exit criteria**
 - Concurrent releases of the same app cannot receive the same version.
 - Allocated versions match what tag-scanning would have produced, verified
   against the AR-2 soak data.
-- A documented, rehearsed fallback to tag-based allocation exists.
+- A domain not at `allocate` still releases through the tag path, unchanged.
+- A documented, rehearsed fallback to tag-based allocation exists — per domain,
+  by moving its stage back.
 
 **Do not start** until AR-2's parity check has been clean across a meaningful
 number of real releases.

--- a/tools/app_registry/PLAN.md
+++ b/tools/app_registry/PLAN.md
@@ -66,9 +66,10 @@ problem.
   every `app_metadata` target decodes with `DiscardUnknown: false`, and a
   full-coverage fixture app leaves no proto field unset.
 - Migrate `tools/helm/composer.go` to `appmetapb.AppManifest`. The dead
-  `labels` / `annotations` / `dependencies` fields are already gone, as is the
-  map-iteration nondeterminism that would have made the golden-output test
-  below impossible.
+  `labels` / `annotations` / `dependencies` fields and the map-iteration
+  nondeterminism that would have made the golden-output test below impossible
+  are handled separately, in the `helm-deterministic-output` change. That must
+  land before this step.
 - Migrate `tools/release_helper_go` to `appmetapb.AppManifest`.
 - **Remove the `Language`-as-version hack** in `cmd/plan.go` (`apps[i].Language
   = version`, read back via `strings.HasPrefix(app.Language, "v")`), now that

--- a/tools/app_registry/PLAN.md
+++ b/tools/app_registry/PLAN.md
@@ -1,0 +1,236 @@
+# App Registry — Delivery Plan
+
+Phased build-out of `//tools/app_registry`. Each phase has a **plan ID**; worker
+agents track execution in a `TODO-<PLAN_ID>.md` alongside this file (e.g.
+`TODO-AR-2.md`). Those TODO files are created when a phase starts, not up front.
+
+Read [ARCHITECTURE.md](ARCHITECTURE.md) before executing any phase.
+
+## Sequencing rationale
+
+Promotion tracking is additive and low-risk; replacing git-tag version
+allocation moves an existing working source of truth into a stateful service.
+Do the first, prove it, then do the second. Shipping AR-5 before AR-3 would put
+a registry outage in the path of every release before the registry has delivered
+anything.
+
+```mermaid
+graph LR
+    AR0["AR-0<br/>Design"] --> ARM["AR-M<br/>Manifest schema"]
+    ARM --> AR1["AR-1<br/>Foundations"]
+    AR1 --> AR2["AR-2<br/>Observe"]
+    AR2 --> AR3["AR-3<br/>Promote"]
+    AR3 --> AR4["AR-4<br/>Writeback"]
+    AR4 --> AR5["AR-5<br/>Allocate versions"]
+    AR2 -. "soak period" .-> AR3
+    style AR0 fill:#e8f5e8
+    style ARM fill:#fff4e0
+    style AR5 fill:#ffe9e9
+```
+
+AR-M stands alone and delivers value with or without the registry — it fixes
+drift that exists today. It is sequenced first because AR-2 otherwise adds a
+third manifest representation to the two that already disagree.
+
+---
+
+## AR-0 — Design and contracts
+
+**Status:** complete (this document, `ARCHITECTURE.md`, `README.md`, `protos/`).
+
+**Delivered**
+- Proto contracts for all four services, compiling under
+  `//tools/app_registry/protos:appregistrypb`.
+- Data model, promotability rule, authorization split, writeback mechanism.
+
+**Exit criteria** — met when the promotability model and the chart→image
+lockfile approach are agreed, since both touch existing code.
+
+---
+
+## AR-M — Manifest schema consolidation
+
+**Goal:** one definition of what a `release_app` manifest contains. Independent
+of the registry — this repays itself immediately by removing existing drift.
+
+**Why first:** `release_helper_go` and `tools/helm/composer.go` both decode the
+manifest JSON into their own structs, and they disagree with each other and with
+the Starlark rule (see the table in [`../appmeta/README.md`](../appmeta/README.md)).
+Adding the registry as a third consumer before fixing this compounds the
+problem.
+
+**Scope**
+- `//tools/appmeta/proto` — `AppManifest`, `ChartManifest`, `AppManifestSet`,
+  `DeployUnit`. *(done in AR-0; consumers not yet migrated)*
+- Contract test `//tools/appmeta:manifest_contract_test`, both directions:
+  every `app_metadata` target decodes with `DiscardUnknown: false`, and a
+  full-coverage fixture app leaves no proto field unset.
+- Migrate `tools/helm/composer.go` to `appmetapb.AppManifest`. Resolve the
+  phantom `labels` / `annotations` / `dependencies` fields — either emit them
+  from the rule or delete them.
+- Migrate `tools/release_helper_go` to `appmetapb.AppManifest`.
+- **Remove the `Language`-as-version hack** in `cmd/plan.go` (`apps[i].Language
+  = version`, read back via `strings.HasPrefix(app.Language, "v")`), now that
+  `version` is a real field. Separate reviewable commit — this changes
+  behaviour, not just types.
+- Add `deploy_unit` to `release_app` and set it on standalone-image apps
+  (e.g. `manmanv2-host-manager`).
+
+**Exit criteria**
+- No hand-written manifest struct remains in `tools/`.
+- Contract test fails when a rule attr is added without a proto field, verified
+  by deliberately breaking it once.
+- `bazel test //tools/...` green; a release dry-run produces byte-identical
+  charts and plans to before the migration.
+
+**Risk:** the helm composer is on the critical path for every chart build.
+Migrate it behind a golden-output test comparing rendered charts pre/post.
+
+---
+
+## AR-1 — Foundations
+
+**Goal:** everything the service needs to exist, with no business logic.
+
+**Scope**
+- `libs/go/temporal` — client construction, env-driven config, worker bootstrap,
+  logging bridge to `libs/go/logging`. Add `go.temporal.io/sdk` to `go.mod` and
+  `MODULE.bazel`. **This does not exist yet in Go anywhere in the repo** and is
+  the largest unknown in this phase.
+- `tools/app_registry/migrate` — `golang-migrate` runner over embedded SQL,
+  following `manmanv2/migrate`. Schema per ARCHITECTURE.md, including the SCD2
+  partial unique index and `v_current_promotion`.
+- `tools/app_registry/server` — gRPC server skeleton: `libs/go/db` pool,
+  `libs/go/grpcauth` interceptors, otelgrpc, reflection, health check. All RPCs
+  return `UNIMPLEMENTED`.
+- `tools/app_registry/cli` — Cobra skeleton with a thin gRPC client.
+- `release_app` manifests for `app-registry-api` and `app-registry-migration`.
+- Tilt wiring for local development.
+
+**Exit criteria**
+- `bazel test //tools/app_registry/...` green.
+- Migrations apply and roll back cleanly.
+- Server starts in Tilt and answers reflection + health.
+
+**Risks** — Temporal Go SDK under Bazel with cross-compilation. Read
+`docs/DOCKER.md` before touching image builds; ARM64 breakage is silent at build
+time.
+
+---
+
+## AR-2 — Observe (additive recording)
+
+**Goal:** the registry knows everything CI published. Git tags stay
+authoritative. Nothing depends on the registry yet.
+
+**Scope**
+- Implement `AppRegistry.ReconcileApps`, `ListApps`, `GetApp`, `ListCharts`,
+  `SetAppStatus`.
+- Implement `ArtifactRegistry.RecordBuild`, `RecordArtifact`, `ListArtifacts`,
+  `GetArtifact`, `ResolveArtifact`.
+- Idempotency-key storage and replay.
+- **`tools/helm/composer.go`: emit a chart lockfile** resolving pinned images to
+  digests.
+- `release_helper_go`: emit an `AppManifestSet` from `plan` output. No
+  conversion code — AR-M made this the same type the registry accepts.
+- `.github/workflows/release.yml`: call `app-registry` CLI after image and chart
+  pushes. **Best-effort — `continue-on-error`, must never fail a release.**
+- CLI: `apps list`, `apps get`, `artifacts list`, `artifacts resolve`.
+
+**Exit criteria**
+- Every release for a soak period appears in the registry.
+- A parity check confirms registry artifacts match git tags with zero drift.
+- `artifacts resolve` on a chart returns correct image digests.
+
+**Soak:** run for several weeks of real releases before starting AR-3. Do not
+compress this — it is the phase that earns the trust AR-5 spends.
+
+---
+
+## AR-3 — Promotion
+
+**Goal:** promotion state is recorded and queryable. Still nothing consumes it.
+
+**Scope**
+- Implement `EnvironmentRegistry` (all RPCs); seed `dev`/`stage`/`prod`.
+- Implement `PromotionRegistry.Promote`, `Rollback`, `GetEnvironmentState`,
+  `ListPromotions`, `ListPromotionEvents`.
+- SCD2 close-and-open in one transaction; promotion event log.
+- Promotability enforcement, including `allow_override` and drift reporting.
+- Environment-scoped authorization; `reason` required above rank 0.
+- CLI: `promote`, `rollback`, `status <env>`, `history`, `diff <env> <env>`.
+- A human-triggered `promote.yml` GitHub workflow using an
+  **environment-scoped OIDC subject**, distinct from the builder credential.
+
+**Exit criteria**
+- Promote/rollback round-trips correctly; `GetEnvironmentState --at <T>` returns
+  correct historical state.
+- Attempting to promote a `VIA_CHART` image without `allow_override` is
+  rejected; with it, drift is reported.
+- The builder credential is verifiably unable to promote.
+
+---
+
+## AR-4 — Writeback
+
+**Goal:** promotion state reaches ArgoCD without anything reading the API
+synchronously.
+
+**Scope**
+- `writeback_outbox` written inside the promotion transaction.
+- `tools/app_registry/worker` — Temporal worker draining the outbox.
+- `WritebackWorkflow` (workflow id = promotion id) with activities: render state
+  → commit to gitops repo → put S3 snapshot → mark outbox done.
+- `state_hash` no-op detection; push-conflict retry.
+- `release_app` for `app-registry-worker`.
+- Point **one non-critical app's** ArgoCD source at registry-written state.
+
+**Exit criteria**
+- A promotion produces a gitops commit and an S3 snapshot within seconds.
+- Killing the worker mid-writeback and restarting completes exactly once.
+- The pilot app deploys end-to-end from a promotion.
+- Registry downtime demonstrably does not block an ArgoCD sync.
+
+**Blocked on** open question 2 in ARCHITECTURE.md (gitops repo target and file
+layout).
+
+---
+
+## AR-5 — Version allocation
+
+**Goal:** the registry becomes the version source of truth. Highest risk —
+CI now depends on the registry being up.
+
+**Scope**
+- Implement `ArtifactRegistry.AllocateVersion` against a unique
+  `(owner, kind, version)` constraint.
+- Replace `autoIncrementVersion` in `tools/release_helper_go/cmd/plan.go`.
+- **Keep writing git tags** as a redundant record and disaster-recovery path.
+- Backfill allocated versions from existing tags at cutover so numbering is
+  continuous.
+- Remove the release workflow's version-allocation concurrency group, now
+  redundant.
+
+**Exit criteria**
+- Concurrent releases of the same app cannot receive the same version.
+- Allocated versions match what tag-scanning would have produced, verified
+  against the AR-2 soak data.
+- A documented, rehearsed fallback to tag-based allocation exists.
+
+**Do not start** until AR-2's parity check has been clean across a meaningful
+number of real releases.
+
+---
+
+## Explicitly out of scope
+
+Not in any phase above; the schema accommodates them without migration.
+
+- Approval gates (`PENDING_APPROVAL` state exists but is never written).
+- Ephemeral / per-PR environments (an environment row insert, when wanted).
+- Automatic rollback on failed deploy — needs deploy-health signal the registry
+  does not have.
+- Web UI. The CLI stays thin specifically so this can be added without
+  reimplementing rules.
+- Backfilling historical artifacts from GHCR. Recommendation in
+  ARCHITECTURE.md: don't.

--- a/tools/app_registry/README.md
+++ b/tools/app_registry/README.md
@@ -1,0 +1,146 @@
+# App Registry
+
+A gRPC service that records what CI published and tracks which artifact is
+promoted to each environment.
+
+Today the monorepo's release system is declarative and works well: `release_app`
+manifests describe apps, `tools/release_helper_go` builds images and charts from
+them, and git tags track versions. What has no home is **promotion state** —
+"stage is running `manmanv2-control-api v1.4.0`, prod is two versions behind".
+That currently lives implicitly in ArgoCD values files and in people's heads.
+
+The App Registry gives that state a home, and along the way becomes the
+authoritative index of every artifact CI has published.
+
+**The registry records and answers questions. It does not deploy anything.**
+Deployment stays with ArgoCD, reading state the registry writes back to the
+gitops repo.
+
+## What it is not
+
+- Not a deployer. It never talks to a cluster.
+- Not a replacement for GHCR. The OCI registry still holds the bits; this holds
+  the metadata and the promotion state.
+- Not an approval workflow engine (yet). The schema leaves room — see
+  [ARCHITECTURE.md](ARCHITECTURE.md#future-approval-gate) — but AR-3 promotes
+  immediately.
+
+## Core concepts
+
+| Concept | What it means |
+|---|---|
+| **App** | One `release_app` manifest. Identity is `<domain>-<name>`. |
+| **Chart** | A Helm chart composing one or more apps. Usually the real deploy unit. |
+| **Deploy unit** | Declared per app: does it reach an environment via a `chart`, as a standalone `image`, or `none` (build-only)? This is what makes "what can I promote?" answerable. |
+| **Build** | One CI run. Every artifact traces back to a commit and workflow run. |
+| **Artifact** | A published image or chart, identified by **digest**. The semver tag is a label; the digest is the identity. |
+| **Environment** | A row (`dev`/`stage`/`prod`/…), not an enum, so new environments are an insert. |
+| **Promotion** | SCD2 state: which artifact is current in an environment, and what was current at any past instant. |
+
+### Promotability
+
+The single most useful thing the registry encodes. Each artifact carries a
+derived `promotability`, computed from its owning app's declared deploy unit:
+
+- `PROMOTABLE` — a legal, first-class promotion target.
+- `VIA_CHART` — reaches environments only by being pinned inside a chart.
+  Promoting it directly is possible but recorded as an **override** and reported
+  as drift.
+- `NOT_PROMOTABLE` — never deployed; promotion is rejected.
+
+So `app-registry promote --list` shows exactly the things you can legally
+promote, rather than every image ever pushed.
+
+## Flows
+
+### Recording (CI, additive and non-blocking)
+
+```mermaid
+sequenceDiagram
+    participant GHA as GitHub Actions
+    participant RH as release_helper_go
+    participant REG as app-registry-api
+    participant DB as Postgres
+    participant GHCR as GHCR / Helm OCI
+
+    GHA->>RH: plan (bazel query release_app)
+    RH->>REG: ReconcileApps(manifests, git_sha)
+    REG->>DB: upsert apps/charts, flag absent as MISSING
+    GHA->>REG: RecordBuild(git_sha, run_id, attempt)
+    GHA->>GHCR: push image
+    GHCR-->>GHA: digest
+    GHA->>REG: RecordArtifact(IMAGE, version, digest)
+    GHA->>GHCR: push chart (image digests pinned by tools/helm)
+    GHA->>REG: RecordArtifact(CHART, version, digest, contains:[image digests])
+    Note over GHA,REG: best-effort — a registry failure warns,<br/>it does not fail the release
+    GHA->>GHA: git tag (still authoritative until AR-5)
+```
+
+### Promotion and writeback
+
+```mermaid
+sequenceDiagram
+    actor H as Human
+    participant CLI as app-registry CLI
+    participant REG as app-registry-api
+    participant DB as Postgres
+    participant TW as app-registry-worker (Temporal)
+    participant GIT as gitops repo
+    participant S3 as S3 snapshot
+    participant ARGO as ArgoCD
+
+    H->>CLI: promote manmanv2-api v1.4.0 --env prod --reason "..."
+    CLI->>REG: Promote(...)
+    REG->>REG: authz(env) + promotability check
+    rect rgb(238,244,255)
+    Note over REG,DB: one transaction
+    REG->>DB: close current promotion (valid_to = now)
+    REG->>DB: insert promotion (valid_from = now)
+    REG->>DB: insert promotion_event (actor, reason)
+    REG->>DB: insert outbox row (writeback intent)
+    end
+    REG-->>CLI: promotion + superseded (rollback target)
+    TW->>DB: poll outbox, start WritebackWorkflow
+    TW->>REG: GetEnvironmentState(env)
+    TW->>GIT: commit rendered values (retry on conflict)
+    TW->>S3: put env-state.json
+    TW->>DB: record workflow id on the event
+    ARGO->>GIT: sync
+```
+
+The transactional outbox matters: the promotion row and the intent to write
+back commit together, so the registry can never believe something was promoted
+without a writeback eventually happening. See
+[ARCHITECTURE.md](ARCHITECTURE.md#writeback-outbox--temporal).
+
+### Incident-time query
+
+```mermaid
+graph LR
+    Q["what is prod running?"] --> P["promotion (SCD2)<br/>valid_to IS NULL"]
+    P --> C["chart artifact v1.4.0<br/>digest sha256:..."]
+    C -->|contains| I["image artifact<br/>digest sha256:..."]
+    I --> B["build: git_sha, run_id, actor"]
+    P -. "deploy_unit = image" .-> I
+    T["what was prod running at time T?"] --> P2["promotion where<br/>valid_from &lt;= T &lt; valid_to"]
+    P2 --> C
+```
+
+## Components
+
+| Target | What it is |
+|---|---|
+| `//tools/app_registry/protos:appregistrypb` | Proto definitions and generated Go |
+| `//tools/app_registry/server` | gRPC server (`app-registry-api`) |
+| `//tools/app_registry/worker` | Temporal worker (`app-registry-worker`) — gitops writeback |
+| `//tools/app_registry/cli` | Thin gRPC client (`app-registry`) |
+| `//tools/app_registry/migrate` | Schema migrations (`app-registry-migration`) |
+
+The CLI is deliberately **thin** — no version math, no promotion-legality
+checks. All rules live server-side so a future UI cannot drift from it.
+
+## Status
+
+Design stage. No implementation yet. See [PLAN.md](PLAN.md) for phasing and
+[ARCHITECTURE.md](ARCHITECTURE.md) for the data model and the decisions behind
+it.

--- a/tools/app_registry/TOC.md
+++ b/tools/app_registry/TOC.md
@@ -1,0 +1,33 @@
+# App Registry — TOC
+
+gRPC service that records published artifacts and tracks per-environment
+promotion state. Design stage — no implementation yet.
+
+## Documents
+
+| File | When to read it |
+|------|-----------------|
+| [README.md](README.md) | Starting point — what the registry is, core concepts, end-to-end flow diagrams |
+| [ARCHITECTURE.md](ARCHITECTURE.md) | Before changing the data model, promotability rules, auth split, or writeback mechanism. Contains rejected alternatives and open questions. |
+| [PLAN.md](PLAN.md) | Before starting work — phase definitions (AR-0 … AR-5), scope, and exit criteria |
+| `TODO-<PLAN_ID>.md` | Execution tracking for an in-flight phase; created when that phase starts |
+| `ENV.md` | Not yet written — add when the server gains runtime configuration (AR-1) |
+
+## Components
+
+| Path | Purpose |
+|------|---------|
+| [protos/](protos/) | Proto contracts for all four services (`AppRegistry`, `ArtifactRegistry`, `PromotionRegistry`, `EnvironmentRegistry`) |
+| [server/](server/) | gRPC server — `app-registry-api` |
+| [worker/](worker/) | Temporal worker — gitops writeback (`app-registry-worker`) |
+| [cli/](cli/) | Thin gRPC client — `app-registry` |
+| [migrate/](migrate/) | Schema migrations — `app-registry-migration` |
+
+## Related
+
+- [`../../docs/RELEASE.md`](../../docs/RELEASE.md) — the existing release system this registry indexes
+- [`../appmeta/README.md`](../appmeta/README.md) — **shared manifest schema** (`AppManifest`, `DeployUnit`); the registry consumes it rather than defining its own
+- [`../bazel/release.bzl`](../bazel/release.bzl) — `release_app` manifests, the source of app identity
+- [`../helm/README.md`](../helm/README.md) — chart composition; source of the chart→image lockfile
+- [`../release_helper_go/`](../release_helper_go/) — release CLI that will call the registry
+- [`../../AGENTS.md`](../../AGENTS.md) — SCD2 conventions used by the `promotion` table

--- a/tools/app_registry/cli/README.md
+++ b/tools/app_registry/cli/README.md
@@ -1,0 +1,51 @@
+# app-registry (CLI)
+
+Thin gRPC client for the App Registry. Skeleton in **AR-1**, commands added
+alongside the RPCs they call in **AR-2** / **AR-3**.
+
+Not yet implemented.
+
+## Thin means thin
+
+**No business logic lives here.** No version math, no promotability rules, no
+promotion-legality checks — those are server-side so a future UI cannot drift
+from the CLI. This file exists mostly to state that constraint.
+
+The CLI validates argument shape, calls one RPC, and formats the response.
+
+## Intended commands
+
+```
+app-registry apps list [--domain D] [--status S] [--deploy-unit U]
+app-registry apps get <domain-name>
+app-registry apps set-status <domain-name> --status archived --reason "..."
+app-registry apps reconcile --from-plan <file> [--dry-run]     # CI
+
+app-registry artifacts list <domain-name> [--kind image|chart] [--promotable]
+app-registry artifacts get <domain-name> --version vX.Y.Z
+app-registry artifacts resolve <digest|artifact-id>            # chart -> images
+app-registry artifacts record ...                              # CI
+
+app-registry promote <domain-name> <version> --env prod --reason "..."
+                     [--allow-override] [--dry-run]
+app-registry rollback <domain-name> --env prod --reason "..."
+app-registry status <env> [--domain D] [--at <RFC3339>]
+app-registry history <domain-name> [--env E]
+app-registry diff <env-a> <env-b>
+
+app-registry env list | upsert | archive                       # admin
+```
+
+`--promotable` on `artifacts list` is the answer to "what can I actually
+promote?" — it filters by the derived promotability described in
+[`../ARCHITECTURE.md`](../ARCHITECTURE.md#promotability).
+
+## Conventions
+
+- Cobra, matching `tools/release_helper_go`.
+- Invoked in CI as `bazel run //tools/app_registry/cli:app-registry -- ...`,
+  the same pattern as `release_helper_go` in `.github/workflows/release.yml`.
+- `--format json|table`; JSON output is what CI parses.
+- Client auth via `libs/go/grpcauth` client credentials. Promotion commands use
+  a different credential than recording commands — see the auth split in
+  [`../ARCHITECTURE.md`](../ARCHITECTURE.md#authorization).

--- a/tools/app_registry/migrate/README.md
+++ b/tools/app_registry/migrate/README.md
@@ -22,7 +22,7 @@ ArgoCD sync waves. See `friendly_computing_machine/docs/argocd-integration.md`.
 
 | File | Contents |
 |---|---|
-| `001_initial_schema` | `app`, `chart`, `chart_app`, `build`, `artifact`, `artifact_link`, `idempotency_key` |
+| `001_initial_schema` | `app`, `chart`, `chart_app`, `build`, `artifact`, `artifact_link`, `idempotency_key`, `domain_adoption` |
 | `002_environments_promotions` | `environment`, `promotion` (SCD2), `promotion_event`, `v_current_promotion` |
 | `003_writeback_outbox` | `writeback_outbox` |
 
@@ -49,6 +49,12 @@ CREATE UNIQUE INDEX artifact_digest_idx ON artifact (digest);
 -- version allocation collision guard (AR-5 depends on this)
 CREATE UNIQUE INDEX artifact_version_idx ON artifact (owner_id, kind, version);
 ```
+
+`domain_adoption` gates the per-domain cutover described in
+[`../ARCHITECTURE.md`](../ARCHITECTURE.md#resolved-questions): one row per
+domain, with a stage of `observe` / `promote` / `allocate`. It ships in `001`
+even though only AR-5 enforces it, so no domain is left without a row when the
+gate turns on.
 
 See the SCD2 section of [`../ARCHITECTURE.md`](../ARCHITECTURE.md#scd2-on-promotion)
 and the repo-wide convention in `AGENTS.md`.

--- a/tools/app_registry/migrate/README.md
+++ b/tools/app_registry/migrate/README.md
@@ -1,0 +1,54 @@
+# app-registry-migration
+
+Schema migration runner for the App Registry database. Built in **AR-1**.
+
+Not yet implemented.
+
+## Pattern
+
+Follows `manmanv2/migrate` exactly — embedded SQL plus `libs/go/migrate`:
+
+```go
+//go:embed migrations/*.sql
+var migrations embed.FS
+
+func main() { migrate.RunCLI(migrations, "migrations") }
+```
+
+Deployed as a Helm pre-sync job (`app_type: job`), ordered ahead of the API via
+ArgoCD sync waves. See `friendly_computing_machine/docs/argocd-integration.md`.
+
+## Planned migrations
+
+| File | Contents |
+|---|---|
+| `001_initial_schema` | `app`, `chart`, `chart_app`, `build`, `artifact`, `artifact_link`, `idempotency_key` |
+| `002_environments_promotions` | `environment`, `promotion` (SCD2), `promotion_event`, `v_current_promotion` |
+| `003_writeback_outbox` | `writeback_outbox` |
+
+Split this way so AR-2 needs only `001`, AR-3 adds `002`, and AR-4 adds `003` —
+each phase ships an independently applicable migration.
+
+## Required indexes
+
+Do not omit these; they are load-bearing, not optimizations.
+
+```sql
+-- makes double-promotion structurally impossible, and is the hot read path
+CREATE UNIQUE INDEX promotion_current_idx
+  ON promotion (environment_id, target_key)
+  WHERE valid_to IS NULL;
+
+-- historical "state at time T" queries
+CREATE INDEX promotion_window_idx
+  ON promotion (environment_id, target_key, valid_from DESC);
+
+-- digest is the real artifact identity
+CREATE UNIQUE INDEX artifact_digest_idx ON artifact (digest);
+
+-- version allocation collision guard (AR-5 depends on this)
+CREATE UNIQUE INDEX artifact_version_idx ON artifact (owner_id, kind, version);
+```
+
+See the SCD2 section of [`../ARCHITECTURE.md`](../ARCHITECTURE.md#scd2-on-promotion)
+and the repo-wide convention in `AGENTS.md`.

--- a/tools/app_registry/protos/BUILD.bazel
+++ b/tools/app_registry/protos/BUILD.bazel
@@ -1,0 +1,30 @@
+"""App Registry proto — gRPC service definitions."""
+
+load("@rules_go//proto:def.bzl", "go_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+# Single Go package for all app registry protos, matching the manmanv2 pattern.
+go_proto_library(
+    name = "appregistrypb",
+    compilers = ["@rules_go//proto:go_grpc"],
+    importpath = "github.com/whale-net/everything/tools/app_registry/protos",
+    proto = ":appregistrypb_proto",
+    # The manifest schema is owned by //tools/appmeta/proto, not by the
+    # registry — release_helper_go and the helm composer consume it too.
+    deps = ["//tools/appmeta/proto:appmetapb"],
+    visibility = ["//visibility:public"],
+)
+
+proto_library(
+    name = "appregistrypb_proto",
+    srcs = [
+        "api.proto",
+        "api_messages_app.proto",
+        "api_messages_artifact.proto",
+        "api_messages_environment.proto",
+        "api_messages_promotion.proto",
+        "messages.proto",
+    ],
+    deps = ["//tools/appmeta/proto:appmetapb_proto"],
+    visibility = ["//visibility:public"],
+)

--- a/tools/app_registry/protos/api.proto
+++ b/tools/app_registry/protos/api.proto
@@ -1,0 +1,77 @@
+syntax = "proto3";
+
+package appregistry.v1;
+
+option go_package = "github.com/whale-net/everything/tools/app_registry/protos;appregistrypb";
+
+import "tools/app_registry/protos/api_messages_app.proto";
+import "tools/app_registry/protos/api_messages_artifact.proto";
+import "tools/app_registry/protos/api_messages_environment.proto";
+import "tools/app_registry/protos/api_messages_promotion.proto";
+
+// The registry is split into four services along its authorization boundary,
+// not along its data model. `builder` (the CI service account) may call
+// AppRegistry and ArtifactRegistry. `promoter` (a human, or a
+// human-triggered workflow using an environment-scoped credential) may call
+// PromotionRegistry. `admin` may call EnvironmentRegistry. A credential that
+// can record a build must never be able to promote it.
+
+// ============================================================================
+// AppRegistry — app and chart identity. Role: builder (writes), any (reads).
+// ============================================================================
+service AppRegistry {
+  // Full reconcile from the release_app manifests discovered by bazel query.
+  // Apps absent from the request are marked MISSING, never deleted.
+  rpc ReconcileApps(ReconcileAppsRequest) returns (ReconcileAppsResponse);
+
+  rpc ListApps(ListAppsRequest) returns (ListAppsResponse);
+  rpc GetApp(GetAppRequest) returns (GetAppResponse);
+  rpc ListCharts(ListChartsRequest) returns (ListChartsResponse);
+
+  // Human triage of a MISSING app: archive it or restore it. Role: admin.
+  rpc SetAppStatus(SetAppStatusRequest) returns (SetAppStatusResponse);
+}
+
+// ============================================================================
+// ArtifactRegistry — published builds and artifacts.
+// Role: builder (writes), any (reads).
+// ============================================================================
+service ArtifactRegistry {
+  rpc RecordBuild(RecordBuildRequest) returns (RecordBuildResponse);
+  rpc RecordArtifact(RecordArtifactRequest) returns (RecordArtifactResponse);
+
+  rpc ListArtifacts(ListArtifactsRequest) returns (ListArtifactsResponse);
+  rpc GetArtifact(GetArtifactRequest) returns (GetArtifactResponse);
+
+  // Walk a chart artifact down to the image digests it pins.
+  rpc ResolveArtifact(ResolveArtifactRequest) returns (ResolveArtifactResponse);
+
+  // Phase AR-5: transactional version allocation, replacing git-tag scanning.
+  rpc AllocateVersion(AllocateVersionRequest) returns (AllocateVersionResponse);
+}
+
+// ============================================================================
+// PromotionRegistry — what is deployed where.
+// Role: promoter (writes, environment-scoped), any (reads).
+// ============================================================================
+service PromotionRegistry {
+  rpc Promote(PromoteRequest) returns (PromoteResponse);
+  rpc Rollback(RollbackRequest) returns (RollbackResponse);
+
+  // Current state, or state at any past instant via the SCD2 window. This is
+  // the query the writeback worker and deploy tooling use.
+  rpc GetEnvironmentState(GetEnvironmentStateRequest) returns (GetEnvironmentStateResponse);
+
+  rpc ListPromotions(ListPromotionsRequest) returns (ListPromotionsResponse);
+  rpc ListPromotionEvents(ListPromotionEventsRequest) returns (ListPromotionEventsResponse);
+}
+
+// ============================================================================
+// EnvironmentRegistry — environment definitions. Role: admin.
+// ============================================================================
+service EnvironmentRegistry {
+  rpc UpsertEnvironment(UpsertEnvironmentRequest) returns (UpsertEnvironmentResponse);
+  rpc GetEnvironment(GetEnvironmentRequest) returns (GetEnvironmentResponse);
+  rpc ListEnvironments(ListEnvironmentsRequest) returns (ListEnvironmentsResponse);
+  rpc ArchiveEnvironment(ArchiveEnvironmentRequest) returns (ArchiveEnvironmentResponse);
+}

--- a/tools/app_registry/protos/api_messages_app.proto
+++ b/tools/app_registry/protos/api_messages_app.proto
@@ -1,0 +1,113 @@
+syntax = "proto3";
+
+package appregistry.v1;
+
+option go_package = "github.com/whale-net/everything/tools/app_registry/protos;appregistrypb";
+
+import "tools/app_registry/protos/messages.proto";
+import "tools/appmeta/proto/appmeta.proto";
+
+// ============================================================================
+// Reconciliation
+// ============================================================================
+
+// ReconcileAppsRequest is a FULL replace, not an incremental upsert. The
+// caller sends every manifest in the monorepo; anything the registry knows
+// about that is absent from this set is marked APP_STATUS_MISSING for human
+// triage. Nothing is ever hard-deleted.
+//
+// The payload is the manifest set exactly as `release_helper_go` discovered it
+// from `bazel query` — the registry does not define its own manifest shape, so
+// there is nothing to keep in sync. Adding a field to release_app makes it
+// available here automatically.
+message ReconcileAppsRequest {
+  whalenet.appmeta.v1.AppManifestSet manifests = 1;
+
+  // When true, compute and return the diff without writing anything.
+  bool dry_run = 2;
+
+  // Required. Repeated calls with the same key are a no-op returning the
+  // original result. Use "<workflow_run_id>-<attempt>".
+  string idempotency_key = 3;
+}
+
+message ReconcileAppsResponse {
+  repeated App created_apps = 1;
+  repeated App updated_apps = 2;
+
+  // Apps that fell out of the manifest set and were flagged for triage.
+  repeated App newly_missing_apps = 3;
+
+  // Apps previously MISSING that reappeared; automatically returned to ACTIVE.
+  repeated App recovered_apps = 4;
+
+  repeated Chart created_charts = 5;
+  repeated Chart updated_charts = 6;
+  repeated Chart newly_missing_charts = 7;
+  repeated Chart recovered_charts = 8;
+
+  bool dry_run = 9;
+}
+
+// ============================================================================
+// Reads
+// ============================================================================
+
+message ListAppsRequest {
+  string domain = 1;  // optional filter
+
+  // Defaults to [ACTIVE, MISSING] when empty — archived apps are hidden
+  // unless explicitly asked for.
+  repeated AppStatus statuses = 2;
+
+  whalenet.appmeta.v1.DeployUnit deploy_unit = 3;  // optional filter
+  PageRequest page = 4;
+}
+
+message ListAppsResponse {
+  repeated App apps = 1;
+  PageResponse page = 2;
+}
+
+message GetAppRequest {
+  // Either app_id, or full_name ("<domain>-<name>").
+  string app_id = 1;
+  string full_name = 2;
+}
+
+message GetAppResponse {
+  App app = 1;
+
+  // Charts that compose this app, so a caller can see what it would actually
+  // need to promote.
+  repeated Chart charts = 2;
+}
+
+message ListChartsRequest {
+  string domain = 1;
+  repeated AppStatus statuses = 2;
+  PageRequest page = 3;
+}
+
+message ListChartsResponse {
+  repeated Chart charts = 1;
+  PageResponse page = 2;
+}
+
+// ============================================================================
+// Manual triage of MISSING rows
+// ============================================================================
+
+// SetAppStatusRequest lets a human resolve a MISSING app: archive it if the
+// removal was intentional, or reactivate it if the reconcile was wrong.
+// Transitioning to ACTIVE is only accepted if the app is present in the most
+// recent reconcile.
+message SetAppStatusRequest {
+  string app_id = 1;
+  AppStatus status = 2;
+  string reason = 3;  // required — recorded in the audit log
+}
+
+message SetAppStatusResponse {
+  App app = 1;
+}

--- a/tools/app_registry/protos/api_messages_artifact.proto
+++ b/tools/app_registry/protos/api_messages_artifact.proto
@@ -1,0 +1,152 @@
+syntax = "proto3";
+
+package appregistry.v1;
+
+option go_package = "github.com/whale-net/everything/tools/app_registry/protos;appregistrypb";
+
+import "tools/app_registry/protos/messages.proto";
+
+// ============================================================================
+// Recording builds and artifacts (the CI write path)
+// ============================================================================
+
+message RecordBuildRequest {
+  string git_sha = 1;
+  string git_ref = 2;
+  string workflow_run_id = 3;
+  int32 workflow_attempt = 4;
+  string actor = 5;
+  int64 started_at = 6;
+
+  // Required. "<workflow_run_id>-<attempt>".
+  string idempotency_key = 7;
+}
+
+message RecordBuildResponse {
+  Build build = 1;
+
+  // True when this build was already recorded and the existing row was
+  // returned unchanged.
+  bool already_recorded = 2;
+}
+
+// ContainedImage is one image a chart pins, as resolved by tools/helm at
+// compose time. Charts must be recorded with digests, not floating tags —
+// this is what makes environment state auditable.
+message ContainedImage {
+  // App this image belongs to, as "<domain>-<name>".
+  string app_full_name = 1;
+  string repository = 2;
+  string version = 3;
+  string digest = 4;
+}
+
+message RecordArtifactRequest {
+  string build_id = 1;
+  ArtifactKind kind = 2;
+
+  // For kind == IMAGE: the app's "<domain>-<name>".
+  // For kind == CHART: the chart's "<domain>-<name>".
+  string owner_full_name = 3;
+
+  string repository = 4;
+  string version = 5;  // semver tag, validated as v<major>.<minor>.<patch>
+  string digest = 6;   // "sha256:..." — required
+
+  // Only valid for kind == CHART. Every referenced image must already be
+  // recorded, or the call fails — a chart may not pin an unknown digest.
+  repeated ContainedImage contains = 7;
+
+  int64 published_at = 8;
+
+  // Required. "<workflow_run_id>-<attempt>-<owner_full_name>-<kind>".
+  string idempotency_key = 9;
+}
+
+message RecordArtifactResponse {
+  Artifact artifact = 1;
+  bool already_recorded = 2;
+}
+
+// ============================================================================
+// Reads
+// ============================================================================
+
+message ListArtifactsRequest {
+  // Filter by owner; "<domain>-<name>" of an app or chart.
+  string owner_full_name = 1;
+  ArtifactKind kind = 2;
+
+  // When set, return only artifacts a caller could legally promote. This is
+  // the filter the CLI uses to answer "what can I promote?".
+  bool promotable_only = 3;
+
+  PageRequest page = 4;
+}
+
+message ListArtifactsResponse {
+  repeated Artifact artifacts = 1;
+  PageResponse page = 2;
+}
+
+message GetArtifactRequest {
+  // Identify by artifact_id, by digest (globally unique), or by the
+  // (owner_full_name, kind, version) triple.
+  string artifact_id = 1;
+  string digest = 2;
+  string owner_full_name = 3;
+  ArtifactKind kind = 4;
+  string version = 5;
+}
+
+message GetArtifactResponse {
+  Artifact artifact = 1;
+  Build build = 2;
+}
+
+// ResolveArtifactRequest walks a chart artifact down to the concrete image
+// digests it pins. This is the incident-time query: given what is in prod,
+// what code is actually running.
+message ResolveArtifactRequest {
+  string artifact_id = 1;
+  string digest = 2;
+}
+
+message ResolveArtifactResponse {
+  Artifact artifact = 1;
+
+  // Flattened image artifacts, each with its originating build so a digest
+  // maps straight back to a commit.
+  repeated Artifact images = 2;
+  repeated Build builds = 3;
+}
+
+// ============================================================================
+// Version allocation (phase AR-5)
+// ============================================================================
+
+// AllocateVersionRequest replaces the `git tag --sort=-version:refname` scan
+// in release_helper_go. Allocation is a transactional insert against a unique
+// (owner, version) constraint, so concurrent CI runs cannot collide.
+message AllocateVersionRequest {
+  string owner_full_name = 1;
+  ArtifactKind kind = 2;
+
+  // "major" | "minor" | "patch". Ignored when explicit_version is set.
+  string increment = 3;
+
+  // Bypass auto-increment and reserve this exact version. Fails if taken.
+  string explicit_version = 4;
+
+  // Required. "<workflow_run_id>-<attempt>-<owner_full_name>".
+  string idempotency_key = 5;
+}
+
+message AllocateVersionResponse {
+  string version = 1;
+
+  // Version this was incremented from; empty for a first release.
+  string previous_version = 2;
+
+  bool already_allocated = 3;
+}

--- a/tools/app_registry/protos/api_messages_environment.proto
+++ b/tools/app_registry/protos/api_messages_environment.proto
@@ -1,0 +1,50 @@
+syntax = "proto3";
+
+package appregistry.v1;
+
+option go_package = "github.com/whale-net/everything/tools/app_registry/protos;appregistrypb";
+
+import "tools/app_registry/protos/messages.proto";
+
+// Environments are managed rows rather than a compiled-in enum, so adding
+// prod-eu or a per-PR ephemeral environment is an insert, not a release.
+
+message UpsertEnvironmentRequest {
+  string key = 1;  // immutable identity, e.g. "stage"
+  string display_name = 2;
+  int32 rank = 3;
+  bool requires_approval = 4;
+  string gitops_path = 5;
+  repeated string allowed_principals = 6;
+}
+
+message UpsertEnvironmentResponse {
+  Environment environment = 1;
+  bool created = 2;
+}
+
+message ListEnvironmentsRequest {
+  bool include_archived = 1;
+}
+
+message ListEnvironmentsResponse {
+  // Ordered by rank ascending.
+  repeated Environment environments = 1;
+}
+
+message GetEnvironmentRequest {
+  string key = 1;
+}
+
+message GetEnvironmentResponse {
+  Environment environment = 1;
+}
+
+message ArchiveEnvironmentRequest {
+  string key = 1;
+  string reason = 2;
+}
+
+message ArchiveEnvironmentResponse {
+  Environment environment = 1;
+}

--- a/tools/app_registry/protos/api_messages_promotion.proto
+++ b/tools/app_registry/protos/api_messages_promotion.proto
@@ -1,0 +1,158 @@
+syntax = "proto3";
+
+package appregistry.v1;
+
+option go_package = "github.com/whale-net/everything/tools/app_registry/protos;appregistrypb";
+
+import "tools/app_registry/protos/messages.proto";
+
+// ============================================================================
+// Promotion (the human write path)
+// ============================================================================
+
+message PromoteRequest {
+  string environment_key = 1;
+
+  // The artifact being promoted. Identify by artifact_id, by digest, or by
+  // the (owner_full_name, kind, version) triple — the CLI uses the triple.
+  string artifact_id = 2;
+  string digest = 3;
+  string owner_full_name = 4;
+  ArtifactKind kind = 5;
+  string version = 6;
+
+  // Required for environments with rank above dev. Recorded on the audit log.
+  string reason = 7;
+
+  // Acknowledge that this promotes an image belonging to a DEPLOY_UNIT_CHART
+  // app, bypassing its chart. Without this flag such a request is rejected;
+  // with it, the promotion is stored with is_override = true and reported as
+  // drift.
+  bool allow_override = 8;
+
+  // Compute and return the resulting state transition without writing.
+  bool dry_run = 9;
+
+  // Required. Client-generated; makes retries safe.
+  string idempotency_key = 10;
+}
+
+message PromoteResponse {
+  // The newly current promotion.
+  Promotion promotion = 1;
+
+  // The promotion this superseded, with valid_to now set. Empty on a first
+  // promotion. This is what a rollback would target.
+  Promotion superseded = 2;
+
+  PromotionEvent event = 3;
+
+  // Writeback workflow started for this promotion. Empty on dry_run.
+  string temporal_workflow_id = 4;
+
+  bool dry_run = 5;
+  bool already_promoted = 6;
+}
+
+// RollbackRequest is sugar over Promote: it re-promotes whatever was
+// previously current for this target in this environment. Kept as its own RPC
+// because it records PROMOTION_ACTION_ROLLBACK and needs no artifact lookup.
+message RollbackRequest {
+  string environment_key = 1;
+  string owner_full_name = 2;
+  ArtifactKind kind = 3;
+  string reason = 4;
+  bool dry_run = 5;
+  string idempotency_key = 6;
+}
+
+message RollbackResponse {
+  Promotion promotion = 1;
+  Promotion superseded = 2;
+  PromotionEvent event = 3;
+  string temporal_workflow_id = 4;
+  bool dry_run = 5;
+}
+
+// ============================================================================
+// Environment state — the deploy-tooling read path
+// ============================================================================
+
+message GetEnvironmentStateRequest {
+  string environment_key = 1;
+
+  // Optional Unix timestamp. When 0, returns current state. When set, returns
+  // the state as of that instant, via the SCD2 valid_from/valid_to window.
+  int64 at = 2;
+
+  string domain = 3;  // optional filter
+}
+
+// EnvironmentStateEntry is one deployed thing in one environment.
+message EnvironmentStateEntry {
+  Promotion promotion = 1;
+  Artifact artifact = 2;
+
+  // For chart promotions: the image digests the chart pins.
+  repeated ArtifactLink images = 3;
+
+  // Set when an image belonging to this chart was separately promoted with
+  // allow_override, so the running digest differs from the chart's pin.
+  repeated DriftEntry drift = 4;
+}
+
+// DriftEntry reports a divergence between what a chart pins and what is
+// actually promoted.
+message DriftEntry {
+  string app_id = 1;
+  string app_full_name = 2;
+  string chart_pinned_digest = 3;
+  string promoted_digest = 4;
+  string promotion_id = 5;
+}
+
+message GetEnvironmentStateResponse {
+  Environment environment = 1;
+  repeated EnvironmentStateEntry entries = 2;
+
+  // Timestamp the state is valid as of — echoes `at`, or now.
+  int64 as_of = 3;
+
+  // Stable content hash of this state document. The writeback worker uses it
+  // to skip no-op gitops commits.
+  string state_hash = 4;
+}
+
+// ============================================================================
+// History and audit
+// ============================================================================
+
+message ListPromotionsRequest {
+  string environment_key = 1;   // optional filter
+  string owner_full_name = 2;   // optional filter
+
+  // When true, include superseded rows (the full history). Default false
+  // returns only current promotions.
+  bool include_history = 3;
+
+  PageRequest page = 4;
+}
+
+message ListPromotionsResponse {
+  repeated Promotion promotions = 1;
+  PageResponse page = 2;
+}
+
+message ListPromotionEventsRequest {
+  string promotion_id = 1;      // optional filter
+  string environment_key = 2;   // optional filter
+  string owner_full_name = 3;   // optional filter
+  string actor = 4;             // optional filter
+  int64 since = 5;              // optional Unix timestamp
+  PageRequest page = 6;
+}
+
+message ListPromotionEventsResponse {
+  repeated PromotionEvent events = 1;
+  PageResponse page = 2;
+}

--- a/tools/app_registry/protos/messages.proto
+++ b/tools/app_registry/protos/messages.proto
@@ -1,0 +1,279 @@
+syntax = "proto3";
+
+package appregistry.v1;
+
+option go_package = "github.com/whale-net/everything/tools/app_registry/protos;appregistrypb";
+
+// DeployUnit and the manifest messages are NOT defined here. They belong to
+// //tools/appmeta/proto, the shared schema of record for release_app manifest
+// JSON, so that release_helper_go and the helm composer can consume them
+// without depending on the registry. See ARCHITECTURE.md "Shared manifest
+// schema".
+import "tools/appmeta/proto/appmeta.proto";
+
+// ============================================================================
+// Enums
+// ============================================================================
+
+// ArtifactKind is the type of published, digest-addressable thing.
+enum ArtifactKind {
+  ARTIFACT_KIND_UNSPECIFIED = 0;
+  ARTIFACT_KIND_IMAGE = 1;
+  ARTIFACT_KIND_CHART = 2;
+}
+
+// Promotability is a DERIVED field the server computes from the owning app's
+// or chart's DeployUnit. Clients (CLI, future UI) should filter on this rather
+// than reimplementing the rule. See ARCHITECTURE.md "Promotability".
+enum Promotability {
+  PROMOTABILITY_UNSPECIFIED = 0;
+
+  // A legal, first-class promotion target.
+  PROMOTABILITY_PROMOTABLE = 1;
+
+  // Reaches environments only by being pinned inside a promotable chart.
+  // Promoting directly is possible but is recorded as an override.
+  PROMOTABILITY_VIA_CHART = 2;
+
+  // Never deployed. Promotion is rejected.
+  PROMOTABILITY_NOT_PROMOTABLE = 3;
+}
+
+// AppStatus tracks reconciliation against the release_app manifests in the
+// monorepo. Rows are never hard-deleted — promotion history must stay
+// queryable for apps that no longer exist.
+enum AppStatus {
+  APP_STATUS_UNSPECIFIED = 0;
+
+  // Present in the most recent manifest reconcile.
+  APP_STATUS_ACTIVE = 1;
+
+  // Absent from the most recent reconcile but not yet triaged by a human.
+  // Surfaced as a work queue: either the app was renamed (fix it) or it was
+  // genuinely removed (archive it).
+  APP_STATUS_MISSING = 2;
+
+  // A human confirmed this app is gone. Excluded from default listings.
+  APP_STATUS_ARCHIVED = 3;
+}
+
+// PromotionState allows the approval gate described in ARCHITECTURE.md to be
+// added later without a schema change. Phase AR-3 only ever writes ACTIVE and
+// SUPERSEDED.
+enum PromotionState {
+  PROMOTION_STATE_UNSPECIFIED = 0;
+  PROMOTION_STATE_PENDING_APPROVAL = 1;
+  PROMOTION_STATE_ACTIVE = 2;
+  PROMOTION_STATE_SUPERSEDED = 3;
+  PROMOTION_STATE_FAILED = 4;
+}
+
+// PromotionAction is the human-meaningful verb recorded on the append-only
+// event log. The SCD2 promotion table answers "what"; this answers "why".
+enum PromotionAction {
+  PROMOTION_ACTION_UNSPECIFIED = 0;
+  PROMOTION_ACTION_PROMOTE = 1;
+  PROMOTION_ACTION_ROLLBACK = 2;
+  PROMOTION_ACTION_OVERRIDE = 3;
+  PROMOTION_ACTION_RETIRE = 4;
+  PROMOTION_ACTION_APPROVE = 5;
+  PROMOTION_ACTION_REJECT = 6;
+}
+
+// ============================================================================
+// Core entities
+// ============================================================================
+
+// App mirrors one release_app manifest in the monorepo. Identity is
+// (domain, name); full_name is the "<domain>-<app>" form already used for
+// image repositories and git tags.
+message App {
+  string app_id = 1;      // registry-assigned UUID, stable across renames
+  string domain = 2;      // e.g. "manmanv2"
+  string name = 3;        // e.g. "control-api"
+  string full_name = 4;   // "<domain>-<name>", derived
+
+  string description = 5;
+  string language = 6;    // "go" | "python"
+  string app_type = 7;    // external-api | internal-api | worker | job
+  whalenet.appmeta.v1.DeployUnit deploy_unit = 8;
+
+  // Bazel label the manifest came from, e.g. "//manmanv2/api:control-api".
+  // Makes the registry row traceable back to source.
+  string bazel_label = 9;
+
+  // Image repository this app publishes to, e.g.
+  // "ghcr.io/whale-net/manmanv2-control-api".
+  string image_repository = 10;
+
+  AppStatus status = 11;
+  int64 first_seen_at = 12;  // Unix timestamp
+  int64 last_seen_at = 13;   // Unix timestamp, updated every reconcile
+}
+
+// Chart is a Helm chart composed from one or more apps. Charts are their own
+// registerable identity because tools/helm composes several apps into one
+// chart, and the chart — not the app — is usually the promotion target.
+message Chart {
+  string chart_id = 1;
+  string domain = 2;
+  string name = 3;
+  string full_name = 4;
+
+  string description = 5;
+
+  // app_ids composed into this chart, per its manifest.
+  repeated string app_ids = 6;
+
+  // Helm OCI repository, e.g. "ghcr.io/whale-net/charts".
+  string chart_repository = 7;
+
+  whalenet.appmeta.v1.DeployUnit deploy_unit = 8;  // normally DEPLOY_UNIT_CHART
+  AppStatus status = 9;
+  int64 first_seen_at = 10;
+  int64 last_seen_at = 11;
+}
+
+// Build is one CI run that produced a set of artifacts. Artifacts always hang
+// off a build so that any deployed digest traces back to a commit and a
+// workflow run.
+message Build {
+  string build_id = 1;
+
+  string git_sha = 2;
+  string git_ref = 3;          // e.g. "refs/heads/main"
+
+  string workflow_run_id = 4;  // GitHub Actions run id
+  int32 workflow_attempt = 5;
+  string actor = 6;            // GitHub actor or service account subject
+
+  int64 started_at = 7;
+  int64 recorded_at = 8;
+}
+
+// Artifact is a published, digest-addressable thing. The digest is the
+// identity; the semver tag is a convenience label that may move.
+message Artifact {
+  string artifact_id = 1;
+  ArtifactKind kind = 2;
+
+  // Exactly one of these is set, depending on kind.
+  string app_id = 3;    // set when kind == IMAGE
+  string chart_id = 4;  // set when kind == CHART
+
+  string repository = 5;  // e.g. "ghcr.io/whale-net/manmanv2-control-api"
+  string version = 6;     // semver tag, e.g. "v1.4.0"
+  string digest = 7;      // "sha256:..." — the real identity, globally unique
+
+  string build_id = 8;
+  int64 published_at = 9;
+
+  // DERIVED by the server from the owning app's/chart's deploy_unit.
+  Promotability promotability = 10;
+
+  // For kind == CHART: the image artifacts this chart pins, resolved to
+  // digests at publish time by tools/helm. Empty for kind == IMAGE.
+  repeated ArtifactLink contains = 11;
+}
+
+// ArtifactLink records that a chart artifact pins a specific image digest.
+// This is what makes "which image digest is prod actually running" answerable
+// without rendering a chart.
+message ArtifactLink {
+  string artifact_id = 1;  // the contained image artifact
+  string app_id = 2;
+  string repository = 3;
+  string version = 4;
+  string digest = 5;
+}
+
+// Environment is a row, not an enum, so ephemeral and regional environments
+// can be added later without a schema or proto change.
+message Environment {
+  string environment_id = 1;
+  string key = 2;           // "dev" | "stage" | "prod" | "prod-eu" | ...
+  string display_name = 3;
+
+  // Ordering for promotion-legality rules (e.g. "must be in stage before
+  // prod"). Higher rank == closer to production. Not enforced in AR-3.
+  int32 rank = 4;
+
+  // When true, Promote lands in PROMOTION_STATE_PENDING_APPROVAL instead of
+  // ACTIVE. Not honored until the approval gate ships.
+  bool requires_approval = 5;
+
+  // Path in the gitops repo this environment's rendered state is written to.
+  string gitops_path = 6;
+
+  // Principals permitted to promote here, checked against the caller's OIDC
+  // claims. Empty means "same as builder role" — only acceptable for dev.
+  repeated string allowed_principals = 7;
+
+  bool archived = 8;
+  int64 created_at = 9;
+}
+
+// Promotion is SCD2 state: what is deployed to an environment right now, and
+// what was deployed at any past instant. Follows the repo-wide valid_from /
+// valid_to convention (see AGENTS.md).
+message Promotion {
+  string promotion_id = 1;
+
+  string environment_id = 2;
+  string environment_key = 3;  // denormalized for readability
+
+  // The promotion target. Exactly one of app_id / chart_id is set, matching
+  // artifact.kind.
+  string app_id = 4;
+  string chart_id = 5;
+  string artifact_id = 6;
+
+  // Denormalized artifact identity so a state dump is readable on its own.
+  string repository = 7;
+  string version = 8;
+  string digest = 9;
+
+  PromotionState state = 10;
+
+  // True when an image belonging to a DEPLOY_UNIT_CHART app was promoted
+  // directly, bypassing its chart. Legal, but reported as drift against the
+  // chart's pinned digest.
+  bool is_override = 11;
+
+  int64 valid_from = 12;
+  int64 valid_to = 13;  // 0 == still current
+}
+
+// PromotionEvent is the append-only audit log. One Promote call writes exactly
+// one event; approvals and rollbacks add further events against the same
+// promotion.
+message PromotionEvent {
+  string event_id = 1;
+  string promotion_id = 2;
+
+  PromotionAction action = 3;
+  string actor = 4;    // OIDC subject or GitHub actor
+  string reason = 5;   // free text, required for prod
+
+  // Set when the writeback was orchestrated by Temporal, so an operator can
+  // jump from an audit row to the workflow history.
+  string temporal_workflow_id = 6;
+  string temporal_run_id = 7;
+
+  int64 occurred_at = 8;
+}
+
+// ============================================================================
+// Shared request plumbing
+// ============================================================================
+
+// Pagination is uniform across all List RPCs.
+message PageRequest {
+  int32 page_size = 1;   // server clamps; 0 means server default
+  string page_token = 2;
+}
+
+message PageResponse {
+  string next_page_token = 1;
+  int32 total_size = 2;
+}

--- a/tools/app_registry/server/README.md
+++ b/tools/app_registry/server/README.md
@@ -1,0 +1,40 @@
+# app-registry-api
+
+gRPC server implementing all four services in
+[`../protos/api.proto`](../protos/api.proto). Built in **AR-1** (skeleton) and
+filled in across **AR-2** / **AR-3**.
+
+Not yet implemented.
+
+## Intended layout
+
+```
+server/
+  main.go             # wiring: config, db pool, auth interceptors, grpc.Serve
+  handlers/           # one file per service, thin — validation + delegation
+    app.go            # AppRegistry
+    artifact.go       # ArtifactRegistry
+    promotion.go      # PromotionRegistry
+    environment.go    # EnvironmentRegistry
+  repository/         # interfaces
+    postgres/         # pgx implementations, SCD2 transactions
+  promotability/      # deploy_unit -> Promotability rules + override checks
+  idempotency/        # key storage and response replay
+```
+
+## Conventions
+
+- Follows `manmanv2/api` for structure: `go_binary` + `release_app`, otelgrpc
+  interceptors, reflection enabled.
+- `libs/go/db` for the pgx pool, `libs/go/grpcauth` for OIDC, `libs/go/logging`
+  for structured logs.
+- Business rules live here, never in the CLI — see
+  [`../ARCHITECTURE.md`](../ARCHITECTURE.md).
+- Every write RPC requires an `idempotency_key` and replays stored responses.
+- Promotion writes close-and-open SCD2 rows plus the audit event plus the
+  writeback outbox row in **one transaction**.
+
+## Release metadata
+
+`app_type: internal-api`, `port: 50051`. Only reachable in-cluster and by CI —
+it is not an external API.

--- a/tools/app_registry/worker/README.md
+++ b/tools/app_registry/worker/README.md
@@ -1,0 +1,49 @@
+# app-registry-worker
+
+Temporal worker that drains the `writeback_outbox` and propagates promotion
+state to the gitops repo and the S3 snapshot. Built in **AR-4**.
+
+Not yet implemented.
+
+## Why a worker at all
+
+The API must never push to git inside a promotion RPC — a git push is slow,
+fails transiently, and cannot participate in the promotion transaction. Instead
+the API writes an outbox row atomically with the promotion, and this worker
+turns that intent into durable, retryable work.
+
+Temporal cannot enlist in a Postgres transaction, so the outbox — not Temporal —
+is what guarantees a promotion is never lost. Temporal is the executor.
+
+## Intended layout
+
+```
+worker/
+  main.go             # temporal worker bootstrap via libs/go/temporal
+  poller/             # outbox drain loop -> StartWorkflow(id = promotion_id)
+  workflows/
+    writeback.go      # WritebackWorkflow
+  activities/
+    render.go         # GetEnvironmentState -> rendered values document
+    gitops.go         # clone/commit/push, retry on conflict
+    snapshot.go       # put env-state.json to S3 (libs/go/s3)
+    complete.go       # mark outbox row done, stamp workflow id on the event
+```
+
+## Guarantees
+
+- Workflow id is the promotion id, so Temporal dedups redelivered outbox rows.
+- Every activity is idempotent and independently retryable.
+- `state_hash` from `GetEnvironmentState` short-circuits no-op commits.
+- Push conflicts retry by re-reading current state — last writer wins per
+  environment file, which is correct since the registry owns that file.
+
+## Dependencies not yet in the repo
+
+`go.temporal.io/sdk` is not in `go.mod`/`MODULE.bazel`, and `libs/go/temporal`
+does not exist (`friendly_computing_machine` uses the Python SDK only). Both
+land in **AR-1**.
+
+## Release metadata
+
+`app_type: worker`.

--- a/tools/appmeta/README.md
+++ b/tools/appmeta/README.md
@@ -19,7 +19,7 @@ drifted:
 | `health_check`, `ingress`, `resources`, `command`, `args` | ✅ | ❌ | ✅ |
 | `version` | ✅ | ❌ | ✅ |
 | `binary_target`, `openapi_spec_target` | ✅ | ✅ | ❌ |
-| `labels`, `annotations`, `dependencies` | ❌ | ❌ | ✅ phantom |
+| `labels`, `annotations`, `dependencies` | ❌ | ❌ | ~~✅ phantom~~ removed |
 
 The missing `version` field has already cost something real:
 `tools/release_helper_go/cmd/plan.go` stores the release version in the
@@ -89,8 +89,9 @@ lockfile) — so this rides along rather than being a separate disruption.
 
 1. Land `appmeta.proto` and the contract test against today's rule output.
 2. Replace `helm/composer.go`'s `AppMetadata` with `appmetapb.AppManifest`.
-   Delete the phantom `labels` / `annotations` / `dependencies` fields, or add
-   them to the rule if they were meant to exist.
+   (The phantom `labels` / `annotations` / `dependencies` fields were already
+   deleted, along with the map-ordering nondeterminism that would have
+   prevented golden-output testing of this step.)
 3. Replace `release_helper_go`'s `AppMetadata` with `appmetapb.AppManifest`, and
    **remove the `Language`-as-version hack** in `plan.go` now that `version` is
    a real field.

--- a/tools/appmeta/README.md
+++ b/tools/appmeta/README.md
@@ -19,7 +19,7 @@ drifted:
 | `health_check`, `ingress`, `resources`, `command`, `args` | ✅ | ❌ | ✅ |
 | `version` | ✅ | ❌ | ✅ |
 | `binary_target`, `openapi_spec_target` | ✅ | ✅ | ❌ |
-| `labels`, `annotations`, `dependencies` | ❌ | ❌ | ~~✅ phantom~~ removed |
+| `labels`, `annotations`, `dependencies` | ❌ | ❌ | ✅ phantom (removed separately) |
 
 The missing `version` field has already cost something real:
 `tools/release_helper_go/cmd/plan.go` stores the release version in the
@@ -89,9 +89,10 @@ lockfile) — so this rides along rather than being a separate disruption.
 
 1. Land `appmeta.proto` and the contract test against today's rule output.
 2. Replace `helm/composer.go`'s `AppMetadata` with `appmetapb.AppManifest`.
-   (The phantom `labels` / `annotations` / `dependencies` fields were already
-   deleted, along with the map-ordering nondeterminism that would have
-   prevented golden-output testing of this step.)
+   (The phantom `labels` / `annotations` / `dependencies` fields, and the
+   map-ordering nondeterminism that would have prevented golden-output testing
+   of this step, are removed by the separate `helm-deterministic-output`
+   change, which must land first.)
 3. Replace `release_helper_go`'s `AppMetadata` with `appmetapb.AppManifest`, and
    **remove the `Language`-as-version hack** in `plan.go` now that `version` is
    a real field.

--- a/tools/appmeta/README.md
+++ b/tools/appmeta/README.md
@@ -21,6 +21,9 @@ drifted:
 | `binary_target`, `openapi_spec_target` | ✅ | ✅ | ❌ |
 | `labels`, `annotations`, `dependencies` | ❌ | ❌ | ✅ phantom (removed separately) |
 
+Charts drift the same way: `HelmChartMetadata` in `plan_helm.go` omits
+`version` and `environment`, both of which `helm_chart_metadata` emits.
+
 The missing `version` field has already cost something real:
 `tools/release_helper_go/cmd/plan.go` stores the release version in the
 `Language` field and reads it back with `strings.HasPrefix(app.Language, "v")`,
@@ -46,9 +49,19 @@ chart.
 
 ## Wire format
 
-The Starlark rules write plain `snake_case` JSON. `protojson` accepts proto
-field names as written, so **no change to the emitted format is required** —
-existing manifests parse as-is.
+The Starlark rules produce plain `snake_case` JSON, delivered two ways from the
+same `metadata` dict:
+
+- the `*_metadata.json` file output (`DefaultInfo`), and
+- the `AppMetadataInfo` / `HelmChartMetadataInfo` Starlark providers, which
+  `release_helper_go` reads via `bazel cquery --output=starlark` with
+  `json.encode(...metadata)` — the discovery path since #444, and the fast one,
+  since it runs no actions.
+
+Both carry identical bytes, so one schema covers both.
+
+`protojson` accepts proto field names as written, so **no change to the emitted
+format is required** — existing manifests parse as-is.
 
 Always decode with:
 
@@ -65,8 +78,11 @@ vanishing — which is exactly how the current drift went unnoticed.
 Shared types alone do not prevent drift; a rule attribute can still be added
 without anyone extending the proto. The enforcement is a test:
 
-1. `bazel query 'kind(app_metadata, //...)'`, build every target, and unmarshal
-   each output with `DiscardUnknown: false`. Catches **rule → proto** drift.
+1. Discover every `app_metadata` / `helm_chart_metadata` target the way
+   `release_helper_go` does — `bazel query` for labels, then `bazel cquery
+   --output=starlark` over the providers — and unmarshal each result with
+   `DiscardUnknown: false`. Catches **rule → proto** drift, and runs no build
+   actions.
 2. A fixture app in `testdata/` sets *every* `release_app` attribute; assert the
    decoded message has no unset field. Catches **proto → rule** drift, i.e. a
    field defined here that the rule never populates.

--- a/tools/appmeta/README.md
+++ b/tools/appmeta/README.md
@@ -1,0 +1,102 @@
+# appmeta — release manifest schema of record
+
+Proto definition of the JSON emitted by the `app_metadata` and
+`helm_chart_metadata` Starlark rules in [`//tools/bazel:release.bzl`](../bazel/release.bzl).
+
+**Design stage.** The proto exists; consumers have not been migrated yet. See
+[Migration](#migration) and `//tools/app_registry/PLAN.md` (phase AR-2).
+
+## Why this exists
+
+`release_app` manifests are the declarative source of truth for every app in the
+monorepo, and the JSON they produce is a real interface between Starlark and Go.
+That interface had no schema, so each consumer wrote its own struct — and they
+drifted:
+
+| Field | `release.bzl` emits | `release_helper_go` | `helm/composer.go` |
+|---|:---:|:---:|:---:|
+| `description`, `app_type`, `port`, `replicas` | ✅ | ❌ | ✅ |
+| `health_check`, `ingress`, `resources`, `command`, `args` | ✅ | ❌ | ✅ |
+| `version` | ✅ | ❌ | ✅ |
+| `binary_target`, `openapi_spec_target` | ✅ | ✅ | ❌ |
+| `labels`, `annotations`, `dependencies` | ❌ | ❌ | ✅ phantom |
+
+The missing `version` field has already cost something real:
+`tools/release_helper_go/cmd/plan.go` stores the release version in the
+`Language` field and reads it back with `strings.HasPrefix(app.Language, "v")`,
+because the struct it decodes into has nowhere else to put it.
+
+Adding the app registry as a third consumer would have made this worse. Instead
+the registry is the forcing function to collapse to one definition.
+
+## Dependency direction
+
+```
+              //tools/appmeta/proto:appmetapb
+                 (schema of record)
+                  ^      ^       ^
+                  |      |       |
+      release_helper_go  |   app_registry
+                    helm/composer
+```
+
+`appmeta` depends on nothing. In particular the schema must **not** live inside
+`app_registry`, or the helm composer would depend on the registry to build a
+chart.
+
+## Wire format
+
+The Starlark rules write plain `snake_case` JSON. `protojson` accepts proto
+field names as written, so **no change to the emitted format is required** —
+existing manifests parse as-is.
+
+Always decode with:
+
+```go
+protojson.UnmarshalOptions{DiscardUnknown: false}
+```
+
+`DiscardUnknown: false` is the whole point. Any key a Starlark rule emits that
+has no field in `appmeta.proto` becomes a hard error instead of silently
+vanishing — which is exactly how the current drift went unnoticed.
+
+## The contract test
+
+Shared types alone do not prevent drift; a rule attribute can still be added
+without anyone extending the proto. The enforcement is a test:
+
+1. `bazel query 'kind(app_metadata, //...)'`, build every target, and unmarshal
+   each output with `DiscardUnknown: false`. Catches **rule → proto** drift.
+2. A fixture app in `testdata/` sets *every* `release_app` attribute; assert the
+   decoded message has no unset field. Catches **proto → rule** drift, i.e. a
+   field defined here that the rule never populates.
+
+Both directions fail loudly at `bazel test` time.
+
+## Adding a field
+
+Three edits, and the contract test fails until all three are done:
+
+1. Add the attr to `app_metadata` in `release.bzl` and emit it.
+2. Add the field to `AppManifest` in `appmeta.proto`.
+3. Extend the fixture in `testdata/`.
+
+## Migration
+
+Sequenced with AR-2 in `//tools/app_registry/PLAN.md`, which already has to
+touch `release.bzl` (for `deploy_unit`) and `composer.go` (for the chart
+lockfile) — so this rides along rather than being a separate disruption.
+
+1. Land `appmeta.proto` and the contract test against today's rule output.
+2. Replace `helm/composer.go`'s `AppMetadata` with `appmetapb.AppManifest`.
+   Delete the phantom `labels` / `annotations` / `dependencies` fields, or add
+   them to the rule if they were meant to exist.
+3. Replace `release_helper_go`'s `AppMetadata` with `appmetapb.AppManifest`, and
+   **remove the `Language`-as-version hack** in `plan.go` now that `version` is
+   a real field.
+4. Add `deploy_unit` to `release_app` and to the proto.
+5. `release_helper_go` emits `AppManifestSet`; the registry's `ReconcileApps`
+   consumes it directly with no conversion.
+
+Step 3 is the one that changes existing behaviour rather than just types — the
+version-sentinel removal should be its own reviewable commit.

--- a/tools/appmeta/proto/BUILD.bazel
+++ b/tools/appmeta/proto/BUILD.bazel
@@ -1,0 +1,22 @@
+"""Schema of record for release_app manifest JSON.
+
+Consumed by release_helper_go, the helm composer, and the app registry. This
+package must not depend on any of them — it is the shared contract, not a
+component of one consumer.
+"""
+
+load("@rules_go//proto:def.bzl", "go_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+go_proto_library(
+    name = "appmetapb",
+    importpath = "github.com/whale-net/everything/tools/appmeta/proto",
+    proto = ":appmetapb_proto",
+    visibility = ["//visibility:public"],
+)
+
+proto_library(
+    name = "appmetapb_proto",
+    srcs = ["appmeta.proto"],
+    visibility = ["//visibility:public"],
+)

--- a/tools/appmeta/proto/appmeta.proto
+++ b/tools/appmeta/proto/appmeta.proto
@@ -1,0 +1,134 @@
+syntax = "proto3";
+
+package whalenet.appmeta.v1;
+
+option go_package = "github.com/whale-net/everything/tools/appmeta/proto;appmetapb";
+
+// Schema of record for the JSON emitted by the `app_metadata` and
+// `helm_chart_metadata` Starlark rules in //tools/bazel:release.bzl.
+//
+// This package is the single definition of what a release_app manifest
+// contains. Every consumer — release_helper_go, the helm composer, the app
+// registry — decodes into these types instead of maintaining its own struct.
+//
+// WIRE FORMAT: the Starlark rules write plain snake_case JSON. `protojson`
+// accepts proto field names as-is, so no change to the emitted format is
+// required. Always decode with:
+//
+//     protojson.UnmarshalOptions{DiscardUnknown: false}
+//
+// so that any key a Starlark rule emits without a corresponding field here
+// becomes a hard error rather than silent data loss. That check is the
+// anti-drift mechanism; see //tools/appmeta:manifest_contract_test.
+//
+// ADDING A FIELD: add the attr to `app_metadata` in release.bzl, add it to the
+// message below, and extend the fixture in //tools/appmeta/testdata. The
+// contract test fails until all three agree.
+
+// DeployUnit declares how an app reaches an environment. Consumed by the app
+// registry to decide what is legal to promote, and sourced from the
+// `deploy_unit` attribute on release_app.
+enum DeployUnit {
+  DEPLOY_UNIT_UNSPECIFIED = 0;
+
+  // App reaches environments inside a Helm chart. Its images are pinned by the
+  // chart and are not independently promotable.
+  DEPLOY_UNIT_CHART = 1;
+
+  // App is deployed by moving an image reference directly, with no chart in
+  // between (e.g. manmanv2-host-manager).
+  DEPLOY_UNIT_IMAGE = 2;
+
+  // Built and published, but never deployed to an environment.
+  DEPLOY_UNIT_NONE = 3;
+}
+
+// HealthCheck mirrors the "health_check" object in the manifest JSON.
+message HealthCheck {
+  bool enabled = 1;
+  string path = 2;
+}
+
+// Ingress mirrors the "ingress" object in the manifest JSON.
+message Ingress {
+  string host = 1;
+  string tls_secret_name = 2;
+}
+
+// Resources mirrors the "resources" object in the manifest JSON.
+message Resources {
+  string requests_cpu = 1;
+  string requests_memory = 2;
+  string limits_cpu = 3;
+  string limits_memory = 4;
+}
+
+// AppManifest is one `release_app` declaration, as emitted by the
+// `app_metadata` rule. Field numbers are grouped to match the argument groups
+// documented on the release_app macro.
+message AppManifest {
+  // --- identity ---
+  string name = 1;      // app name, dashes only (e.g. "control-api")
+  string domain = 2;    // e.g. "manmanv2"
+  string description = 3;
+  string language = 4;  // "go" | "python"
+
+  // --- image coordinates ---
+  string registry = 10;      // "ghcr.io"
+  string organization = 11;  // "whale-net"
+  string repo_name = 12;     // "<domain>-<name>" unless custom_repo_name is set
+  string version = 13;       // default version from the macro; "latest" normally
+
+  // --- bazel targets ---
+  string binary_target = 20;
+  string image_target = 21;
+  string openapi_spec_target = 22;
+
+  // --- deployment shape ---
+  string app_type = 30;  // external-api | internal-api | worker | job
+  int32 port = 31;
+  int32 replicas = 32;
+  repeated string command = 33;
+  repeated string args = 34;
+
+  HealthCheck health_check = 40;
+  Ingress ingress = 41;
+  Resources resources = 42;
+
+  // --- release/promotion policy ---
+  // Added for the app registry. Defaults to DEPLOY_UNIT_CHART when the
+  // Starlark attr is unset, since charts are the normal delivery path.
+  DeployUnit deploy_unit = 50;
+}
+
+// ChartManifest is one `helm_chart` declaration, as emitted by the
+// `helm_chart_metadata` rule.
+message ChartManifest {
+  string name = 1;
+  string domain = 2;
+  string version = 3;
+  string namespace = 4;
+  string environment = 5;
+
+  // App names composed into this chart. Not "<domain>-<name>" — these are bare
+  // app names, matching what the Starlark rule extracts from the app_metadata
+  // target labels.
+  repeated string apps = 6;
+
+  string chart_target = 7;
+}
+
+// AppManifestSet is the full set of manifests discovered by a `bazel query`
+// sweep. This is what `release_helper_go` produces and what the app registry's
+// ReconcileApps consumes — the registry performs a full replace against it, so
+// partial sets must never be sent.
+message AppManifestSet {
+  repeated AppManifest apps = 1;
+  repeated ChartManifest charts = 2;
+
+  // Commit the sweep was taken at.
+  string git_sha = 3;
+
+  // Unix timestamp of the sweep.
+  int64 discovered_at = 4;
+}


### PR DESCRIPTION
Design-stage groundwork for an app registry: a service that records what CI
published and tracks which artifact is promoted to each environment.

**No implementation.** Protos, docs, and a component skeleton only, so the
modelling and sequencing decisions are reviewable before code exists.

Three commits, kept separate for readability and to make a later split easy:

| Commit | Contents |
|---|---|
| `9cc40aa4` | `//tools/appmeta/proto` — shared schema of record for `release_app` manifest JSON |
| `f1b7a8a0` | `//tools/app_registry/protos` — the four service contracts |
| `f7966667` | ARCHITECTURE / PLAN / README / TOC + component skeleton |

## Why

The release system is already declarative and works well. What has no home is
**promotion state** — "stage is on v1.4.0, prod is two versions behind" —
which currently lives implicitly in ArgoCD values files.

## Existing drift this surfaced

Two Go structs already decode `app_metadata`'s JSON, and they disagree with
each other and with the Starlark rule:

| Field | `release.bzl` emits | `release_helper_go` | `helm/composer.go` |
|---|:---:|:---:|:---:|
| `description`, `app_type`, `port`, `replicas` | yes | **no** | yes |
| `health_check`, `ingress`, `resources`, `command`, `args` | yes | **no** | yes |
| `version` | yes | **no** | yes |
| `binary_target`, `openapi_spec_target` | yes | yes | **no** |
| `labels`, `annotations`, `dependencies` | **no** | no | **phantom** |

That has already cost something concrete: because `release_helper_go`'s struct
has no `version` field, `cmd/plan.go` stores the release version in `Language`
and reads it back with `strings.HasPrefix(app.Language, "v")`.

Adding the registry as a third consumer would compound this, so `appmeta`
becomes the single definition. It depends on nothing — the schema must not
live under `app_registry`, or the helm composer would depend on the registry
in order to build a chart.

The Starlark rules keep emitting the same snake_case JSON; `protojson` reads
it unchanged. Drift is prevented by a contract test (decode with
`DiscardUnknown: false`, plus a full-coverage fixture for the reverse
direction), not by the shared type alone.

The `labels` / `annotations` / `dependencies` fields are dead at every level —
never emitted, never read, and their downstream `AppConfig` counterparts are
never rendered either. They get deleted in AR-M.

## Design points worth reviewer attention

- **Nothing in the deploy path calls the API synchronously.** ArgoCD reads the
  gitops repo the worker writes; CI recording is best-effort. That is what
  makes it safe for the registry to be a `release_app` in this repo that
  deploys itself.
- **Promotion and its writeback intent commit atomically** via a transactional
  outbox, with Temporal executing from it. Otherwise the registry can believe
  prod moved while the gitops repo disagrees — the exact failure this system
  exists to prevent.
- **Auth is split along the service boundary**, so the credential every build
  job already holds cannot promote.
- **Promotability is derived from a declared `deploy_unit`**, which is what
  makes "what am I allowed to promote?" answerable.

## Sequencing

Promotion tracking is additive; replacing git-tag version allocation moves a
working source of truth into a stateful service. Do the first, soak it against
real releases, then do the second. AR-M (schema consolidation) is first
because it repays itself whether or not the registry ever ships.

## Notes

- Temporal is not yet a Go dependency anywhere in this repo (fcm uses the
  Python SDK). `libs/go/temporal` + MODULE.bazel wiring is flagged as the
  largest unknown in AR-1.
- Supersedes #485, #486, #487 — same commits, one PR.
- Open question for reviewers: gitops repo target and file layout, which
  blocks AR-4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)