### PR TITLE
fix(tools/helm): drop dead metadata fields, make chart output deterministic

### DIFF
--- a/tools/helm/composer.go
+++ b/tools/helm/composer.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"text/template"
 )
@@ -24,9 +25,6 @@ type AppMetadata struct {
 	Port         int               `json:"port,omitempty"`
 	Replicas     int               `json:"replicas,omitempty"`
 	Resources    *ResourceConfig   `json:"resources,omitempty"`
-	Labels       map[string]string `json:"labels,omitempty"`
-	Annotations  map[string]string `json:"annotations,omitempty"`
-	Dependencies []string          `json:"dependencies,omitempty"`
 	HealthCheck  *HealthCheckMeta  `json:"health_check,omitempty"`
 	Ingress      *IngressMeta      `json:"ingress,omitempty"`
 	Command      []string          `json:"command,omitempty"`
@@ -166,8 +164,6 @@ type TemplateData struct {
 	Command     []string
 	Args        []string
 	Env         map[string]string
-	Labels      map[string]string
-	Annotations map[string]string
 }
 
 // ChartConfig represents configuration for chart generation
@@ -573,9 +569,15 @@ func (w *YAMLWriter) WriteMap(key string, m map[string]string) {
 	}
 	w.WriteKey(key)
 	w.indent += 2
-	for k, v := range m {
+	// Sort keys so output is reproducible — Go randomizes map iteration order.
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
 		prefix := strings.Repeat(" ", w.indent)
-		fmt.Fprintf(w.f, "%s%s: %q\n", prefix, k, v)
+		fmt.Fprintf(w.f, "%s%s: %q\n", prefix, k, m[k])
 	}
 	w.indent -= 2
 }
@@ -642,7 +644,16 @@ func writeValuesYAML(f *os.File, data ValuesData) error {
 
 	// Write apps section
 	w.StartSection("apps")
-	for name, app := range data.Apps {
+	// Sort app names so chart output is reproducible — Go randomizes map
+	// iteration order, which otherwise makes values.yaml (and therefore the
+	// published chart digest) vary between builds of identical inputs.
+	appNames := make([]string, 0, len(data.Apps))
+	for name := range data.Apps {
+		appNames = append(appNames, name)
+	}
+	sort.Strings(appNames)
+	for _, name := range appNames {
+		app := data.Apps[name]
 		w.StartSection(name)
 		w.WriteString("type", app.Type)
 		if app.Domain != "" {


### PR DESCRIPTION
Two independent cleanups in the helm composer, both surfaced while auditing
manifest drift for the app registry (#489). Split out because this is the only
change in that effort that touches production behaviour — everything else is
additive protos and docs.

## 1. Remove five never-connected struct fields

`AppMetadata.Labels` / `.Annotations` / `.Dependencies` and
`TemplateData.Labels` / `.Annotations`.

Dead at every level:

- `release_app` has no corresponding attrs and `_app_metadata_impl` never emits
  those JSON keys, so they could only ever decode as nil
- `buildAppConfig` never read them
- no template references `.Labels` or `.Annotations`, so the `TemplateData`
  counterparts were never rendered either

Not a half-wired feature — never connected at either end. Reinstating per-app
labels later is a real feature (rule attr → proto field → values → template),
not a reconnection.

`IngressDefaults.Annotations` is unrelated, live, and stays.

## 2. Chart output was not reproducible

`for name, app := range data.Apps` over a `map[string]AppConfig`, and the same
pattern in `YAMLWriter.WriteMap` (used for `env` and ingress annotations), let
Go's randomized map iteration order vary app ordering in `values.yaml` between
builds of identical inputs.

Confirmed against the **unmodified** tree — three clean builds of
`//demo:all_types_chart`:

```
run 1: 94e5dc134b276522f7c02abb2f2b3e87
run 2: 94e5dc134b276522f7c02abb2f2b3e87
run 3: 0a16060e22be0ac5512dad26e1d699d7
```

This means identical inputs could publish charts with different bytes and
therefore different digests. It also makes golden-output testing impossible,
which the upcoming manifest-schema migration in #489 depends on.

## Verification

- 5 clean builds now produce identical checksums
- all 20 chart YAML files across `//demo` and `//manmanv2` are byte-identical to
  pre-change output once ordering is normalized
- `bazel test //tools/...` → 7/7 pass

## Relationship to #489

Prerequisite for the AR-M composer migration described there. Independent and
mergeable on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)