### PR TITLE
AR-2a: App Registry recording RPCs (ReconcileApps, RecordBuild/RecordArtifact)

### DIFF
--- a/tools/app_registry/ARCHITECTURE.md
+++ b/tools/app_registry/ARCHITECTURE.md
@@ -224,6 +224,44 @@ API synchronously**:
 The registry can be down for hours without blocking a release or a deploy. The
 only thing lost is the ability to *make new promotions* during the outage.
 
+### `APP_REGISTRY_CICD_OPT_IN` — the bootstrap kill switch
+
+"Best-effort" is not enough on its own. The registry is built and released by
+the very pipeline that would call it, so before it is deployed and its secrets
+exist there is a genuine chicken-and-egg risk: **you must never be unable to
+build the app because the app is not yet deployed.**
+
+Every CI step that talks to the registry is therefore gated on a GitHub repo
+variable:
+
+```yaml
+if: vars.APP_REGISTRY_CICD_OPT_IN == 'true'
+```
+
+- **Unset or anything other than `true` (the default): CI makes no registry
+  calls at all.** The pipeline behaves exactly as it does today. This is the
+  state the repo ships in and stays in until the registry is deployed and its
+  credentials are configured.
+- **`true`:** recording steps run, still `continue-on-error` so a registry
+  outage warns rather than failing a release.
+
+Two independent gates, easily confused — keep them distinct:
+
+| Gate | Layer | Question it answers |
+|---|---|---|
+| `APP_REGISTRY_CICD_OPT_IN` | GitHub Actions | Does CI talk to the registry **at all**? |
+| `domain_adoption.stage` | Registry server | For a given domain, what is the registry **authoritative for**? |
+
+The first is a global bootstrap/kill switch owned by whoever administers the
+repo; the second is the per-domain rollout described under
+[Resolved questions](#resolved-questions). The opt-in must be `true` before any
+domain's stage matters, and turning it off is the single-lever rollback for the
+entire CI integration.
+
+Applies from AR-2c (the first phase to add CI steps) onward, including AR-5's
+`AllocateVersion` — version allocation must fall back to the tag-based path
+when the opt-in is off, or a registry outage becomes a release outage.
+
 ## Rejected alternatives
 
 | Decision | Chosen | Rejected | Why |

--- a/tools/app_registry/ARCHITECTURE.md
+++ b/tools/app_registry/ARCHITECTURE.md
@@ -210,6 +210,35 @@ retries are therefore safe by construction.
 Convention: `<workflow_run_id>-<attempt>[-<owner>-<kind>]` for CI; a
 client-generated UUID for human promotions.
 
+## Triage: the MISSING/ARCHIVED lifecycle
+
+An app's `status` moves between three states, but only one edge is a human
+decision:
+
+- **active → missing**: automatic. `Reconcile` marks an app/chart `MISSING`
+  whenever a full manifest set no longer contains it — see "Design
+  principles" #1, manifests are authoritative.
+- **missing → active** ("recovered"): automatic. If a manifest reappears in a
+  later `Reconcile` call, the row goes straight back to `ACTIVE` with no human
+  step. This is why `SetAppStatus` does not support `ACTIVE` as a target —
+  there would be nothing for a human to do that `Reconcile` doesn't already
+  do on the next run.
+- **missing → archived**: the one human-triggered transition, via
+  `SetAppStatus`. It means "this app is gone for good, stop flagging it as
+  MISSING." `reason` is required.
+
+`SetAppStatus` rejects every other transition with `FailedPrecondition` —
+most notably `active → archived` (an app must go through `MISSING` first) and
+any attempt to set `ACTIVE` directly. `archived → archived` is an idempotent
+no-op success rather than an error, so a retried archive call is safe.
+
+An earlier version of this RPC also allowed `SetAppStatus(ACTIVE)`, gated by
+comparing an app's `last_seen_at` against the table-wide max to approximate
+"was this app in the latest reconcile." That heuristic existed only to guard
+a case Reconcile's recovered path already handles automatically, and was
+fragile (a concurrent reconcile of an unrelated domain could shift the
+table-wide max mid-check). It has been removed along with the ACTIVE target.
+
 ## Availability and bootstrap
 
 The registry is itself a `release_app` in this monorepo, so it deploys itself.

--- a/tools/app_registry/PLAN.md
+++ b/tools/app_registry/PLAN.md
@@ -135,6 +135,12 @@ authoritative. Nothing depends on the registry yet.
   conversion code — AR-M made this the same type the registry accepts.
 - `.github/workflows/release.yml`: call `app-registry` CLI after image and chart
   pushes. **Best-effort — `continue-on-error`, must never fail a release.**
+- **Every registry step gated on `if: vars.APP_REGISTRY_CICD_OPT_IN == 'true'`.**
+  Default (unset) means CI makes no registry calls whatever, so the pipeline that
+  builds and releases the registry never depends on the registry already being
+  deployed. See ARCHITECTURE.md → "`APP_REGISTRY_CICD_OPT_IN` — the bootstrap
+  kill switch". This is a hard requirement, not a nicety: the repo ships with it
+  off and stays that way until the registry is deployed and its secrets exist.
 - CLI: `apps list`, `apps get`, `artifacts list`, `artifacts resolve`.
 
 **Exit criteria**

--- a/tools/app_registry/server/BUILD.bazel
+++ b/tools/app_registry/server/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//libs/go/logging",
         "//tools/app_registry/protos:appregistrypb",
         "//tools/app_registry/server/handlers",
+        "//tools/app_registry/server/repository",
         "//tools/app_registry/server/repository/postgres",
         "@io_opentelemetry_go_contrib_instrumentation_google_golang_org_grpc_otelgrpc//:otelgrpc",
         "@org_golang_google_grpc//:grpc",
@@ -51,6 +52,7 @@ go_test(
     embed = [":api_lib"],
     deps = [
         "//tools/app_registry/protos:appregistrypb",
+        "//tools/app_registry/server/repository/fake",
         "@org_golang_google_grpc//:grpc",
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//credentials/insecure",

--- a/tools/app_registry/server/handlers/BUILD.bazel
+++ b/tools/app_registry/server/handlers/BUILD.bazel
@@ -1,17 +1,40 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "handlers",
     srcs = [
         "app.go",
         "artifact.go",
+        "convert.go",
         "environment.go",
+        "errors.go",
+        "idempotency.go",
         "promotion.go",
     ],
     importpath = "github.com/whale-net/everything/tools/app_registry/server/handlers",
     visibility = ["//visibility:public"],
     deps = [
         "//tools/app_registry/protos:appregistrypb",
+        "//tools/app_registry/server/repository",
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//status",
+        "@org_golang_google_protobuf//proto",
+    ],
+)
+
+go_test(
+    name = "handlers_test",
+    size = "small",
+    srcs = [
+        "app_test.go",
+        "artifact_test.go",
+    ],
+    embed = [":handlers"],
+    deps = [
+        "//tools/app_registry/protos:appregistrypb",
+        "//tools/app_registry/server/repository",
+        "//tools/app_registry/server/repository/fake",
+        "//tools/appmeta/proto:appmetapb",
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//status",
     ],

--- a/tools/app_registry/server/handlers/BUILD.bazel
+++ b/tools/app_registry/server/handlers/BUILD.bazel
@@ -32,7 +32,6 @@ go_test(
     embed = [":handlers"],
     deps = [
         "//tools/app_registry/protos:appregistrypb",
-        "//tools/app_registry/server/repository",
         "//tools/app_registry/server/repository/fake",
         "//tools/appmeta/proto:appmetapb",
         "@org_golang_google_grpc//codes",

--- a/tools/app_registry/server/handlers/app.go
+++ b/tools/app_registry/server/handlers/app.go
@@ -130,6 +130,10 @@ func (s *AppServer) ListCharts(ctx context.Context, req *pb.ListChartsRequest) (
 	}, nil
 }
 
+// SetAppStatus is the human-triage path and supports exactly one transition:
+// missing -> archived. Reconcile already handles missing -> active
+// automatically via its "recovered" path, so ACTIVE is not a legal target
+// here — see ARCHITECTURE.md "Triage".
 func (s *AppServer) SetAppStatus(ctx context.Context, req *pb.SetAppStatusRequest) (*pb.SetAppStatusResponse, error) {
 	if req.AppId == "" {
 		return nil, status.Error(codes.InvalidArgument, "app_id is required")
@@ -137,12 +141,11 @@ func (s *AppServer) SetAppStatus(ctx context.Context, req *pb.SetAppStatusReques
 	if req.Reason == "" {
 		return nil, status.Error(codes.InvalidArgument, "reason is required")
 	}
-	target := appStatusFromPB(req.Status)
-	if target != repository.StatusActive && target != repository.StatusArchived {
-		return nil, status.Error(codes.InvalidArgument, "status must be ACTIVE or ARCHIVED")
+	if appStatusFromPB(req.Status) != repository.StatusArchived {
+		return nil, status.Error(codes.InvalidArgument, "status must be ARCHIVED; missing -> active happens automatically via reconcile")
 	}
 
-	app, err := s.repo.Apps().SetAppStatus(ctx, req.AppId, target, req.Reason)
+	app, err := s.repo.Apps().SetAppStatus(ctx, req.AppId, repository.StatusArchived, req.Reason)
 	if err != nil {
 		return nil, mapRepoErr(err)
 	}

--- a/tools/app_registry/server/handlers/app.go
+++ b/tools/app_registry/server/handlers/app.go
@@ -7,39 +7,144 @@ import (
 	"context"
 
 	pb "github.com/whale-net/everything/tools/app_registry/protos"
+	"github.com/whale-net/everything/tools/app_registry/server/repository"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 )
 
-// AppServer implements pb.AppRegistryServer. AR-1 wires it up with no
-// business logic; every RPC returns codes.Unimplemented. AR-2/AR-3 fill in
-// the repository-backed implementations.
+// AppServer implements pb.AppRegistryServer, backed by repository.Registry.
 type AppServer struct {
 	pb.UnimplementedAppRegistryServer
+	repo repository.Registry
 }
 
-// NewAppServer constructs an AppServer. Takes no dependencies yet — AR-2
-// wires in repository.AppRepository here.
-func NewAppServer() *AppServer {
-	return &AppServer{}
+// NewAppServer constructs an AppServer over repo.
+func NewAppServer(repo repository.Registry) *AppServer {
+	return &AppServer{repo: repo}
 }
 
 func (s *AppServer) ReconcileApps(ctx context.Context, req *pb.ReconcileAppsRequest) (*pb.ReconcileAppsResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "ReconcileApps not implemented")
+	if req.Manifests == nil {
+		return nil, status.Error(codes.InvalidArgument, "manifests is required")
+	}
+
+	// dry_run computes a diff and writes nothing: it never touches the
+	// idempotency store either (there is nothing for a retry to replay
+	// safely — every dry run recomputes against current state, which is the
+	// whole point).
+	if req.DryRun {
+		result, err := s.repo.Apps().Reconcile(ctx, req.Manifests.Apps, req.Manifests.Charts, true)
+		if err != nil {
+			return nil, mapRepoErr(err)
+		}
+		return reconcileResultToPB(result, true), nil
+	}
+
+	if req.IdempotencyKey == "" {
+		return nil, status.Error(codes.InvalidArgument, "idempotency_key is required")
+	}
+
+	resp, _, err := runIdempotent(ctx, s.repo, req.IdempotencyKey, "ReconcileApps",
+		func() proto.Message { return &pb.ReconcileAppsResponse{} },
+		func(ctx context.Context, r repository.Registry) (proto.Message, error) {
+			result, err := r.Apps().Reconcile(ctx, req.Manifests.Apps, req.Manifests.Charts, false)
+			if err != nil {
+				return nil, err
+			}
+			return reconcileResultToPB(result, false), nil
+		},
+	)
+	if err != nil {
+		return nil, mapRepoErr(err)
+	}
+	return resp.(*pb.ReconcileAppsResponse), nil
+}
+
+func reconcileResultToPB(r *repository.ReconcileResult, dryRun bool) *pb.ReconcileAppsResponse {
+	return &pb.ReconcileAppsResponse{
+		CreatedApps:        appsToPB(r.CreatedApps),
+		UpdatedApps:        appsToPB(r.UpdatedApps),
+		NewlyMissingApps:   appsToPB(r.NewlyMissingApps),
+		RecoveredApps:      appsToPB(r.RecoveredApps),
+		CreatedCharts:      chartsToPB(r.CreatedCharts),
+		UpdatedCharts:      chartsToPB(r.UpdatedCharts),
+		NewlyMissingCharts: chartsToPB(r.NewlyMissingCharts),
+		RecoveredCharts:    chartsToPB(r.RecoveredCharts),
+		DryRun:             dryRun,
+	}
 }
 
 func (s *AppServer) ListApps(ctx context.Context, req *pb.ListAppsRequest) (*pb.ListAppsResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "ListApps not implemented")
+	apps, err := s.repo.Apps().ListApps(ctx, repository.AppListFilter{
+		Domain:     req.Domain,
+		Statuses:   appStatusesFromPB(req.Statuses),
+		DeployUnit: req.DeployUnit,
+	})
+	if err != nil {
+		return nil, mapRepoErr(err)
+	}
+	return &pb.ListAppsResponse{
+		Apps: appsToPB(apps),
+		Page: &pb.PageResponse{TotalSize: int32(len(apps))},
+	}, nil
 }
 
 func (s *AppServer) GetApp(ctx context.Context, req *pb.GetAppRequest) (*pb.GetAppResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "GetApp not implemented")
+	app, err := s.lookupApp(ctx, req.AppId, req.FullName)
+	if err != nil {
+		return nil, mapRepoErr(err)
+	}
+	charts, err := s.repo.Apps().ChartsForApp(ctx, app.AppID)
+	if err != nil {
+		return nil, mapRepoErr(err)
+	}
+	return &pb.GetAppResponse{
+		App:    appToPB(*app),
+		Charts: chartsToPB(charts),
+	}, nil
+}
+
+func (s *AppServer) lookupApp(ctx context.Context, appID, fullName string) (*repository.App, error) {
+	switch {
+	case appID != "":
+		return s.repo.Apps().GetAppByID(ctx, appID)
+	case fullName != "":
+		return s.repo.Apps().GetAppByFullName(ctx, fullName)
+	default:
+		return nil, status.Error(codes.InvalidArgument, "app_id or full_name is required")
+	}
 }
 
 func (s *AppServer) ListCharts(ctx context.Context, req *pb.ListChartsRequest) (*pb.ListChartsResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "ListCharts not implemented")
+	charts, err := s.repo.Apps().ListCharts(ctx, repository.ChartListFilter{
+		Domain:   req.Domain,
+		Statuses: appStatusesFromPB(req.Statuses),
+	})
+	if err != nil {
+		return nil, mapRepoErr(err)
+	}
+	return &pb.ListChartsResponse{
+		Charts: chartsToPB(charts),
+		Page:   &pb.PageResponse{TotalSize: int32(len(charts))},
+	}, nil
 }
 
 func (s *AppServer) SetAppStatus(ctx context.Context, req *pb.SetAppStatusRequest) (*pb.SetAppStatusResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "SetAppStatus not implemented")
+	if req.AppId == "" {
+		return nil, status.Error(codes.InvalidArgument, "app_id is required")
+	}
+	if req.Reason == "" {
+		return nil, status.Error(codes.InvalidArgument, "reason is required")
+	}
+	target := appStatusFromPB(req.Status)
+	if target != repository.StatusActive && target != repository.StatusArchived {
+		return nil, status.Error(codes.InvalidArgument, "status must be ACTIVE or ARCHIVED")
+	}
+
+	app, err := s.repo.Apps().SetAppStatus(ctx, req.AppId, target, req.Reason)
+	if err != nil {
+		return nil, mapRepoErr(err)
+	}
+	return &pb.SetAppStatusResponse{App: appToPB(*app)}, nil
 }

--- a/tools/app_registry/server/handlers/app_test.go
+++ b/tools/app_registry/server/handlers/app_test.go
@@ -1,0 +1,278 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	pb "github.com/whale-net/everything/tools/app_registry/protos"
+	"github.com/whale-net/everything/tools/app_registry/server/repository/fake"
+	appmetapb "github.com/whale-net/everything/tools/appmeta/proto"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func manifestSet(apps []*appmetapb.AppManifest, charts []*appmetapb.ChartManifest) *appmetapb.AppManifestSet {
+	return &appmetapb.AppManifestSet{Apps: apps, Charts: charts}
+}
+
+func oneApp(domain, name string) *appmetapb.AppManifest {
+	return &appmetapb.AppManifest{
+		Domain: domain, Name: name, Description: "d", Language: "go", AppType: "worker",
+		DeployUnit: appmetapb.DeployUnit_DEPLOY_UNIT_IMAGE,
+	}
+}
+
+// TestReconcileApps_FullLifecycle walks create -> update -> absent-marks-MISSING
+// -> reappear-recovers-ACTIVE, matching the AR-2a scope's required coverage.
+func TestReconcileApps_FullLifecycle(t *testing.T) {
+	ctx := context.Background()
+	srv := NewAppServer(fake.New())
+
+	// 1. create
+	resp, err := srv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
+		Manifests:      manifestSet([]*appmetapb.AppManifest{oneApp("demo", "svc")}, nil),
+		IdempotencyKey: "run-1-1",
+	})
+	if err != nil {
+		t.Fatalf("create reconcile: %v", err)
+	}
+	if len(resp.CreatedApps) != 1 || resp.CreatedApps[0].Status != pb.AppStatus_APP_STATUS_ACTIVE {
+		t.Fatalf("expected 1 created ACTIVE app, got %+v", resp.CreatedApps)
+	}
+	appID := resp.CreatedApps[0].AppId
+
+	// 2. update (same app, different description)
+	am := oneApp("demo", "svc")
+	am.Description = "updated"
+	resp, err = srv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
+		Manifests:      manifestSet([]*appmetapb.AppManifest{am}, nil),
+		IdempotencyKey: "run-1-2",
+	})
+	if err != nil {
+		t.Fatalf("update reconcile: %v", err)
+	}
+	if len(resp.UpdatedApps) != 1 || resp.UpdatedApps[0].Description != "updated" {
+		t.Fatalf("expected 1 updated app with new description, got %+v", resp.UpdatedApps)
+	}
+
+	// 3. absent -> MISSING
+	resp, err = srv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
+		Manifests:      manifestSet(nil, nil),
+		IdempotencyKey: "run-1-3",
+	})
+	if err != nil {
+		t.Fatalf("absent reconcile: %v", err)
+	}
+	if len(resp.NewlyMissingApps) != 1 || resp.NewlyMissingApps[0].AppId != appID {
+		t.Fatalf("expected app %s newly missing, got %+v", appID, resp.NewlyMissingApps)
+	}
+
+	getResp, err := srv.GetApp(ctx, &pb.GetAppRequest{AppId: appID})
+	if err != nil {
+		t.Fatalf("get app after marking missing: %v", err)
+	}
+	if getResp.App.Status != pb.AppStatus_APP_STATUS_MISSING {
+		t.Fatalf("expected MISSING, got %v", getResp.App.Status)
+	}
+
+	// 4. reappear -> recovered ACTIVE
+	resp, err = srv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
+		Manifests:      manifestSet([]*appmetapb.AppManifest{oneApp("demo", "svc")}, nil),
+		IdempotencyKey: "run-1-4",
+	})
+	if err != nil {
+		t.Fatalf("recover reconcile: %v", err)
+	}
+	if len(resp.RecoveredApps) != 1 || resp.RecoveredApps[0].Status != pb.AppStatus_APP_STATUS_ACTIVE {
+		t.Fatalf("expected 1 recovered ACTIVE app, got %+v", resp.RecoveredApps)
+	}
+}
+
+// TestReconcileApps_DryRunWritesNothing proves dry_run computes a diff
+// without mutating the registry: a subsequent real reconcile still sees the
+// app as newly created.
+func TestReconcileApps_DryRunWritesNothing(t *testing.T) {
+	ctx := context.Background()
+	srv := NewAppServer(fake.New())
+
+	dryResp, err := srv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
+		Manifests: manifestSet([]*appmetapb.AppManifest{oneApp("demo", "svc")}, nil),
+		DryRun:    true,
+	})
+	if err != nil {
+		t.Fatalf("dry run reconcile: %v", err)
+	}
+	if !dryResp.DryRun || len(dryResp.CreatedApps) != 1 {
+		t.Fatalf("expected dry_run diff showing 1 created app, got %+v", dryResp)
+	}
+
+	listResp, err := srv.ListApps(ctx, &pb.ListAppsRequest{})
+	if err != nil {
+		t.Fatalf("list apps: %v", err)
+	}
+	if len(listResp.Apps) != 0 {
+		t.Fatalf("dry_run must write nothing; found %d apps", len(listResp.Apps))
+	}
+
+	// A real reconcile afterwards should still see this as a fresh create.
+	realResp, err := srv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
+		Manifests:      manifestSet([]*appmetapb.AppManifest{oneApp("demo", "svc")}, nil),
+		IdempotencyKey: "run-2-1",
+	})
+	if err != nil {
+		t.Fatalf("real reconcile after dry run: %v", err)
+	}
+	if len(realResp.CreatedApps) != 1 {
+		t.Fatalf("expected the real reconcile to still create the app, got %+v", realResp)
+	}
+}
+
+// TestReconcileApps_IdempotencyReplaysWithoutDoubleWrite proves a repeated
+// call with the same idempotency_key replays the original response and does
+// not re-execute the write — asserted by row count, per AR-2a's required
+// coverage.
+func TestReconcileApps_IdempotencyReplaysWithoutDoubleWrite(t *testing.T) {
+	ctx := context.Background()
+	srv := NewAppServer(fake.New())
+
+	req := &pb.ReconcileAppsRequest{
+		Manifests:      manifestSet([]*appmetapb.AppManifest{oneApp("demo", "svc")}, nil),
+		IdempotencyKey: "same-key",
+	}
+
+	first, err := srv.ReconcileApps(ctx, req)
+	if err != nil {
+		t.Fatalf("first reconcile: %v", err)
+	}
+	if len(first.CreatedApps) != 1 {
+		t.Fatalf("expected 1 created app, got %+v", first.CreatedApps)
+	}
+
+	second, err := srv.ReconcileApps(ctx, req)
+	if err != nil {
+		t.Fatalf("replayed reconcile: %v", err)
+	}
+	if len(second.CreatedApps) != 1 || second.CreatedApps[0].AppId != first.CreatedApps[0].AppId {
+		t.Fatalf("replayed response should be byte-identical to the first, got %+v vs %+v", second, first)
+	}
+
+	listResp, err := srv.ListApps(ctx, &pb.ListAppsRequest{})
+	if err != nil {
+		t.Fatalf("list apps: %v", err)
+	}
+	if len(listResp.Apps) != 1 {
+		t.Fatalf("idempotent replay must not double-write; expected 1 app row, got %d", len(listResp.Apps))
+	}
+}
+
+// TestReconcileApps_UnknownChartAppFailsWholeReconcile covers "resolve
+// ChartManifest.apps (bare app names) to app IDs and fail the reconcile if
+// any is unknown."
+func TestReconcileApps_UnknownChartAppFailsWholeReconcile(t *testing.T) {
+	ctx := context.Background()
+	srv := NewAppServer(fake.New())
+
+	_, err := srv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
+		Manifests: manifestSet(nil, []*appmetapb.ChartManifest{
+			{Domain: "demo", Name: "chart", Apps: []string{"nonexistent"}},
+		}),
+		IdempotencyKey: "run-3-1",
+	})
+	if err == nil {
+		t.Fatal("expected an error for a chart referencing an unknown app")
+	}
+	st, _ := status.FromError(err)
+	if st.Code() != codes.InvalidArgument {
+		t.Fatalf("expected InvalidArgument, got %v", st.Code())
+	}
+
+	// Nothing should have been written.
+	listResp, _ := srv.ListCharts(ctx, &pb.ListChartsRequest{})
+	if len(listResp.Charts) != 0 {
+		t.Fatalf("failed reconcile must not write a partial chart, got %d charts", len(listResp.Charts))
+	}
+}
+
+// TestReconcileApps_ChartComposesApps covers the happy path of resolving a
+// chart's bare app names to app_ids.
+func TestReconcileApps_ChartComposesApps(t *testing.T) {
+	ctx := context.Background()
+	srv := NewAppServer(fake.New())
+
+	resp, err := srv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
+		Manifests: manifestSet(
+			[]*appmetapb.AppManifest{oneApp("demo", "svc")},
+			[]*appmetapb.ChartManifest{{Domain: "demo", Name: "chart", Apps: []string{"svc"}}},
+		),
+		IdempotencyKey: "run-4-1",
+	})
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if len(resp.CreatedCharts) != 1 || len(resp.CreatedCharts[0].AppIds) != 1 {
+		t.Fatalf("expected 1 chart composing 1 app, got %+v", resp.CreatedCharts)
+	}
+	if resp.CreatedCharts[0].AppIds[0] != resp.CreatedApps[0].AppId {
+		t.Fatalf("chart's app_ids should resolve to the created app's id")
+	}
+}
+
+// TestSetAppStatus_RejectsActivateWhenNotInLatestReconcile covers "only
+// allow -> ACTIVE if present in the latest reconcile."
+func TestSetAppStatus_RejectsActivateWhenNotInLatestReconcile(t *testing.T) {
+	ctx := context.Background()
+	srv := NewAppServer(fake.New())
+
+	created, err := srv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
+		Manifests:      manifestSet([]*appmetapb.AppManifest{oneApp("demo", "svc"), oneApp("demo", "other")}, nil),
+		IdempotencyKey: "run-5-1",
+	})
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	var svcID string
+	for _, a := range created.CreatedApps {
+		if a.Name == "svc" {
+			svcID = a.AppId
+		}
+	}
+
+	// Drop "svc" from the manifest set and archive it once it's MISSING.
+	if _, err := srv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
+		Manifests:      manifestSet([]*appmetapb.AppManifest{oneApp("demo", "other")}, nil),
+		IdempotencyKey: "run-5-2",
+	}); err != nil {
+		t.Fatalf("reconcile dropping svc: %v", err)
+	}
+
+	_, err = srv.SetAppStatus(ctx, &pb.SetAppStatusRequest{
+		AppId: svcID, Status: pb.AppStatus_APP_STATUS_ACTIVE, Reason: "manual reactivate",
+	})
+	if err == nil {
+		t.Fatal("expected SetAppStatus(ACTIVE) to fail for an app absent from the latest reconcile")
+	}
+	st, _ := status.FromError(err)
+	if st.Code() != codes.FailedPrecondition {
+		t.Fatalf("expected FailedPrecondition, got %v", st.Code())
+	}
+
+	// Archiving, by contrast, is always legal.
+	archived, err := srv.SetAppStatus(ctx, &pb.SetAppStatusRequest{
+		AppId: svcID, Status: pb.AppStatus_APP_STATUS_ARCHIVED, Reason: "gone for good",
+	})
+	if err != nil {
+		t.Fatalf("archive: %v", err)
+	}
+	if archived.App.Status != pb.AppStatus_APP_STATUS_ARCHIVED {
+		t.Fatalf("expected ARCHIVED, got %v", archived.App.Status)
+	}
+}
+
+func TestSetAppStatus_RequiresReason(t *testing.T) {
+	ctx := context.Background()
+	srv := NewAppServer(fake.New())
+	_, err := srv.SetAppStatus(ctx, &pb.SetAppStatusRequest{AppId: "x", Status: pb.AppStatus_APP_STATUS_ARCHIVED})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("expected InvalidArgument when reason is missing, got %v", err)
+	}
+}

--- a/tools/app_registry/server/handlers/app_test.go
+++ b/tools/app_registry/server/handlers/app_test.go
@@ -217,46 +217,30 @@ func TestReconcileApps_ChartComposesApps(t *testing.T) {
 	}
 }
 
-// TestSetAppStatus_RejectsActivateWhenNotInLatestReconcile covers "only
-// allow -> ACTIVE if present in the latest reconcile."
-func TestSetAppStatus_RejectsActivateWhenNotInLatestReconcile(t *testing.T) {
+// TestSetAppStatus_MissingToArchivedSucceeds covers the only transition a
+// human triggers through this RPC: missing -> archived. missing -> active
+// happens automatically via Reconcile's "recovered" path instead.
+func TestSetAppStatus_MissingToArchivedSucceeds(t *testing.T) {
 	ctx := context.Background()
 	srv := NewAppServer(fake.New())
 
 	created, err := srv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
-		Manifests:      manifestSet([]*appmetapb.AppManifest{oneApp("demo", "svc"), oneApp("demo", "other")}, nil),
+		Manifests:      manifestSet([]*appmetapb.AppManifest{oneApp("demo", "svc")}, nil),
 		IdempotencyKey: "run-5-1",
 	})
 	if err != nil {
 		t.Fatalf("reconcile: %v", err)
 	}
-	var svcID string
-	for _, a := range created.CreatedApps {
-		if a.Name == "svc" {
-			svcID = a.AppId
-		}
-	}
+	svcID := created.CreatedApps[0].AppId
 
-	// Drop "svc" from the manifest set and archive it once it's MISSING.
+	// Drop "svc" from the manifest set so it becomes MISSING.
 	if _, err := srv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
-		Manifests:      manifestSet([]*appmetapb.AppManifest{oneApp("demo", "other")}, nil),
+		Manifests:      manifestSet(nil, nil),
 		IdempotencyKey: "run-5-2",
 	}); err != nil {
 		t.Fatalf("reconcile dropping svc: %v", err)
 	}
 
-	_, err = srv.SetAppStatus(ctx, &pb.SetAppStatusRequest{
-		AppId: svcID, Status: pb.AppStatus_APP_STATUS_ACTIVE, Reason: "manual reactivate",
-	})
-	if err == nil {
-		t.Fatal("expected SetAppStatus(ACTIVE) to fail for an app absent from the latest reconcile")
-	}
-	st, _ := status.FromError(err)
-	if st.Code() != codes.FailedPrecondition {
-		t.Fatalf("expected FailedPrecondition, got %v", st.Code())
-	}
-
-	// Archiving, by contrast, is always legal.
 	archived, err := srv.SetAppStatus(ctx, &pb.SetAppStatusRequest{
 		AppId: svcID, Status: pb.AppStatus_APP_STATUS_ARCHIVED, Reason: "gone for good",
 	})
@@ -265,6 +249,58 @@ func TestSetAppStatus_RejectsActivateWhenNotInLatestReconcile(t *testing.T) {
 	}
 	if archived.App.Status != pb.AppStatus_APP_STATUS_ARCHIVED {
 		t.Fatalf("expected ARCHIVED, got %v", archived.App.Status)
+	}
+
+	// archived -> archived is an idempotent no-op success, not an error.
+	archivedAgain, err := srv.SetAppStatus(ctx, &pb.SetAppStatusRequest{
+		AppId: svcID, Status: pb.AppStatus_APP_STATUS_ARCHIVED, Reason: "gone for good, again",
+	})
+	if err != nil {
+		t.Fatalf("re-archive: %v", err)
+	}
+	if archivedAgain.App.Status != pb.AppStatus_APP_STATUS_ARCHIVED {
+		t.Fatalf("expected ARCHIVED, got %v", archivedAgain.App.Status)
+	}
+}
+
+// TestSetAppStatus_RejectsActiveToArchived covers the FailedPrecondition
+// path: an app must be MISSING before it can be archived.
+func TestSetAppStatus_RejectsActiveToArchived(t *testing.T) {
+	ctx := context.Background()
+	srv := NewAppServer(fake.New())
+
+	created, err := srv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
+		Manifests:      manifestSet([]*appmetapb.AppManifest{oneApp("demo", "svc")}, nil),
+		IdempotencyKey: "run-6-1",
+	})
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	svcID := created.CreatedApps[0].AppId
+
+	_, err = srv.SetAppStatus(ctx, &pb.SetAppStatusRequest{
+		AppId: svcID, Status: pb.AppStatus_APP_STATUS_ARCHIVED, Reason: "should not work",
+	})
+	if err == nil {
+		t.Fatal("expected SetAppStatus to fail archiving an ACTIVE app")
+	}
+	st, _ := status.FromError(err)
+	if st.Code() != codes.FailedPrecondition {
+		t.Fatalf("expected FailedPrecondition, got %v", st.Code())
+	}
+}
+
+// TestSetAppStatus_RejectsActiveTarget covers "ACTIVE is not a legal target
+// at all" — dropped along with the last_seen_at heuristic that used to guard
+// it, since Reconcile's recovered path is the only way back to ACTIVE.
+func TestSetAppStatus_RejectsActiveTarget(t *testing.T) {
+	ctx := context.Background()
+	srv := NewAppServer(fake.New())
+	_, err := srv.SetAppStatus(ctx, &pb.SetAppStatusRequest{
+		AppId: "x", Status: pb.AppStatus_APP_STATUS_ACTIVE, Reason: "manual reactivate",
+	})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("expected InvalidArgument for status ACTIVE, got %v", err)
 	}
 }
 

--- a/tools/app_registry/server/handlers/artifact.go
+++ b/tools/app_registry/server/handlers/artifact.go
@@ -2,41 +2,223 @@ package handlers
 
 import (
 	"context"
+	"regexp"
+	"strings"
+	"time"
 
 	pb "github.com/whale-net/everything/tools/app_registry/protos"
+	"github.com/whale-net/everything/tools/app_registry/server/repository"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 )
 
-// ArtifactServer implements pb.ArtifactRegistryServer. See AppServer for the
-// AR-1 skeleton convention — no business logic, codes.Unimplemented only.
+var semverRe = regexp.MustCompile(`^v\d+\.\d+\.\d+$`)
+
+// ArtifactServer implements pb.ArtifactRegistryServer, backed by
+// repository.Registry. AllocateVersion stays codes.Unimplemented — that's
+// AR-5.
 type ArtifactServer struct {
 	pb.UnimplementedArtifactRegistryServer
+	repo repository.Registry
 }
 
-// NewArtifactServer constructs an ArtifactServer.
-func NewArtifactServer() *ArtifactServer {
-	return &ArtifactServer{}
+// NewArtifactServer constructs an ArtifactServer over repo.
+func NewArtifactServer(repo repository.Registry) *ArtifactServer {
+	return &ArtifactServer{repo: repo}
 }
 
 func (s *ArtifactServer) RecordBuild(ctx context.Context, req *pb.RecordBuildRequest) (*pb.RecordBuildResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "RecordBuild not implemented")
+	if req.WorkflowRunId == "" {
+		return nil, status.Error(codes.InvalidArgument, "workflow_run_id is required")
+	}
+	if req.GitSha == "" {
+		return nil, status.Error(codes.InvalidArgument, "git_sha is required")
+	}
+	if req.IdempotencyKey == "" {
+		return nil, status.Error(codes.InvalidArgument, "idempotency_key is required")
+	}
+
+	attempt := req.WorkflowAttempt
+	if attempt == 0 {
+		attempt = 1
+	}
+
+	resp, _, err := runIdempotent(ctx, s.repo, req.IdempotencyKey, "RecordBuild",
+		func() proto.Message { return &pb.RecordBuildResponse{} },
+		func(ctx context.Context, r repository.Registry) (proto.Message, error) {
+			var startedAt *time.Time
+			if req.StartedAt != 0 {
+				t := unixToTime(req.StartedAt)
+				startedAt = &t
+			}
+			build, alreadyRecorded, err := r.Builds().RecordBuild(ctx, repository.Build{
+				GitSHA:          req.GitSha,
+				GitRef:          req.GitRef,
+				WorkflowRunID:   req.WorkflowRunId,
+				WorkflowAttempt: attempt,
+				Actor:           req.Actor,
+				StartedAt:       startedAt,
+			})
+			if err != nil {
+				return nil, err
+			}
+			return &pb.RecordBuildResponse{Build: buildToPB(*build), AlreadyRecorded: alreadyRecorded}, nil
+		},
+	)
+	if err != nil {
+		return nil, mapRepoErr(err)
+	}
+	return resp.(*pb.RecordBuildResponse), nil
 }
 
 func (s *ArtifactServer) RecordArtifact(ctx context.Context, req *pb.RecordArtifactRequest) (*pb.RecordArtifactResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "RecordArtifact not implemented")
+	if req.BuildId == "" {
+		return nil, status.Error(codes.InvalidArgument, "build_id is required")
+	}
+	kind := artifactKindFromPB(req.Kind)
+	if kind == "" {
+		return nil, status.Error(codes.InvalidArgument, "kind is required")
+	}
+	if req.OwnerFullName == "" {
+		return nil, status.Error(codes.InvalidArgument, "owner_full_name is required")
+	}
+	if req.Digest == "" || !strings.HasPrefix(req.Digest, "sha256:") {
+		return nil, status.Error(codes.InvalidArgument, `digest is required and must be "sha256:..."`)
+	}
+	if req.Version != "" && !semverRe.MatchString(req.Version) {
+		return nil, status.Errorf(codes.InvalidArgument, "version %q must match v<major>.<minor>.<patch>", req.Version)
+	}
+	if kind == repository.ArtifactKindImage && len(req.Contains) > 0 {
+		return nil, status.Error(codes.InvalidArgument, "contains is only valid for kind == CHART")
+	}
+	if req.IdempotencyKey == "" {
+		return nil, status.Error(codes.InvalidArgument, "idempotency_key is required")
+	}
+
+	resp, _, err := runIdempotent(ctx, s.repo, req.IdempotencyKey, "RecordArtifact",
+		func() proto.Message { return &pb.RecordArtifactResponse{} },
+		func(ctx context.Context, r repository.Registry) (proto.Message, error) {
+			owner, err := s.resolveOwner(ctx, r, kind, req.OwnerFullName)
+			if err != nil {
+				return nil, err
+			}
+
+			a := repository.Artifact{
+				Kind:        kind,
+				Repository:  req.Repository,
+				Version:     req.Version,
+				Digest:      req.Digest,
+				BuildID:     req.BuildId,
+				PublishedAt: unixToTime(req.PublishedAt),
+			}
+			if kind == repository.ArtifactKindImage {
+				a.AppID = owner
+			} else {
+				a.ChartID = owner
+			}
+
+			artifact, alreadyRecorded, err := r.Artifacts().RecordArtifact(ctx, a, containedImagesFromPB(req.Contains))
+			if err != nil {
+				return nil, err
+			}
+			return &pb.RecordArtifactResponse{Artifact: artifactToPB(*artifact), AlreadyRecorded: alreadyRecorded}, nil
+		},
+	)
+	if err != nil {
+		return nil, mapRepoErr(err)
+	}
+	return resp.(*pb.RecordArtifactResponse), nil
+}
+
+// resolveOwner resolves owner_full_name to an app_id or chart_id, depending
+// on kind, wrapping repository.ErrNotFound as ErrInvalidArgument — an
+// unknown owner is a caller mistake, not a "row doesn't exist yet" case.
+func (s *ArtifactServer) resolveOwner(ctx context.Context, r repository.Registry, kind repository.ArtifactKind, ownerFullName string) (string, error) {
+	if kind == repository.ArtifactKindImage {
+		app, err := r.Apps().GetAppByFullName(ctx, ownerFullName)
+		if err != nil {
+			return "", repository.ErrInvalidArgument
+		}
+		return app.AppID, nil
+	}
+	chart, err := r.Apps().GetChartByFullName(ctx, ownerFullName)
+	if err != nil {
+		return "", repository.ErrInvalidArgument
+	}
+	return chart.ChartID, nil
 }
 
 func (s *ArtifactServer) ListArtifacts(ctx context.Context, req *pb.ListArtifactsRequest) (*pb.ListArtifactsResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "ListArtifacts not implemented")
+	artifacts, err := s.repo.Artifacts().ListArtifacts(ctx, repository.ArtifactListFilter{
+		OwnerFullName:  req.OwnerFullName,
+		Kind:           artifactKindFromPB(req.Kind),
+		PromotableOnly: req.PromotableOnly,
+	})
+	if err != nil {
+		return nil, mapRepoErr(err)
+	}
+	return &pb.ListArtifactsResponse{
+		Artifacts: artifactsToPB(artifacts),
+		Page:      &pb.PageResponse{TotalSize: int32(len(artifacts))},
+	}, nil
 }
 
 func (s *ArtifactServer) GetArtifact(ctx context.Context, req *pb.GetArtifactRequest) (*pb.GetArtifactResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "GetArtifact not implemented")
+	lookup, err := artifactLookupFromGetRequest(req)
+	if err != nil {
+		return nil, err
+	}
+	artifact, err := s.repo.Artifacts().GetArtifact(ctx, lookup)
+	if err != nil {
+		return nil, mapRepoErr(err)
+	}
+	resp := &pb.GetArtifactResponse{Artifact: artifactToPB(*artifact)}
+	if build, err := s.repo.Builds().GetBuild(ctx, artifact.BuildID); err == nil {
+		resp.Build = buildToPB(*build)
+	}
+	return resp, nil
 }
 
+func artifactLookupFromGetRequest(req *pb.GetArtifactRequest) (repository.ArtifactLookup, error) {
+	switch {
+	case req.ArtifactId != "":
+		return repository.ArtifactLookup{ArtifactID: req.ArtifactId}, nil
+	case req.Digest != "":
+		return repository.ArtifactLookup{Digest: req.Digest}, nil
+	case req.OwnerFullName != "":
+		return repository.ArtifactLookup{
+			OwnerFullName: req.OwnerFullName,
+			Kind:          artifactKindFromPB(req.Kind),
+			Version:       req.Version,
+		}, nil
+	default:
+		return repository.ArtifactLookup{}, errMissingArtifactLookup
+	}
+}
+
+var errMissingArtifactLookup = status.Error(codes.InvalidArgument, "artifact_id, digest, or owner_full_name+kind+version is required")
+
 func (s *ArtifactServer) ResolveArtifact(ctx context.Context, req *pb.ResolveArtifactRequest) (*pb.ResolveArtifactResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "ResolveArtifact not implemented")
+	var lookup repository.ArtifactLookup
+	switch {
+	case req.ArtifactId != "":
+		lookup = repository.ArtifactLookup{ArtifactID: req.ArtifactId}
+	case req.Digest != "":
+		lookup = repository.ArtifactLookup{Digest: req.Digest}
+	default:
+		return nil, status.Error(codes.InvalidArgument, "artifact_id or digest is required")
+	}
+
+	artifact, images, builds, err := s.repo.Artifacts().ResolveArtifact(ctx, lookup)
+	if err != nil {
+		return nil, mapRepoErr(err)
+	}
+	return &pb.ResolveArtifactResponse{
+		Artifact: artifactToPB(*artifact),
+		Images:   artifactsToPB(images),
+		Builds:   buildsToPB(builds),
+	}, nil
 }
 
 func (s *ArtifactServer) AllocateVersion(ctx context.Context, req *pb.AllocateVersionRequest) (*pb.AllocateVersionResponse, error) {

--- a/tools/app_registry/server/handlers/artifact_test.go
+++ b/tools/app_registry/server/handlers/artifact_test.go
@@ -1,0 +1,254 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	pb "github.com/whale-net/everything/tools/app_registry/protos"
+	"github.com/whale-net/everything/tools/app_registry/server/repository/fake"
+	appmetapb "github.com/whale-net/everything/tools/appmeta/proto"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// setup builds an AppServer and ArtifactServer sharing one fake registry,
+// with one app per DeployUnit so promotability derivation can be exercised
+// for all three cases in one place.
+func setup(t *testing.T) (*AppServer, *ArtifactServer, map[string]*pb.App) {
+	t.Helper()
+	repo := fake.New()
+	appSrv := NewAppServer(repo)
+	artifactSrv := NewArtifactServer(repo)
+	ctx := context.Background()
+
+	reconcile, err := appSrv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
+		Manifests: manifestSet([]*appmetapb.AppManifest{
+			{Domain: "demo", Name: "chart-app", DeployUnit: appmetapb.DeployUnit_DEPLOY_UNIT_CHART},
+			{Domain: "demo", Name: "image-app", DeployUnit: appmetapb.DeployUnit_DEPLOY_UNIT_IMAGE},
+			{Domain: "demo", Name: "none-app", DeployUnit: appmetapb.DeployUnit_DEPLOY_UNIT_NONE},
+		}, []*appmetapb.ChartManifest{
+			{Domain: "demo", Name: "achart", Apps: []string{"chart-app"}},
+		}),
+		IdempotencyKey: "setup-1",
+	})
+	if err != nil {
+		t.Fatalf("setup reconcile: %v", err)
+	}
+
+	apps := map[string]*pb.App{}
+	for _, a := range reconcile.CreatedApps {
+		apps[a.Name] = a
+	}
+	apps["achart"] = nil // placeholder; charts tracked separately below
+	for _, c := range reconcile.CreatedCharts {
+		_ = c
+	}
+	return appSrv, artifactSrv, apps
+}
+
+func recordBuild(t *testing.T, srv *ArtifactServer, runID string) *pb.Build {
+	t.Helper()
+	resp, err := srv.RecordBuild(context.Background(), &pb.RecordBuildRequest{
+		GitSha: "abc123", WorkflowRunId: runID, IdempotencyKey: runID + "-build",
+	})
+	if err != nil {
+		t.Fatalf("RecordBuild: %v", err)
+	}
+	return resp.Build
+}
+
+// TestRecordArtifact_PromotabilityDerivation covers all three DeployUnit
+// rows of ARCHITECTURE.md's promotability table for image artifacts, plus
+// charts always being PROMOTABLE.
+func TestRecordArtifact_PromotabilityDerivation(t *testing.T) {
+	_, artifactSrv, apps := setup(t)
+	ctx := context.Background()
+	build := recordBuild(t, artifactSrv, "run-promo")
+
+	cases := []struct {
+		appName string
+		want    pb.Promotability
+	}{
+		{"chart-app", pb.Promotability_PROMOTABILITY_VIA_CHART},
+		{"image-app", pb.Promotability_PROMOTABILITY_PROMOTABLE},
+		{"none-app", pb.Promotability_PROMOTABILITY_NOT_PROMOTABLE},
+	}
+	for _, tc := range cases {
+		t.Run(tc.appName, func(t *testing.T) {
+			resp, err := artifactSrv.RecordArtifact(ctx, &pb.RecordArtifactRequest{
+				BuildId: build.BuildId, Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE,
+				OwnerFullName: "demo-" + tc.appName, Digest: "sha256:" + tc.appName, Version: "v1.0.0",
+				IdempotencyKey: "record-" + tc.appName,
+			})
+			if err != nil {
+				t.Fatalf("RecordArtifact(%s): %v", tc.appName, err)
+			}
+			if resp.Artifact.Promotability != tc.want {
+				t.Fatalf("%s: expected promotability %v, got %v", tc.appName, tc.want, resp.Artifact.Promotability)
+			}
+		})
+	}
+	_ = apps
+}
+
+func TestRecordArtifact_ChartIsAlwaysPromotable(t *testing.T) {
+	_, artifactSrv, _ := setup(t)
+	ctx := context.Background()
+	build := recordBuild(t, artifactSrv, "run-chart-promo")
+
+	imgResp, err := artifactSrv.RecordArtifact(ctx, &pb.RecordArtifactRequest{
+		BuildId: build.BuildId, Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE,
+		OwnerFullName: "demo-chart-app", Digest: "sha256:imageforchart", Version: "v1.0.0",
+		IdempotencyKey: "record-image-for-chart",
+	})
+	if err != nil {
+		t.Fatalf("record image: %v", err)
+	}
+
+	chartResp, err := artifactSrv.RecordArtifact(ctx, &pb.RecordArtifactRequest{
+		BuildId: build.BuildId, Kind: pb.ArtifactKind_ARTIFACT_KIND_CHART,
+		OwnerFullName: "demo-achart", Digest: "sha256:chart1", Version: "v1.0.0",
+		Contains: []*pb.ContainedImage{
+			{AppFullName: "demo-chart-app", Repository: "repo", Version: "v1.0.0", Digest: imgResp.Artifact.Digest},
+		},
+		IdempotencyKey: "record-chart1",
+	})
+	if err != nil {
+		t.Fatalf("record chart: %v", err)
+	}
+	if chartResp.Artifact.Promotability != pb.Promotability_PROMOTABILITY_PROMOTABLE {
+		t.Fatalf("expected chart PROMOTABLE, got %v", chartResp.Artifact.Promotability)
+	}
+}
+
+// TestRecordArtifact_RejectsChartPinningUnrecordedImage is required coverage:
+// a chart artifact may not reference an image digest that was never recorded.
+func TestRecordArtifact_RejectsChartPinningUnrecordedImage(t *testing.T) {
+	_, artifactSrv, _ := setup(t)
+	ctx := context.Background()
+	build := recordBuild(t, artifactSrv, "run-reject")
+
+	_, err := artifactSrv.RecordArtifact(ctx, &pb.RecordArtifactRequest{
+		BuildId: build.BuildId, Kind: pb.ArtifactKind_ARTIFACT_KIND_CHART,
+		OwnerFullName: "demo-achart", Digest: "sha256:chartreject", Version: "v1.0.0",
+		Contains: []*pb.ContainedImage{
+			{AppFullName: "demo-chart-app", Repository: "repo", Version: "v1.0.0", Digest: "sha256:neverrecorded"},
+		},
+		IdempotencyKey: "record-reject",
+	})
+	if err == nil {
+		t.Fatal("expected an error for a chart pinning an unrecorded image digest")
+	}
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("expected InvalidArgument, got %v (%v)", status.Code(err), err)
+	}
+}
+
+// TestResolveArtifact_ReturnsImagesForChart is required coverage: resolving
+// a chart artifact returns the correct pinned image artifacts and builds.
+func TestResolveArtifact_ReturnsImagesForChart(t *testing.T) {
+	_, artifactSrv, _ := setup(t)
+	ctx := context.Background()
+	build := recordBuild(t, artifactSrv, "run-resolve")
+
+	img, err := artifactSrv.RecordArtifact(ctx, &pb.RecordArtifactRequest{
+		BuildId: build.BuildId, Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE,
+		OwnerFullName: "demo-chart-app", Digest: "sha256:resolveimg", Version: "v1.2.3",
+		IdempotencyKey: "record-resolve-img",
+	})
+	if err != nil {
+		t.Fatalf("record image: %v", err)
+	}
+
+	chart, err := artifactSrv.RecordArtifact(ctx, &pb.RecordArtifactRequest{
+		BuildId: build.BuildId, Kind: pb.ArtifactKind_ARTIFACT_KIND_CHART,
+		OwnerFullName: "demo-achart", Digest: "sha256:resolvechart", Version: "v1.0.0",
+		Contains: []*pb.ContainedImage{
+			{AppFullName: "demo-chart-app", Repository: "repo", Version: "v1.2.3", Digest: img.Artifact.Digest},
+		},
+		IdempotencyKey: "record-resolve-chart",
+	})
+	if err != nil {
+		t.Fatalf("record chart: %v", err)
+	}
+
+	resolved, err := artifactSrv.ResolveArtifact(ctx, &pb.ResolveArtifactRequest{ArtifactId: chart.Artifact.ArtifactId})
+	if err != nil {
+		t.Fatalf("ResolveArtifact: %v", err)
+	}
+	if len(resolved.Images) != 1 || resolved.Images[0].Digest != "sha256:resolveimg" {
+		t.Fatalf("expected 1 resolved image with digest sha256:resolveimg, got %+v", resolved.Images)
+	}
+	if len(resolved.Builds) != 1 || resolved.Builds[0].BuildId != build.BuildId {
+		t.Fatalf("expected the image's originating build, got %+v", resolved.Builds)
+	}
+}
+
+// TestRecordArtifact_IdempotencyReplaysWithoutDoubleWrite proves a repeated
+// RecordArtifact call with the same idempotency_key does not create a second
+// row, asserted by ListArtifacts count.
+func TestRecordArtifact_IdempotencyReplaysWithoutDoubleWrite(t *testing.T) {
+	_, artifactSrv, _ := setup(t)
+	ctx := context.Background()
+	build := recordBuild(t, artifactSrv, "run-idem")
+
+	req := &pb.RecordArtifactRequest{
+		BuildId: build.BuildId, Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE,
+		OwnerFullName: "demo-image-app", Digest: "sha256:idem", Version: "v1.0.0",
+		IdempotencyKey: "idem-key",
+	}
+	if _, err := artifactSrv.RecordArtifact(ctx, req); err != nil {
+		t.Fatalf("first RecordArtifact: %v", err)
+	}
+	if _, err := artifactSrv.RecordArtifact(ctx, req); err != nil {
+		t.Fatalf("replayed RecordArtifact: %v", err)
+	}
+
+	list, err := artifactSrv.ListArtifacts(ctx, &pb.ListArtifactsRequest{})
+	if err != nil {
+		t.Fatalf("ListArtifacts: %v", err)
+	}
+	if len(list.Artifacts) != 1 {
+		t.Fatalf("expected exactly 1 artifact row after replay, got %d", len(list.Artifacts))
+	}
+}
+
+func TestRecordBuild_IdempotencyReplaysWithoutDoubleWrite(t *testing.T) {
+	_, artifactSrv, _ := setup(t)
+	ctx := context.Background()
+
+	req := &pb.RecordBuildRequest{GitSha: "abc", WorkflowRunId: "dup-run", IdempotencyKey: "dup-key"}
+	first, err := artifactSrv.RecordBuild(ctx, req)
+	if err != nil {
+		t.Fatalf("first RecordBuild: %v", err)
+	}
+	second, err := artifactSrv.RecordBuild(ctx, req)
+	if err != nil {
+		t.Fatalf("replayed RecordBuild: %v", err)
+	}
+	if second.Build.BuildId != first.Build.BuildId {
+		t.Fatalf("expected replay to return the same build, got %s vs %s", second.Build.BuildId, first.Build.BuildId)
+	}
+}
+
+func TestRecordArtifact_RejectsMissingIdempotencyKey(t *testing.T) {
+	_, artifactSrv, _ := setup(t)
+	ctx := context.Background()
+	build := recordBuild(t, artifactSrv, "run-noidem")
+
+	_, err := artifactSrv.RecordArtifact(ctx, &pb.RecordArtifactRequest{
+		BuildId: build.BuildId, Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE,
+		OwnerFullName: "demo-image-app", Digest: "sha256:noidem", Version: "v1.0.0",
+	})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("expected InvalidArgument for missing idempotency_key, got %v", err)
+	}
+}
+
+func TestArtifactServer_AllocateVersionStillUnimplemented(t *testing.T) {
+	_, artifactSrv, _ := setup(t)
+	_, err := artifactSrv.AllocateVersion(context.Background(), &pb.AllocateVersionRequest{})
+	if status.Code(err) != codes.Unimplemented {
+		t.Fatalf("expected Unimplemented, got %v", err)
+	}
+}

--- a/tools/app_registry/server/handlers/artifact_test.go
+++ b/tools/app_registry/server/handlers/artifact_test.go
@@ -144,6 +144,46 @@ func TestRecordArtifact_RejectsChartPinningUnrecordedImage(t *testing.T) {
 	}
 }
 
+// TestRecordArtifact_DuplicateOwnerKindVersionIsAlreadyExists covers the
+// unique_violation mapping (SQLSTATE 23505 -> codes.AlreadyExists) that Fix 1
+// adds centrally to the postgres layer: recording a second, differently-
+// digested artifact for an (owner, kind, version) already claimed is a
+// conflict a caller (e.g. AR-5's AllocateVersion) should retry with a
+// different version, not codes.Internal — which would look like a server bug
+// and invite a pointless retry of the exact same request. The fake enforces
+// the same (owner, kind, version) uniqueness postgres's artifact_version_idx
+// does, so this test predicts real behaviour.
+func TestRecordArtifact_DuplicateOwnerKindVersionIsAlreadyExists(t *testing.T) {
+	_, artifactSrv, _ := setup(t)
+	ctx := context.Background()
+	build := recordBuild(t, artifactSrv, "run-dup")
+
+	first := &pb.RecordArtifactRequest{
+		BuildId: build.BuildId, Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE,
+		OwnerFullName: "demo-image-app", Digest: "sha256:first", Version: "v1.2.3",
+		IdempotencyKey: "record-dup-1",
+	}
+	if _, err := artifactSrv.RecordArtifact(ctx, first); err != nil {
+		t.Fatalf("first RecordArtifact: %v", err)
+	}
+
+	// Same owner, kind, and version; a different digest and a fresh
+	// idempotency key, so this is not an idempotent replay — it is a
+	// genuine conflict the unique index rejects.
+	second := &pb.RecordArtifactRequest{
+		BuildId: build.BuildId, Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE,
+		OwnerFullName: "demo-image-app", Digest: "sha256:different", Version: "v1.2.3",
+		IdempotencyKey: "record-dup-2",
+	}
+	_, err := artifactSrv.RecordArtifact(ctx, second)
+	if err == nil {
+		t.Fatal("expected an error recording a duplicate (owner, kind, version) with a different digest")
+	}
+	if status.Code(err) != codes.AlreadyExists {
+		t.Fatalf("expected AlreadyExists, got %v (%v)", status.Code(err), err)
+	}
+}
+
 // TestResolveArtifact_ReturnsImagesForChart is required coverage: resolving
 // a chart artifact returns the correct pinned image artifacts and builds.
 func TestResolveArtifact_ReturnsImagesForChart(t *testing.T) {

--- a/tools/app_registry/server/handlers/convert.go
+++ b/tools/app_registry/server/handlers/convert.go
@@ -1,0 +1,221 @@
+package handlers
+
+import (
+	"time"
+
+	pb "github.com/whale-net/everything/tools/app_registry/protos"
+	"github.com/whale-net/everything/tools/app_registry/server/repository"
+)
+
+func unixToTime(sec int64) time.Time {
+	if sec == 0 {
+		return time.Time{}
+	}
+	return time.Unix(sec, 0).UTC()
+}
+
+func timeToUnix(t time.Time) int64 {
+	if t.IsZero() {
+		return 0
+	}
+	return t.Unix()
+}
+
+func appStatusToPB(s repository.Status) pb.AppStatus {
+	switch s {
+	case repository.StatusActive:
+		return pb.AppStatus_APP_STATUS_ACTIVE
+	case repository.StatusMissing:
+		return pb.AppStatus_APP_STATUS_MISSING
+	case repository.StatusArchived:
+		return pb.AppStatus_APP_STATUS_ARCHIVED
+	default:
+		return pb.AppStatus_APP_STATUS_UNSPECIFIED
+	}
+}
+
+func appStatusFromPB(s pb.AppStatus) repository.Status {
+	switch s {
+	case pb.AppStatus_APP_STATUS_ACTIVE:
+		return repository.StatusActive
+	case pb.AppStatus_APP_STATUS_MISSING:
+		return repository.StatusMissing
+	case pb.AppStatus_APP_STATUS_ARCHIVED:
+		return repository.StatusArchived
+	default:
+		return ""
+	}
+}
+
+func artifactKindToPB(k repository.ArtifactKind) pb.ArtifactKind {
+	switch k {
+	case repository.ArtifactKindImage:
+		return pb.ArtifactKind_ARTIFACT_KIND_IMAGE
+	case repository.ArtifactKindChart:
+		return pb.ArtifactKind_ARTIFACT_KIND_CHART
+	default:
+		return pb.ArtifactKind_ARTIFACT_KIND_UNSPECIFIED
+	}
+}
+
+func artifactKindFromPB(k pb.ArtifactKind) repository.ArtifactKind {
+	switch k {
+	case pb.ArtifactKind_ARTIFACT_KIND_IMAGE:
+		return repository.ArtifactKindImage
+	case pb.ArtifactKind_ARTIFACT_KIND_CHART:
+		return repository.ArtifactKindChart
+	default:
+		return ""
+	}
+}
+
+func promotabilityToPB(p repository.Promotability) pb.Promotability {
+	switch p {
+	case repository.PromotabilityPromotable:
+		return pb.Promotability_PROMOTABILITY_PROMOTABLE
+	case repository.PromotabilityViaChart:
+		return pb.Promotability_PROMOTABILITY_VIA_CHART
+	case repository.PromotabilityNotPromotable:
+		return pb.Promotability_PROMOTABILITY_NOT_PROMOTABLE
+	default:
+		return pb.Promotability_PROMOTABILITY_UNSPECIFIED
+	}
+}
+
+func appToPB(a repository.App) *pb.App {
+	return &pb.App{
+		AppId:           a.AppID,
+		Domain:          a.Domain,
+		Name:            a.Name,
+		FullName:        a.FullName(),
+		Description:     a.Description,
+		Language:        a.Language,
+		AppType:         a.AppType,
+		DeployUnit:      a.DeployUnit,
+		BazelLabel:      a.BazelLabel,
+		ImageRepository: a.ImageRepository,
+		Status:          appStatusToPB(a.Status),
+		FirstSeenAt:     timeToUnix(a.FirstSeenAt),
+		LastSeenAt:      timeToUnix(a.LastSeenAt),
+	}
+}
+
+func appsToPB(apps []repository.App) []*pb.App {
+	out := make([]*pb.App, 0, len(apps))
+	for _, a := range apps {
+		out = append(out, appToPB(a))
+	}
+	return out
+}
+
+func chartToPB(c repository.Chart) *pb.Chart {
+	return &pb.Chart{
+		ChartId:         c.ChartID,
+		Domain:          c.Domain,
+		Name:            c.Name,
+		FullName:        c.FullName(),
+		Description:     c.Description,
+		AppIds:          c.AppIDs,
+		ChartRepository: c.ChartRepository,
+		DeployUnit:      c.DeployUnit,
+		Status:          appStatusToPB(c.Status),
+		FirstSeenAt:     timeToUnix(c.FirstSeenAt),
+		LastSeenAt:      timeToUnix(c.LastSeenAt),
+	}
+}
+
+func chartsToPB(charts []repository.Chart) []*pb.Chart {
+	out := make([]*pb.Chart, 0, len(charts))
+	for _, c := range charts {
+		out = append(out, chartToPB(c))
+	}
+	return out
+}
+
+func buildToPB(b repository.Build) *pb.Build {
+	var startedAt int64
+	if b.StartedAt != nil {
+		startedAt = timeToUnix(*b.StartedAt)
+	}
+	return &pb.Build{
+		BuildId:         b.BuildID,
+		GitSha:          b.GitSHA,
+		GitRef:          b.GitRef,
+		WorkflowRunId:   b.WorkflowRunID,
+		WorkflowAttempt: b.WorkflowAttempt,
+		Actor:           b.Actor,
+		StartedAt:       startedAt,
+		RecordedAt:      timeToUnix(b.RecordedAt),
+	}
+}
+
+func buildsToPB(builds []repository.Build) []*pb.Build {
+	out := make([]*pb.Build, 0, len(builds))
+	for _, b := range builds {
+		out = append(out, buildToPB(b))
+	}
+	return out
+}
+
+func artifactLinkToPB(l repository.ArtifactLink) *pb.ArtifactLink {
+	return &pb.ArtifactLink{
+		ArtifactId: l.ImageArtifactID,
+		AppId:      l.AppID,
+		Repository: l.Repository,
+		Version:    l.Version,
+		Digest:     l.Digest,
+	}
+}
+
+func artifactToPB(a repository.Artifact) *pb.Artifact {
+	out := &pb.Artifact{
+		ArtifactId:    a.ArtifactID,
+		Kind:          artifactKindToPB(a.Kind),
+		Repository:    a.Repository,
+		Version:       a.Version,
+		Digest:        a.Digest,
+		BuildId:       a.BuildID,
+		PublishedAt:   timeToUnix(a.PublishedAt),
+		Promotability: promotabilityToPB(a.Promotability),
+	}
+	if a.Kind == repository.ArtifactKindImage {
+		out.AppId = a.AppID
+	} else {
+		out.ChartId = a.ChartID
+	}
+	for _, l := range a.Contains {
+		out.Contains = append(out.Contains, artifactLinkToPB(l))
+	}
+	return out
+}
+
+func artifactsToPB(artifacts []repository.Artifact) []*pb.Artifact {
+	out := make([]*pb.Artifact, 0, len(artifacts))
+	for _, a := range artifacts {
+		out = append(out, artifactToPB(a))
+	}
+	return out
+}
+
+func appStatusesFromPB(statuses []pb.AppStatus) []repository.Status {
+	out := make([]repository.Status, 0, len(statuses))
+	for _, s := range statuses {
+		if v := appStatusFromPB(s); v != "" {
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
+func containedImagesFromPB(images []*pb.ContainedImage) []repository.ContainedImageInput {
+	out := make([]repository.ContainedImageInput, 0, len(images))
+	for _, ci := range images {
+		out = append(out, repository.ContainedImageInput{
+			AppFullName: ci.AppFullName,
+			Repository:  ci.Repository,
+			Version:     ci.Version,
+			Digest:      ci.Digest,
+		})
+	}
+	return out
+}

--- a/tools/app_registry/server/handlers/errors.go
+++ b/tools/app_registry/server/handlers/errors.go
@@ -1,0 +1,29 @@
+package handlers
+
+import (
+	"errors"
+
+	"github.com/whale-net/everything/tools/app_registry/server/repository"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// mapRepoErr translates a repository domain error into the matching gRPC
+// status, falling back to codes.Internal. See repository.go's error vars.
+func mapRepoErr(err error) error {
+	if err == nil {
+		return nil
+	}
+	switch {
+	case errors.Is(err, repository.ErrNotFound):
+		return status.Error(codes.NotFound, err.Error())
+	case errors.Is(err, repository.ErrAlreadyExists):
+		return status.Error(codes.AlreadyExists, err.Error())
+	case errors.Is(err, repository.ErrInvalidArgument):
+		return status.Error(codes.InvalidArgument, err.Error())
+	case errors.Is(err, repository.ErrFailedPrecondition):
+		return status.Error(codes.FailedPrecondition, err.Error())
+	default:
+		return status.Errorf(codes.Internal, "internal error: %v", err)
+	}
+}

--- a/tools/app_registry/server/handlers/idempotency.go
+++ b/tools/app_registry/server/handlers/idempotency.go
@@ -1,0 +1,55 @@
+package handlers
+
+import (
+	"context"
+
+	"github.com/whale-net/everything/tools/app_registry/server/repository"
+	"google.golang.org/protobuf/proto"
+)
+
+// runIdempotent executes fn inside a single Registry transaction (see
+// repository.Registry.WithTx), replaying a previously stored response for
+// key instead of re-executing fn when one exists. This is the mechanism
+// backing ARCHITECTURE.md "Idempotency" for every write RPC: the write and
+// the idempotency-key row commit or roll back together, so a crash between
+// them can never leave a write unrecorded or a key pointing at a stale
+// response.
+//
+// newEmpty must return a fresh zero-value instance of the RPC's response
+// message type, used to unmarshal a replayed response.
+func runIdempotent(
+	ctx context.Context,
+	reg repository.Registry,
+	key, method string,
+	newEmpty func() proto.Message,
+	fn func(ctx context.Context, r repository.Registry) (proto.Message, error),
+) (resp proto.Message, replayed bool, err error) {
+	err = reg.WithTx(ctx, func(ctx context.Context, r repository.Registry) error {
+		if raw, found, gerr := r.Idempotency().Get(ctx, key); gerr != nil {
+			return gerr
+		} else if found {
+			msg := newEmpty()
+			if uerr := proto.Unmarshal(raw, msg); uerr != nil {
+				return uerr
+			}
+			resp = msg
+			replayed = true
+			return nil
+		}
+
+		out, ferr := fn(ctx, r)
+		if ferr != nil {
+			return ferr
+		}
+		raw, merr := proto.Marshal(out)
+		if merr != nil {
+			return merr
+		}
+		if perr := r.Idempotency().Put(ctx, key, method, raw); perr != nil {
+			return perr
+		}
+		resp = out
+		return nil
+	})
+	return resp, replayed, err
+}

--- a/tools/app_registry/server/main.go
+++ b/tools/app_registry/server/main.go
@@ -1,6 +1,7 @@
-// Command app-registry-api is the App Registry's gRPC server. AR-1 wires up
-// the four services from protos/api.proto with no business logic — every RPC
-// returns codes.Unimplemented. See ../ARCHITECTURE.md and ../README.md.
+// Command app-registry-api is the App Registry's gRPC server. AppRegistry and
+// ArtifactRegistry are real as of AR-2a; PromotionRegistry and
+// EnvironmentRegistry still return codes.Unimplemented until AR-3/AR-4. See
+// ../ARCHITECTURE.md and ../README.md.
 package main
 
 import (
@@ -17,6 +18,7 @@ import (
 	"github.com/whale-net/everything/libs/go/logging"
 	pb "github.com/whale-net/everything/tools/app_registry/protos"
 	"github.com/whale-net/everything/tools/app_registry/server/handlers"
+	"github.com/whale-net/everything/tools/app_registry/server/repository"
 	"github.com/whale-net/everything/tools/app_registry/server/repository/postgres"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc"
@@ -57,7 +59,6 @@ func run() error {
 	}
 	defer pool.Close()
 	repo := postgres.NewRepository(pool)
-	_ = repo // wired into handlers starting AR-2
 	log.Println("Database connection established")
 
 	// Create auth interceptors
@@ -79,7 +80,7 @@ func run() error {
 		grpc.ChainStreamInterceptor(streamInt),
 	)
 
-	healthServer := registerServices(grpcServer)
+	healthServer := registerServices(grpcServer, repo)
 
 	// Start listening
 	listener, err := net.Listen("tcp", fmt.Sprintf(":%s", port))
@@ -116,12 +117,15 @@ func run() error {
 // and reflection services on grpcServer, and returns the health server so
 // the caller can flip it to NOT_SERVING on shutdown. Split out from run() so
 // it can be exercised directly against a bufconn listener in tests, with no
-// database or gRPC auth setup required — see main_test.go.
-func registerServices(grpcServer *grpc.Server) *health.Server {
-	// Register all four App Registry services. Every RPC returns
-	// codes.Unimplemented in AR-1 — see handlers/*.go.
-	pb.RegisterAppRegistryServer(grpcServer, handlers.NewAppServer())
-	pb.RegisterArtifactRegistryServer(grpcServer, handlers.NewArtifactServer())
+// real database or gRPC auth setup required — see main_test.go, which passes
+// a fake repository.Registry.
+func registerServices(grpcServer *grpc.Server, repo repository.Registry) *health.Server {
+	// AppRegistry and ArtifactRegistry are real as of AR-2a (AllocateVersion
+	// stays Unimplemented — that's AR-5). PromotionRegistry and
+	// EnvironmentRegistry stay Unimplemented until AR-3/AR-4 — see
+	// handlers/promotion.go, handlers/environment.go.
+	pb.RegisterAppRegistryServer(grpcServer, handlers.NewAppServer(repo))
+	pb.RegisterArtifactRegistryServer(grpcServer, handlers.NewArtifactServer(repo))
 	pb.RegisterPromotionRegistryServer(grpcServer, handlers.NewPromotionServer())
 	pb.RegisterEnvironmentRegistryServer(grpcServer, handlers.NewEnvironmentServer())
 

--- a/tools/app_registry/server/main_test.go
+++ b/tools/app_registry/server/main_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	pb "github.com/whale-net/everything/tools/app_registry/protos"
+	"github.com/whale-net/everything/tools/app_registry/server/repository/fake"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
@@ -28,7 +29,7 @@ func startTestServer(t *testing.T) *grpc.ClientConn {
 
 	lis := bufconn.Listen(bufSize)
 	grpcServer := grpc.NewServer()
-	registerServices(grpcServer)
+	registerServices(grpcServer, fake.New())
 
 	go func() {
 		// Serve returns a non-nil error on Stop()/GracefulStop() too; the
@@ -91,20 +92,43 @@ func assertUnimplementedFromHandler(t *testing.T, rpc, wantMsg string, err error
 // RPC is genuinely unimplemented" — assertUnimplementedFromHandler checks
 // the message text for exactly that reason. A dropped pb.RegisterXxxServer
 // call in main.go fails this test.
+//
+// AppRegistry and ArtifactRegistry are real as of AR-2a, so those two
+// subtests assert a real (empty-but-successful) response against the fake
+// repository instead of Unimplemented — a dropped Register call would now
+// surface as codes.Unavailable/Unimplemented-with-"unknown service" instead,
+// still caught below. PromotionRegistry and EnvironmentRegistry are still
+// Unimplemented until AR-3/AR-4.
 func TestRegisterServices_AllFourServicesReachable(t *testing.T) {
 	conn := startTestServer(t)
 	ctx := context.Background()
 
 	t.Run("AppRegistry", func(t *testing.T) {
 		client := pb.NewAppRegistryClient(conn)
-		_, err := client.ListApps(ctx, &pb.ListAppsRequest{})
-		assertUnimplementedFromHandler(t, "AppRegistry.ListApps", "ListApps not implemented", err)
+		resp, err := client.ListApps(ctx, &pb.ListAppsRequest{})
+		if err != nil {
+			t.Fatalf("AppRegistry.ListApps: expected success against the fake repository, got %v", err)
+		}
+		if len(resp.Apps) != 0 {
+			t.Fatalf("AppRegistry.ListApps: expected no apps in a fresh fake registry, got %d", len(resp.Apps))
+		}
 	})
 
 	t.Run("ArtifactRegistry", func(t *testing.T) {
 		client := pb.NewArtifactRegistryClient(conn)
-		_, err := client.ListArtifacts(ctx, &pb.ListArtifactsRequest{})
-		assertUnimplementedFromHandler(t, "ArtifactRegistry.ListArtifacts", "ListArtifacts not implemented", err)
+		resp, err := client.ListArtifacts(ctx, &pb.ListArtifactsRequest{})
+		if err != nil {
+			t.Fatalf("ArtifactRegistry.ListArtifacts: expected success against the fake repository, got %v", err)
+		}
+		if len(resp.Artifacts) != 0 {
+			t.Fatalf("ArtifactRegistry.ListArtifacts: expected no artifacts in a fresh fake registry, got %d", len(resp.Artifacts))
+		}
+	})
+
+	t.Run("ArtifactRegistry_AllocateVersion_StillUnimplemented", func(t *testing.T) {
+		client := pb.NewArtifactRegistryClient(conn)
+		_, err := client.AllocateVersion(ctx, &pb.AllocateVersionRequest{})
+		assertUnimplementedFromHandler(t, "ArtifactRegistry.AllocateVersion", "AllocateVersion not implemented", err)
 	})
 
 	t.Run("PromotionRegistry", func(t *testing.T) {

--- a/tools/app_registry/server/repository/BUILD.bazel
+++ b/tools/app_registry/server/repository/BUILD.bazel
@@ -2,7 +2,14 @@ load("@rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "repository",
-    srcs = ["repository.go"],
+    srcs = [
+        "models.go",
+        "promotability.go",
+        "repository.go",
+    ],
     importpath = "github.com/whale-net/everything/tools/app_registry/server/repository",
     visibility = ["//visibility:public"],
+    deps = [
+        "//tools/appmeta/proto:appmetapb",
+    ],
 )

--- a/tools/app_registry/server/repository/fake/BUILD.bazel
+++ b/tools/app_registry/server/repository/fake/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "fake",
+    srcs = [
+        "fake.go",
+        "reconcile.go",
+    ],
+    importpath = "github.com/whale-net/everything/tools/app_registry/server/repository/fake",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//tools/app_registry/server/repository",
+        "//tools/appmeta/proto:appmetapb",
+        "@com_github_google_uuid//:uuid",
+    ],
+)

--- a/tools/app_registry/server/repository/fake/fake.go
+++ b/tools/app_registry/server/repository/fake/fake.go
@@ -201,30 +201,24 @@ func (r *Registry) GetChartByFullName(ctx context.Context, fullName string) (*re
 	return nil, repository.ErrNotFound
 }
 
-func (r *Registry) SetAppStatus(ctx context.Context, appID string, status repository.Status, reason string) (*repository.App, error) {
+// SetAppStatus mirrors the postgres implementation: exactly one human-triage
+// transition (missing -> archived) is legal. missing -> active happens
+// automatically via Reconcile's "recovered" path, never through here.
+// archived -> archived is a no-op success so a retried archive call is safe.
+func (r *Registry) SetAppStatus(ctx context.Context, appID string, target repository.Status, reason string) (*repository.App, error) {
 	a, ok := r.state.Apps[appID]
 	if !ok {
 		return nil, repository.ErrNotFound
 	}
-	if status == repository.StatusActive && !r.presentInLatestReconcile(a) {
-		return nil, repository.ErrFailedPrecondition
+	if a.Status == repository.StatusArchived && target == repository.StatusArchived {
+		return &a, nil
 	}
-	a.Status = status
+	if a.Status != repository.StatusMissing || target != repository.StatusArchived {
+		return nil, fmt.Errorf("%w: app %s is %s; only a missing app can be archived", repository.ErrFailedPrecondition, a.FullName(), a.Status)
+	}
+	a.Status = target
 	r.state.Apps[appID] = a
 	return &a, nil
-}
-
-// presentInLatestReconcile mirrors the postgres implementation's rule:
-// an app was present in the most recent Reconcile call iff its LastSeenAt
-// equals the newest LastSeenAt across the whole app table.
-func (r *Registry) presentInLatestReconcile(a repository.App) bool {
-	var max = a.LastSeenAt
-	for _, other := range r.state.Apps {
-		if other.LastSeenAt.After(max) {
-			max = other.LastSeenAt
-		}
-	}
-	return !a.LastSeenAt.Before(max)
 }
 
 // ============================================================================

--- a/tools/app_registry/server/repository/fake/fake.go
+++ b/tools/app_registry/server/repository/fake/fake.go
@@ -1,0 +1,470 @@
+// Package fake is an in-memory implementation of repository.Registry, used
+// by handler-level logic tests (see server/handlers/*_test.go).
+//
+// There is no Postgres-backed test in this repo under Bazel: the repo has no
+// existing precedent for running a real Postgres instance inside a `bazel
+// test` sandbox (manmanv2's `*_test.go` files under repository/postgres use
+// an in-memory mock for the same reason — see server_port_test.go). Rather
+// than add a new, unproven pattern, AR-2a follows the same approach: this
+// fake exercises the business logic (reconcile diffing, promotability
+// derivation, idempotency, chart/image validation) that handlers.go and
+// postgres/*.go must agree on, while postgres/*.go itself is exercised only
+// by `bazel build` (compiles against the same interfaces) — its SQL is not
+// covered by an automated test in this change. See the AR-2a report for the
+// explicit CI-vs-manual breakdown.
+package fake
+
+import (
+	"context"
+	"encoding/json"
+	"sort"
+	"sync"
+
+	"github.com/google/uuid"
+	"github.com/whale-net/everything/tools/app_registry/server/repository"
+	appmetapb "github.com/whale-net/everything/tools/appmeta/proto"
+)
+
+type idemEntry struct {
+	Method   string
+	Response []byte
+}
+
+// state is everything WithTx snapshots/restores. Kept as a separate struct
+// (rather than fields directly on Registry) so it round-trips through JSON
+// cleanly for a cheap deep copy.
+type state struct {
+	Apps        map[string]repository.App
+	Charts      map[string]repository.Chart
+	Builds      map[string]repository.Build
+	Artifacts   map[string]repository.Artifact
+	Idempotency map[string]idemEntry
+}
+
+func newState() *state {
+	return &state{
+		Apps:        map[string]repository.App{},
+		Charts:      map[string]repository.Chart{},
+		Builds:      map[string]repository.Build{},
+		Artifacts:   map[string]repository.Artifact{},
+		Idempotency: map[string]idemEntry{},
+	}
+}
+
+func (s *state) clone() *state {
+	// Deep copy via JSON round-trip: simple and correct for a test fake
+	// whose fields are all JSON-marshalable (structs, maps, slices, time.Time).
+	raw, err := json.Marshal(s)
+	if err != nil {
+		panic("fake: state failed to marshal: " + err.Error())
+	}
+	out := newState()
+	if err := json.Unmarshal(raw, out); err != nil {
+		panic("fake: state failed to unmarshal: " + err.Error())
+	}
+	return out
+}
+
+// Registry is the in-memory repository.Registry implementation.
+type Registry struct {
+	mu    *sync.Mutex
+	state *state
+}
+
+// New constructs an empty fake Registry.
+func New() *Registry {
+	return &Registry{mu: &sync.Mutex{}, state: newState()}
+}
+
+func (r *Registry) Apps() repository.AppRepository                { return r }
+func (r *Registry) Builds() repository.BuildRepository            { return r }
+func (r *Registry) Artifacts() repository.ArtifactRepository      { return r }
+func (r *Registry) Idempotency() repository.IdempotencyRepository { return r }
+
+// WithTx snapshots state, runs fn against a Registry sharing that snapshot,
+// and commits the snapshot back only if fn succeeds — giving the fake the
+// same all-or-nothing semantics a Postgres transaction provides.
+func (r *Registry) WithTx(ctx context.Context, fn func(ctx context.Context, reg repository.Registry) error) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	txState := r.state.clone()
+	tx := &Registry{mu: r.mu, state: txState}
+	// fn must not re-lock r.mu; tx shares the outer lock so this is safe as
+	// long as fn only calls methods on the Registry it was given.
+	if err := fn(ctx, txHandle{tx}); err != nil {
+		return err
+	}
+	r.state = txState
+	return nil
+}
+
+// txHandle exists only so WithTx doesn't recursively re-enter r.mu.Lock()
+// via a nested Registry.WithTx call from inside fn — none of the current
+// handlers nest transactions, but this keeps the invariant explicit rather
+// than relying on callers never doing so.
+type txHandle struct{ *Registry }
+
+func (h txHandle) WithTx(ctx context.Context, fn func(ctx context.Context, reg repository.Registry) error) error {
+	return fn(ctx, h)
+}
+
+// ============================================================================
+// AppRepository
+// ============================================================================
+
+func (r *Registry) Reconcile(ctx context.Context, apps []*appmetapb.AppManifest, charts []*appmetapb.ChartManifest, dryRun bool) (*repository.ReconcileResult, error) {
+	return reconcile(r.state, apps, charts, dryRun)
+}
+
+func (r *Registry) ListApps(ctx context.Context, filter repository.AppListFilter) ([]repository.App, error) {
+	statuses := defaultAppStatuses(filter.Statuses)
+	var out []repository.App
+	for _, a := range r.state.Apps {
+		if filter.Domain != "" && a.Domain != filter.Domain {
+			continue
+		}
+		if filter.DeployUnit != appmetapb.DeployUnit_DEPLOY_UNIT_UNSPECIFIED && a.DeployUnit != filter.DeployUnit {
+			continue
+		}
+		if !containsStatus(statuses, a.Status) {
+			continue
+		}
+		out = append(out, a)
+	}
+	sortApps(out)
+	return out, nil
+}
+
+func (r *Registry) GetAppByID(ctx context.Context, appID string) (*repository.App, error) {
+	a, ok := r.state.Apps[appID]
+	if !ok {
+		return nil, repository.ErrNotFound
+	}
+	return &a, nil
+}
+
+func (r *Registry) GetAppByFullName(ctx context.Context, fullName string) (*repository.App, error) {
+	for _, a := range r.state.Apps {
+		if a.FullName() == fullName {
+			return &a, nil
+		}
+	}
+	return nil, repository.ErrNotFound
+}
+
+func (r *Registry) ChartsForApp(ctx context.Context, appID string) ([]repository.Chart, error) {
+	var out []repository.Chart
+	for _, c := range r.state.Charts {
+		for _, id := range c.AppIDs {
+			if id == appID {
+				out = append(out, c)
+				break
+			}
+		}
+	}
+	sortCharts(out)
+	return out, nil
+}
+
+func (r *Registry) ListCharts(ctx context.Context, filter repository.ChartListFilter) ([]repository.Chart, error) {
+	statuses := defaultAppStatuses(filter.Statuses)
+	var out []repository.Chart
+	for _, c := range r.state.Charts {
+		if filter.Domain != "" && c.Domain != filter.Domain {
+			continue
+		}
+		if !containsStatus(statuses, c.Status) {
+			continue
+		}
+		out = append(out, c)
+	}
+	sortCharts(out)
+	return out, nil
+}
+
+func (r *Registry) GetChartByID(ctx context.Context, chartID string) (*repository.Chart, error) {
+	c, ok := r.state.Charts[chartID]
+	if !ok {
+		return nil, repository.ErrNotFound
+	}
+	return &c, nil
+}
+
+func (r *Registry) GetChartByFullName(ctx context.Context, fullName string) (*repository.Chart, error) {
+	for _, c := range r.state.Charts {
+		if c.FullName() == fullName {
+			return &c, nil
+		}
+	}
+	return nil, repository.ErrNotFound
+}
+
+func (r *Registry) SetAppStatus(ctx context.Context, appID string, status repository.Status, reason string) (*repository.App, error) {
+	a, ok := r.state.Apps[appID]
+	if !ok {
+		return nil, repository.ErrNotFound
+	}
+	if status == repository.StatusActive && !r.presentInLatestReconcile(a) {
+		return nil, repository.ErrFailedPrecondition
+	}
+	a.Status = status
+	r.state.Apps[appID] = a
+	return &a, nil
+}
+
+// presentInLatestReconcile mirrors the postgres implementation's rule:
+// an app was present in the most recent Reconcile call iff its LastSeenAt
+// equals the newest LastSeenAt across the whole app table.
+func (r *Registry) presentInLatestReconcile(a repository.App) bool {
+	var max = a.LastSeenAt
+	for _, other := range r.state.Apps {
+		if other.LastSeenAt.After(max) {
+			max = other.LastSeenAt
+		}
+	}
+	return !a.LastSeenAt.Before(max)
+}
+
+// ============================================================================
+// BuildRepository
+// ============================================================================
+
+func (r *Registry) RecordBuild(ctx context.Context, b repository.Build) (*repository.Build, bool, error) {
+	for _, existing := range r.state.Builds {
+		if existing.WorkflowRunID == b.WorkflowRunID && existing.WorkflowAttempt == b.WorkflowAttempt {
+			return &existing, true, nil
+		}
+	}
+	b.BuildID = uuid.NewString()
+	r.state.Builds[b.BuildID] = b
+	return &b, false, nil
+}
+
+func (r *Registry) GetBuild(ctx context.Context, buildID string) (*repository.Build, error) {
+	b, ok := r.state.Builds[buildID]
+	if !ok {
+		return nil, repository.ErrNotFound
+	}
+	return &b, nil
+}
+
+// ============================================================================
+// ArtifactRepository
+// ============================================================================
+
+func (r *Registry) RecordArtifact(ctx context.Context, a repository.Artifact, contains []repository.ContainedImageInput) (*repository.Artifact, bool, error) {
+	for _, existing := range r.state.Artifacts {
+		if existing.Digest == a.Digest {
+			out := existing
+			out.Promotability = r.derivePromotability(existing)
+			return &out, true, nil
+		}
+	}
+	a.ArtifactID = uuid.NewString()
+
+	if a.Kind == repository.ArtifactKindChart {
+		links := make([]repository.ArtifactLink, 0, len(contains))
+		for _, ci := range contains {
+			img, err := r.findImageByDigest(ci.Digest)
+			if err != nil {
+				return nil, false, err
+			}
+			links = append(links, repository.ArtifactLink{
+				ImageArtifactID: img.ArtifactID,
+				AppID:           img.AppID,
+				Repository:      ci.Repository,
+				Version:         ci.Version,
+				Digest:          ci.Digest,
+			})
+		}
+		a.Contains = links
+	}
+
+	r.state.Artifacts[a.ArtifactID] = a
+	out := a
+	out.Promotability = r.derivePromotability(a)
+	return &out, false, nil
+}
+
+func (r *Registry) findImageByDigest(digest string) (*repository.Artifact, error) {
+	for _, a := range r.state.Artifacts {
+		if a.Digest == digest && a.Kind == repository.ArtifactKindImage {
+			return &a, nil
+		}
+	}
+	return nil, repository.ErrInvalidArgument
+}
+
+func (r *Registry) ListArtifacts(ctx context.Context, filter repository.ArtifactListFilter) ([]repository.Artifact, error) {
+	var out []repository.Artifact
+	for _, a := range r.state.Artifacts {
+		if filter.Kind != "" && a.Kind != filter.Kind {
+			continue
+		}
+		if filter.OwnerFullName != "" {
+			owner := r.ownerFullName(a)
+			if owner != filter.OwnerFullName {
+				continue
+			}
+		}
+		a.Promotability = r.derivePromotability(a)
+		if filter.PromotableOnly && a.Promotability != repository.PromotabilityPromotable {
+			continue
+		}
+		out = append(out, a)
+	}
+	sortArtifacts(out)
+	return out, nil
+}
+
+func (r *Registry) GetArtifact(ctx context.Context, lookup repository.ArtifactLookup) (*repository.Artifact, error) {
+	a, err := r.findArtifact(lookup)
+	if err != nil {
+		return nil, err
+	}
+	cp := *a
+	cp.Promotability = r.derivePromotability(cp)
+	return &cp, nil
+}
+
+func (r *Registry) findArtifact(lookup repository.ArtifactLookup) (*repository.Artifact, error) {
+	if lookup.ArtifactID != "" {
+		a, ok := r.state.Artifacts[lookup.ArtifactID]
+		if !ok {
+			return nil, repository.ErrNotFound
+		}
+		return &a, nil
+	}
+	if lookup.Digest != "" {
+		for _, a := range r.state.Artifacts {
+			if a.Digest == lookup.Digest {
+				return &a, nil
+			}
+		}
+		return nil, repository.ErrNotFound
+	}
+	if lookup.OwnerFullName != "" {
+		for _, a := range r.state.Artifacts {
+			if a.Kind == lookup.Kind && a.Version == lookup.Version && r.ownerFullName(a) == lookup.OwnerFullName {
+				return &a, nil
+			}
+		}
+		return nil, repository.ErrNotFound
+	}
+	return nil, repository.ErrInvalidArgument
+}
+
+func (r *Registry) ResolveArtifact(ctx context.Context, lookup repository.ArtifactLookup) (*repository.Artifact, []repository.Artifact, []repository.Build, error) {
+	a, err := r.findArtifact(lookup)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if a.Kind != repository.ArtifactKindChart {
+		return nil, nil, nil, repository.ErrInvalidArgument
+	}
+	cp := *a
+	cp.Promotability = r.derivePromotability(cp)
+
+	var images []repository.Artifact
+	var builds []repository.Build
+	for _, link := range a.Contains {
+		img, ok := r.state.Artifacts[link.ImageArtifactID]
+		if !ok {
+			continue
+		}
+		img.Promotability = r.derivePromotability(img)
+		images = append(images, img)
+		if b, ok := r.state.Builds[img.BuildID]; ok {
+			builds = append(builds, b)
+		}
+	}
+	return &cp, images, builds, nil
+}
+
+func (r *Registry) ownerFullName(a repository.Artifact) string {
+	if a.Kind == repository.ArtifactKindImage {
+		if app, ok := r.state.Apps[a.AppID]; ok {
+			return app.FullName()
+		}
+	} else {
+		if c, ok := r.state.Charts[a.ChartID]; ok {
+			return c.FullName()
+		}
+	}
+	return ""
+}
+
+// derivePromotability implements ARCHITECTURE.md "Promotability" via the
+// shared repository.DerivePromotability rule.
+func (r *Registry) derivePromotability(a repository.Artifact) repository.Promotability {
+	var du appmetapb.DeployUnit
+	if a.Kind == repository.ArtifactKindImage {
+		app, ok := r.state.Apps[a.AppID]
+		if !ok {
+			return repository.PromotabilityNotPromotable
+		}
+		du = app.DeployUnit
+	} else {
+		c, ok := r.state.Charts[a.ChartID]
+		if !ok {
+			return repository.PromotabilityNotPromotable
+		}
+		du = c.DeployUnit
+	}
+	return repository.DerivePromotability(a.Kind, du)
+}
+
+// ============================================================================
+// IdempotencyRepository
+// ============================================================================
+
+func (r *Registry) Get(ctx context.Context, key string) ([]byte, bool, error) {
+	e, ok := r.state.Idempotency[key]
+	if !ok {
+		return nil, false, nil
+	}
+	return e.Response, true, nil
+}
+
+func (r *Registry) Put(ctx context.Context, key, method string, response []byte) error {
+	r.state.Idempotency[key] = idemEntry{Method: method, Response: response}
+	return nil
+}
+
+// ============================================================================
+// helpers shared with reconcile.go
+// ============================================================================
+
+func defaultAppStatuses(statuses []repository.Status) []repository.Status {
+	if len(statuses) == 0 {
+		return []repository.Status{repository.StatusActive, repository.StatusMissing}
+	}
+	return statuses
+}
+
+func containsStatus(statuses []repository.Status, s repository.Status) bool {
+	for _, st := range statuses {
+		if st == s {
+			return true
+		}
+	}
+	return false
+}
+
+func sortApps(apps []repository.App) {
+	sort.Slice(apps, func(i, j int) bool { return apps[i].FullName() < apps[j].FullName() })
+}
+
+func sortCharts(charts []repository.Chart) {
+	sort.Slice(charts, func(i, j int) bool { return charts[i].FullName() < charts[j].FullName() })
+}
+
+func sortArtifacts(artifacts []repository.Artifact) {
+	sort.Slice(artifacts, func(i, j int) bool {
+		if artifacts[i].PublishedAt.Equal(artifacts[j].PublishedAt) {
+			return artifacts[i].Digest < artifacts[j].Digest
+		}
+		return artifacts[i].PublishedAt.Before(artifacts[j].PublishedAt)
+	})
+}

--- a/tools/app_registry/server/repository/fake/fake.go
+++ b/tools/app_registry/server/repository/fake/fake.go
@@ -17,6 +17,7 @@ package fake
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"sort"
 	"sync"
 
@@ -261,6 +262,16 @@ func (r *Registry) RecordArtifact(ctx context.Context, a repository.Artifact, co
 			return &out, true, nil
 		}
 	}
+
+	// Mirrors postgres's UNIQUE INDEX artifact_version_idx (owner_id, kind,
+	// version): a fresh digest for an (owner, kind, version) already claimed
+	// by a different artifact is a conflict, not a new row. This is the
+	// AR-5 "someone else took this version" path — see
+	// repository/postgres/errors.go's doc comment.
+	if existing, found := r.findByOwnerKindVersion(a); found {
+		return nil, false, fmt.Errorf("%w: artifact %s %s already recorded", repository.ErrAlreadyExists, r.ownerFullName(existing), existing.Version)
+	}
+
 	a.ArtifactID = uuid.NewString()
 
 	if a.Kind == repository.ArtifactKindChart {
@@ -285,6 +296,26 @@ func (r *Registry) RecordArtifact(ctx context.Context, a repository.Artifact, co
 	out := a
 	out.Promotability = r.derivePromotability(a)
 	return &out, false, nil
+}
+
+// findByOwnerKindVersion looks up an existing artifact sharing a's owner
+// (AppID for images, ChartID for charts), kind, and version — the collision
+// the real artifact_version_idx unique index enforces.
+func (r *Registry) findByOwnerKindVersion(a repository.Artifact) (repository.Artifact, bool) {
+	owner := ownerID(a)
+	for _, existing := range r.state.Artifacts {
+		if existing.Kind == a.Kind && existing.Version == a.Version && ownerID(existing) == owner {
+			return existing, true
+		}
+	}
+	return repository.Artifact{}, false
+}
+
+func ownerID(a repository.Artifact) string {
+	if a.Kind == repository.ArtifactKindImage {
+		return a.AppID
+	}
+	return a.ChartID
 }
 
 func (r *Registry) findImageByDigest(digest string) (*repository.Artifact, error) {

--- a/tools/app_registry/server/repository/fake/reconcile.go
+++ b/tools/app_registry/server/repository/fake/reconcile.go
@@ -1,0 +1,196 @@
+package fake
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/whale-net/everything/tools/app_registry/server/repository"
+	appmetapb "github.com/whale-net/everything/tools/appmeta/proto"
+)
+
+// reconcile implements the FULL replace described in ARCHITECTURE.md and
+// AGENTS-2a.md's ReconcileApps scope. It is shared logic the postgres
+// implementation mirrors in SQL — see postgres/app.go's Reconcile for the
+// same state machine expressed as UPDATE/INSERT statements.
+func reconcile(s *state, apps []*appmetapb.AppManifest, charts []*appmetapb.ChartManifest, dryRun bool) (*repository.ReconcileResult, error) {
+	workState := s
+	if dryRun {
+		workState = s.clone()
+	}
+
+	now := time.Now().UTC()
+	result := &repository.ReconcileResult{}
+
+	presentAppIDs := map[string]bool{}
+	for _, am := range apps {
+		id, existing, found := findAppByDomainName(workState, am.Domain, am.Name)
+		if !found {
+			id = uuid.NewString()
+			newApp := repository.App{
+				AppID:           id,
+				Domain:          am.Domain,
+				Name:            am.Name,
+				Description:     am.Description,
+				Language:        am.Language,
+				AppType:         am.AppType,
+				DeployUnit:      normalizeDeployUnit(am.DeployUnit),
+				BazelLabel:      am.BinaryTarget,
+				ImageRepository: imageRepository(am),
+				Status:          repository.StatusActive,
+				FirstSeenAt:     now,
+				LastSeenAt:      now,
+			}
+			workState.Apps[id] = newApp
+			presentAppIDs[id] = true
+			result.CreatedApps = append(result.CreatedApps, newApp)
+			continue
+		}
+
+		wasMissing := existing.Status == repository.StatusMissing
+		updated := existing
+		updated.Description = am.Description
+		updated.Language = am.Language
+		updated.AppType = am.AppType
+		updated.DeployUnit = normalizeDeployUnit(am.DeployUnit)
+		updated.BazelLabel = am.BinaryTarget
+		updated.ImageRepository = imageRepository(am)
+		updated.Status = repository.StatusActive
+		updated.LastSeenAt = now
+		workState.Apps[id] = updated
+		presentAppIDs[id] = true
+
+		if wasMissing {
+			result.RecoveredApps = append(result.RecoveredApps, updated)
+		} else {
+			result.UpdatedApps = append(result.UpdatedApps, updated)
+		}
+	}
+
+	for id, a := range workState.Apps {
+		if presentAppIDs[id] {
+			continue
+		}
+		if a.Status == repository.StatusActive {
+			a.Status = repository.StatusMissing
+			workState.Apps[id] = a
+			result.NewlyMissingApps = append(result.NewlyMissingApps, a)
+		}
+		// Already-missing and archived rows are left untouched.
+	}
+
+	presentChartIDs := map[string]bool{}
+	for _, cm := range charts {
+		appIDs, err := resolveChartApps(workState, cm)
+		if err != nil {
+			return nil, err
+		}
+
+		id, existing, found := findChartByDomainName(workState, cm.Domain, cm.Name)
+		if !found {
+			id = uuid.NewString()
+			newChart := repository.Chart{
+				ChartID:     id,
+				Domain:      cm.Domain,
+				Name:        cm.Name,
+				DeployUnit:  appmetapb.DeployUnit_DEPLOY_UNIT_CHART,
+				Status:      repository.StatusActive,
+				AppIDs:      appIDs,
+				FirstSeenAt: now,
+				LastSeenAt:  now,
+			}
+			workState.Charts[id] = newChart
+			presentChartIDs[id] = true
+			result.CreatedCharts = append(result.CreatedCharts, newChart)
+			continue
+		}
+
+		wasMissing := existing.Status == repository.StatusMissing
+		updated := existing
+		updated.AppIDs = appIDs
+		updated.Status = repository.StatusActive
+		updated.LastSeenAt = now
+		workState.Charts[id] = updated
+		presentChartIDs[id] = true
+
+		if wasMissing {
+			result.RecoveredCharts = append(result.RecoveredCharts, updated)
+		} else {
+			result.UpdatedCharts = append(result.UpdatedCharts, updated)
+		}
+	}
+
+	for id, c := range workState.Charts {
+		if presentChartIDs[id] {
+			continue
+		}
+		if c.Status == repository.StatusActive {
+			c.Status = repository.StatusMissing
+			workState.Charts[id] = c
+			result.NewlyMissingCharts = append(result.NewlyMissingCharts, c)
+		}
+	}
+
+	return result, nil
+}
+
+func findAppByDomainName(s *state, domain, name string) (string, repository.App, bool) {
+	for id, a := range s.Apps {
+		if a.Domain == domain && a.Name == name {
+			return id, a, true
+		}
+	}
+	return "", repository.App{}, false
+}
+
+func findChartByDomainName(s *state, domain, name string) (string, repository.Chart, bool) {
+	for id, c := range s.Charts {
+		if c.Domain == domain && c.Name == name {
+			return id, c, true
+		}
+	}
+	return "", repository.Chart{}, false
+}
+
+// resolveChartApps resolves ChartManifest.apps (bare app names) to app_ids,
+// per ARCHITECTURE.md/PLAN.md: "fail the reconcile if any is unknown."
+// Same-domain matches are preferred; a cross-domain match is accepted only
+// if it is unique.
+func resolveChartApps(s *state, cm *appmetapb.ChartManifest) ([]string, error) {
+	ids := make([]string, 0, len(cm.Apps))
+	for _, name := range cm.Apps {
+		if id, _, ok := findAppByDomainName(s, cm.Domain, name); ok {
+			ids = append(ids, id)
+			continue
+		}
+		var matches []string
+		for id, a := range s.Apps {
+			if a.Name == name {
+				matches = append(matches, id)
+			}
+		}
+		switch len(matches) {
+		case 0:
+			return nil, fmt.Errorf("%w: chart %s/%s references unknown app %q", repository.ErrInvalidArgument, cm.Domain, cm.Name, name)
+		case 1:
+			ids = append(ids, matches[0])
+		default:
+			return nil, fmt.Errorf("%w: chart %s/%s app name %q is ambiguous across domains", repository.ErrInvalidArgument, cm.Domain, cm.Name, name)
+		}
+	}
+	return ids, nil
+}
+
+func normalizeDeployUnit(du appmetapb.DeployUnit) appmetapb.DeployUnit {
+	if du == appmetapb.DeployUnit_DEPLOY_UNIT_UNSPECIFIED {
+		return appmetapb.DeployUnit_DEPLOY_UNIT_CHART
+	}
+	return du
+}
+
+func imageRepository(am *appmetapb.AppManifest) string {
+	if am.Registry == "" && am.Organization == "" && am.RepoName == "" {
+		return ""
+	}
+	return am.Registry + "/" + am.Organization + "/" + am.RepoName
+}

--- a/tools/app_registry/server/repository/models.go
+++ b/tools/app_registry/server/repository/models.go
@@ -1,0 +1,162 @@
+package repository
+
+import (
+	"time"
+
+	appmetapb "github.com/whale-net/everything/tools/appmeta/proto"
+)
+
+// Status is the shared reconciliation lifecycle for App and Chart rows. See
+// ARCHITECTURE.md "Data model" and AppStatus in protos/messages.proto.
+type Status string
+
+const (
+	StatusActive   Status = "active"
+	StatusMissing  Status = "missing"
+	StatusArchived Status = "archived"
+)
+
+// ArtifactKind mirrors ArtifactKind in protos/messages.proto.
+type ArtifactKind string
+
+const (
+	ArtifactKindImage ArtifactKind = "image"
+	ArtifactKindChart ArtifactKind = "chart"
+)
+
+// Promotability mirrors Promotability in protos/messages.proto. Always
+// derived server-side from the owning app's/chart's DeployUnit — never
+// stored. See ARCHITECTURE.md "Promotability".
+type Promotability string
+
+const (
+	PromotabilityPromotable    Promotability = "promotable"
+	PromotabilityViaChart      Promotability = "via_chart"
+	PromotabilityNotPromotable Promotability = "not_promotable"
+)
+
+// App mirrors one release_app manifest. Never hard-deleted.
+type App struct {
+	AppID           string
+	Domain          string
+	Name            string
+	Description     string
+	Language        string
+	AppType         string
+	DeployUnit      appmetapb.DeployUnit
+	BazelLabel      string
+	ImageRepository string
+	Status          Status
+	FirstSeenAt     time.Time
+	LastSeenAt      time.Time
+}
+
+func (a App) FullName() string { return a.Domain + "-" + a.Name }
+
+// Chart is a Helm chart composing one or more apps.
+type Chart struct {
+	ChartID         string
+	Domain          string
+	Name            string
+	Description     string
+	ChartRepository string
+	DeployUnit      appmetapb.DeployUnit
+	Status          Status
+	AppIDs          []string
+	FirstSeenAt     time.Time
+	LastSeenAt      time.Time
+}
+
+func (c Chart) FullName() string { return c.Domain + "-" + c.Name }
+
+// ReconcileResult buckets every App/Chart row touched by one ReconcileApps
+// call, matching ReconcileAppsResponse in protos/api_messages_app.proto.
+type ReconcileResult struct {
+	CreatedApps        []App
+	UpdatedApps        []App
+	NewlyMissingApps   []App
+	RecoveredApps      []App
+	CreatedCharts      []Chart
+	UpdatedCharts      []Chart
+	NewlyMissingCharts []Chart
+	RecoveredCharts    []Chart
+}
+
+// AppListFilter is ListAppsRequest's filter set, decoupled from the proto.
+type AppListFilter struct {
+	Domain     string
+	Statuses   []Status // empty means [Active, Missing], the RPC default
+	DeployUnit appmetapb.DeployUnit
+}
+
+// ChartListFilter is ListChartsRequest's filter set.
+type ChartListFilter struct {
+	Domain   string
+	Statuses []Status
+}
+
+// Build is one CI run. Every artifact hangs off a build.
+type Build struct {
+	BuildID         string
+	GitSHA          string
+	GitRef          string
+	WorkflowRunID   string
+	WorkflowAttempt int32
+	Actor           string
+	StartedAt       *time.Time
+	RecordedAt      time.Time
+}
+
+// ArtifactLink records that a chart artifact pins a specific image digest.
+type ArtifactLink struct {
+	ImageArtifactID string
+	AppID           string
+	Repository      string
+	Version         string
+	Digest          string
+}
+
+// Artifact is a published, digest-addressable image or chart.
+type Artifact struct {
+	ArtifactID  string
+	Kind        ArtifactKind
+	AppID       string // set when Kind == ArtifactKindImage
+	ChartID     string // set when Kind == ArtifactKindChart
+	Repository  string
+	Version     string
+	Digest      string
+	BuildID     string
+	PublishedAt time.Time
+
+	// Promotability is DERIVED — computed at read time from the owner's
+	// DeployUnit, never persisted. Populated by repository read methods.
+	Promotability Promotability
+
+	// Contains is populated only for Kind == ArtifactKindChart.
+	Contains []ArtifactLink
+}
+
+// ContainedImageInput is one image a chart pins, as resolved by tools/helm.
+type ContainedImageInput struct {
+	AppFullName string
+	Repository  string
+	Version     string
+	Digest      string
+}
+
+// ArtifactListFilter is ListArtifactsRequest's filter set.
+type ArtifactListFilter struct {
+	OwnerFullName  string
+	Kind           ArtifactKind
+	PromotableOnly bool
+}
+
+// ArtifactLookup identifies an artifact by exactly one of the supported
+// keys, matching GetArtifactRequest's oneof-by-convention shape.
+type ArtifactLookup struct {
+	ArtifactID    string
+	Digest        string
+	OwnerFullName string
+	Kind          ArtifactKind
+	Version       string
+}

--- a/tools/app_registry/server/repository/postgres/BUILD.bazel
+++ b/tools/app_registry/server/repository/postgres/BUILD.bazel
@@ -2,11 +2,20 @@ load("@rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "postgres",
-    srcs = ["repository.go"],
+    srcs = [
+        "app.go",
+        "artifact.go",
+        "idempotency.go",
+        "repository.go",
+    ],
     importpath = "github.com/whale-net/everything/tools/app_registry/server/repository/postgres",
     visibility = ["//visibility:public"],
     deps = [
         "//tools/app_registry/server/repository",
+        "//tools/appmeta/proto:appmetapb",
+        "@com_github_google_uuid//:uuid",
+        "@com_github_jackc_pgx_v5//:pgx",
+        "@com_github_jackc_pgx_v5//pgconn",
         "@com_github_jackc_pgx_v5//pgxpool",
     ],
 )

--- a/tools/app_registry/server/repository/postgres/BUILD.bazel
+++ b/tools/app_registry/server/repository/postgres/BUILD.bazel
@@ -1,10 +1,11 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "postgres",
     srcs = [
         "app.go",
         "artifact.go",
+        "errors.go",
         "idempotency.go",
         "repository.go",
     ],
@@ -17,5 +18,15 @@ go_library(
         "@com_github_jackc_pgx_v5//:pgx",
         "@com_github_jackc_pgx_v5//pgconn",
         "@com_github_jackc_pgx_v5//pgxpool",
+    ],
+)
+
+go_test(
+    name = "postgres_test",
+    srcs = ["errors_test.go"],
+    embed = [":postgres"],
+    deps = [
+        "//tools/app_registry/server/repository",
+        "@com_github_jackc_pgx_v5//pgconn",
     ],
 )

--- a/tools/app_registry/server/repository/postgres/app.go
+++ b/tools/app_registry/server/repository/postgres/app.go
@@ -533,15 +533,12 @@ func (r *appRepo) GetChartByFullName(ctx context.Context, fullName string) (*rep
 // SetAppStatus
 // ============================================================================
 
-func (r *appRepo) SetAppStatus(ctx context.Context, appID string, status repository.Status, reason string) (*repository.App, error) {
-	row := r.ex.QueryRow(ctx, `
-		SELECT `+appColumns+`, (SELECT MAX(last_seen_at) FROM app) AS max_last_seen
-		FROM app WHERE app_id = $1`, appID)
+func (r *appRepo) SetAppStatus(ctx context.Context, appID string, target repository.Status, reason string) (*repository.App, error) {
+	row := r.ex.QueryRow(ctx, `SELECT `+appColumns+` FROM app WHERE app_id = $1`, appID)
 
 	var a repository.App
 	var deployUnit, dbStatus string
-	var maxLastSeen time.Time
-	if err := row.Scan(&a.AppID, &a.Domain, &a.Name, &a.Description, &a.Language, &a.AppType, &deployUnit, &a.BazelLabel, &a.ImageRepository, &dbStatus, &a.FirstSeenAt, &a.LastSeenAt, &maxLastSeen); err != nil {
+	if err := row.Scan(&a.AppID, &a.Domain, &a.Name, &a.Description, &a.Language, &a.AppType, &deployUnit, &a.BazelLabel, &a.ImageRepository, &dbStatus, &a.FirstSeenAt, &a.LastSeenAt); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, repository.ErrNotFound
 		}
@@ -550,17 +547,21 @@ func (r *appRepo) SetAppStatus(ctx context.Context, appID string, status reposit
 	a.DeployUnit = deployUnitFromDB(deployUnit)
 	a.Status = repository.Status(dbStatus)
 
-	// "present in the most recent reconcile" is derived, not stored: an app
-	// was touched by the latest Reconcile call iff its last_seen_at equals
-	// the table-wide max (every app present in one reconcile shares the same
-	// last_seen_at, set from a single now := time.Now() in Reconcile).
-	if status == repository.StatusActive && a.LastSeenAt.Before(maxLastSeen) {
-		return nil, repository.ErrFailedPrecondition
+	// SetAppStatus supports exactly one human-triage transition: missing ->
+	// archived. missing -> active happens automatically via Reconcile's
+	// "recovered" path (see ARCHITECTURE.md "Triage"), so it is never legal
+	// here. archived -> archived is a no-op success so a retried archive
+	// call is safe.
+	if a.Status == repository.StatusArchived && target == repository.StatusArchived {
+		return &a, nil
+	}
+	if a.Status != repository.StatusMissing || target != repository.StatusArchived {
+		return nil, fmt.Errorf("%w: app %s is %s; only a missing app can be archived", repository.ErrFailedPrecondition, a.FullName(), a.Status)
 	}
 
-	if _, err := r.ex.Exec(ctx, `UPDATE app SET status = $2 WHERE app_id = $1`, appID, string(status)); err != nil {
+	if _, err := r.ex.Exec(ctx, `UPDATE app SET status = $2 WHERE app_id = $1`, appID, string(target)); err != nil {
 		return nil, err
 	}
-	a.Status = status
+	a.Status = target
 	return &a, nil
 }

--- a/tools/app_registry/server/repository/postgres/app.go
+++ b/tools/app_registry/server/repository/postgres/app.go
@@ -90,6 +90,9 @@ func (r *appRepo) Reconcile(ctx context.Context, apps []*appmetapb.AppManifest, 
 					VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, 'active', $10, $10)`,
 					appID, am.Domain, am.Name, am.Description, am.Language, am.AppType, deployUnitToDB(am.DeployUnit), am.BinaryTarget, imageRepository(am), now)
 				if err != nil {
+					if de, ok := translatePgError(err, fmt.Sprintf("app %s-%s already recorded", am.Domain, am.Name)); ok {
+						return nil, de
+					}
 					return nil, fmt.Errorf("reconcile: insert app %s/%s: %w", am.Domain, am.Name, err)
 				}
 			}
@@ -186,6 +189,9 @@ func (r *appRepo) Reconcile(ctx context.Context, apps []*appmetapb.AppManifest, 
 					INSERT INTO chart (chart_id, domain, name, deploy_unit, status, first_seen_at, last_seen_at)
 					VALUES ($1, $2, $3, 'chart', 'active', $4, $4)`,
 					chartID, cm.Domain, cm.Name, now); err != nil {
+					if de, ok := translatePgError(err, fmt.Sprintf("chart %s-%s already recorded", cm.Domain, cm.Name)); ok {
+						return nil, de
+					}
 					return nil, fmt.Errorf("reconcile: insert chart %s/%s: %w", cm.Domain, cm.Name, err)
 				}
 				if err := r.setChartApps(ctx, chartID, appIDs); err != nil {

--- a/tools/app_registry/server/repository/postgres/app.go
+++ b/tools/app_registry/server/repository/postgres/app.go
@@ -1,0 +1,560 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/whale-net/everything/tools/app_registry/server/repository"
+	appmetapb "github.com/whale-net/everything/tools/appmeta/proto"
+)
+
+type appRepo struct{ ex dbtx }
+
+const appColumns = `app_id, domain, name, description, language, app_type, deploy_unit, bazel_label, image_repository, status, first_seen_at, last_seen_at`
+
+func scanApp(row pgx.Row) (repository.App, error) {
+	var a repository.App
+	var deployUnit, status string
+	if err := row.Scan(&a.AppID, &a.Domain, &a.Name, &a.Description, &a.Language, &a.AppType, &deployUnit, &a.BazelLabel, &a.ImageRepository, &status, &a.FirstSeenAt, &a.LastSeenAt); err != nil {
+		return repository.App{}, err
+	}
+	a.DeployUnit = deployUnitFromDB(deployUnit)
+	a.Status = repository.Status(status)
+	return a, nil
+}
+
+const chartColumns = `chart_id, domain, name, description, chart_repository, deploy_unit, status, first_seen_at, last_seen_at`
+
+func scanChart(row pgx.Row) (repository.Chart, error) {
+	var c repository.Chart
+	var deployUnit, status string
+	if err := row.Scan(&c.ChartID, &c.Domain, &c.Name, &c.Description, &c.ChartRepository, &deployUnit, &status, &c.FirstSeenAt, &c.LastSeenAt); err != nil {
+		return repository.Chart{}, err
+	}
+	c.DeployUnit = deployUnitFromDB(deployUnit)
+	c.Status = repository.Status(status)
+	return c, nil
+}
+
+func deployUnitFromDB(s string) appmetapb.DeployUnit {
+	switch s {
+	case "chart":
+		return appmetapb.DeployUnit_DEPLOY_UNIT_CHART
+	case "image":
+		return appmetapb.DeployUnit_DEPLOY_UNIT_IMAGE
+	case "none":
+		return appmetapb.DeployUnit_DEPLOY_UNIT_NONE
+	default:
+		return appmetapb.DeployUnit_DEPLOY_UNIT_UNSPECIFIED
+	}
+}
+
+func deployUnitToDB(du appmetapb.DeployUnit) string {
+	switch du {
+	case appmetapb.DeployUnit_DEPLOY_UNIT_IMAGE:
+		return "image"
+	case appmetapb.DeployUnit_DEPLOY_UNIT_NONE:
+		return "none"
+	default:
+		return "chart"
+	}
+}
+
+// ============================================================================
+// Reconcile
+// ============================================================================
+
+func (r *appRepo) Reconcile(ctx context.Context, apps []*appmetapb.AppManifest, charts []*appmetapb.ChartManifest, dryRun bool) (*repository.ReconcileResult, error) {
+	now := time.Now().UTC()
+	result := &repository.ReconcileResult{}
+
+	presentAppIDs := map[string]bool{}
+	appIDByKey := map[string]string{} // "domain|name" -> app_id, for chart resolution
+
+	for _, am := range apps {
+		existing, err := r.getAppByDomainName(ctx, am.Domain, am.Name)
+		if err != nil && !errors.Is(err, repository.ErrNotFound) {
+			return nil, fmt.Errorf("reconcile: look up app %s/%s: %w", am.Domain, am.Name, err)
+		}
+
+		if existing == nil {
+			appID := ""
+			if !dryRun {
+				appID = uuid.NewString()
+				_, err := r.ex.Exec(ctx, `
+					INSERT INTO app (app_id, domain, name, description, language, app_type, deploy_unit, bazel_label, image_repository, status, first_seen_at, last_seen_at)
+					VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, 'active', $10, $10)`,
+					appID, am.Domain, am.Name, am.Description, am.Language, am.AppType, deployUnitToDB(am.DeployUnit), am.BinaryTarget, imageRepository(am), now)
+				if err != nil {
+					return nil, fmt.Errorf("reconcile: insert app %s/%s: %w", am.Domain, am.Name, err)
+				}
+			}
+			newApp := repository.App{
+				AppID: appID, Domain: am.Domain, Name: am.Name, Description: am.Description,
+				Language: am.Language, AppType: am.AppType, DeployUnit: normalizeDeployUnit(am.DeployUnit),
+				BazelLabel: am.BinaryTarget, ImageRepository: imageRepository(am),
+				Status: repository.StatusActive, FirstSeenAt: now, LastSeenAt: now,
+			}
+			result.CreatedApps = append(result.CreatedApps, newApp)
+			if appID != "" {
+				presentAppIDs[appID] = true
+				appIDByKey[am.Domain+"|"+am.Name] = appID
+			}
+			continue
+		}
+
+		wasMissing := existing.Status == repository.StatusMissing
+		updated := *existing
+		updated.Description = am.Description
+		updated.Language = am.Language
+		updated.AppType = am.AppType
+		updated.DeployUnit = normalizeDeployUnit(am.DeployUnit)
+		updated.BazelLabel = am.BinaryTarget
+		updated.ImageRepository = imageRepository(am)
+		updated.Status = repository.StatusActive
+		updated.LastSeenAt = now
+
+		if !dryRun {
+			_, err := r.ex.Exec(ctx, `
+				UPDATE app SET description=$2, language=$3, app_type=$4, deploy_unit=$5, bazel_label=$6, image_repository=$7, status='active', last_seen_at=$8
+				WHERE app_id=$1`,
+				existing.AppID, updated.Description, updated.Language, updated.AppType, deployUnitToDB(updated.DeployUnit), updated.BazelLabel, updated.ImageRepository, now)
+			if err != nil {
+				return nil, fmt.Errorf("reconcile: update app %s/%s: %w", am.Domain, am.Name, err)
+			}
+		}
+		presentAppIDs[existing.AppID] = true
+		appIDByKey[am.Domain+"|"+am.Name] = existing.AppID
+
+		if wasMissing {
+			result.RecoveredApps = append(result.RecoveredApps, updated)
+		} else {
+			result.UpdatedApps = append(result.UpdatedApps, updated)
+		}
+	}
+
+	// Anything active-and-absent becomes MISSING. last_seen_at is
+	// deliberately left untouched — SetAppStatus's "present in the latest
+	// reconcile" check compares it against the table-wide max.
+	rows, err := r.ex.Query(ctx, `SELECT `+appColumns+` FROM app WHERE status = 'active'`)
+	if err != nil {
+		return nil, fmt.Errorf("reconcile: scan active apps: %w", err)
+	}
+	var toMarkMissing []repository.App
+	for rows.Next() {
+		a, err := scanApp(rows)
+		if err != nil {
+			rows.Close()
+			return nil, fmt.Errorf("reconcile: scan active apps: %w", err)
+		}
+		if !presentAppIDs[a.AppID] {
+			toMarkMissing = append(toMarkMissing, a)
+		}
+	}
+	rows.Close()
+	for _, a := range toMarkMissing {
+		if !dryRun {
+			if _, err := r.ex.Exec(ctx, `UPDATE app SET status = 'missing' WHERE app_id = $1`, a.AppID); err != nil {
+				return nil, fmt.Errorf("reconcile: mark app %s missing: %w", a.FullName(), err)
+			}
+		}
+		a.Status = repository.StatusMissing
+		result.NewlyMissingApps = append(result.NewlyMissingApps, a)
+	}
+
+	presentChartIDs := map[string]bool{}
+	for _, cm := range charts {
+		appIDs, err := r.resolveChartApps(ctx, appIDByKey, cm)
+		if err != nil {
+			return nil, err
+		}
+
+		existing, err := r.getChartByDomainName(ctx, cm.Domain, cm.Name)
+		if err != nil && !errors.Is(err, repository.ErrNotFound) {
+			return nil, fmt.Errorf("reconcile: look up chart %s/%s: %w", cm.Domain, cm.Name, err)
+		}
+
+		if existing == nil {
+			chartID := ""
+			if !dryRun {
+				chartID = uuid.NewString()
+				if _, err := r.ex.Exec(ctx, `
+					INSERT INTO chart (chart_id, domain, name, deploy_unit, status, first_seen_at, last_seen_at)
+					VALUES ($1, $2, $3, 'chart', 'active', $4, $4)`,
+					chartID, cm.Domain, cm.Name, now); err != nil {
+					return nil, fmt.Errorf("reconcile: insert chart %s/%s: %w", cm.Domain, cm.Name, err)
+				}
+				if err := r.setChartApps(ctx, chartID, appIDs); err != nil {
+					return nil, err
+				}
+			}
+			newChart := repository.Chart{
+				ChartID: chartID, Domain: cm.Domain, Name: cm.Name, DeployUnit: appmetapb.DeployUnit_DEPLOY_UNIT_CHART,
+				Status: repository.StatusActive, AppIDs: appIDs, FirstSeenAt: now, LastSeenAt: now,
+			}
+			result.CreatedCharts = append(result.CreatedCharts, newChart)
+			if chartID != "" {
+				presentChartIDs[chartID] = true
+			}
+			continue
+		}
+
+		wasMissing := existing.Status == repository.StatusMissing
+		updated := *existing
+		updated.AppIDs = appIDs
+		updated.Status = repository.StatusActive
+		updated.LastSeenAt = now
+
+		if !dryRun {
+			if _, err := r.ex.Exec(ctx, `UPDATE chart SET status='active', last_seen_at=$2 WHERE chart_id=$1`, existing.ChartID, now); err != nil {
+				return nil, fmt.Errorf("reconcile: update chart %s/%s: %w", cm.Domain, cm.Name, err)
+			}
+			if err := r.setChartApps(ctx, existing.ChartID, appIDs); err != nil {
+				return nil, err
+			}
+		}
+		presentChartIDs[existing.ChartID] = true
+
+		if wasMissing {
+			result.RecoveredCharts = append(result.RecoveredCharts, updated)
+		} else {
+			result.UpdatedCharts = append(result.UpdatedCharts, updated)
+		}
+	}
+
+	crows, err := r.ex.Query(ctx, `SELECT `+chartColumns+` FROM chart WHERE status = 'active'`)
+	if err != nil {
+		return nil, fmt.Errorf("reconcile: scan active charts: %w", err)
+	}
+	var chartsToMarkMissing []repository.Chart
+	for crows.Next() {
+		c, err := scanChart(crows)
+		if err != nil {
+			crows.Close()
+			return nil, fmt.Errorf("reconcile: scan active charts: %w", err)
+		}
+		if !presentChartIDs[c.ChartID] {
+			chartsToMarkMissing = append(chartsToMarkMissing, c)
+		}
+	}
+	crows.Close()
+	for _, c := range chartsToMarkMissing {
+		if !dryRun {
+			if _, err := r.ex.Exec(ctx, `UPDATE chart SET status = 'missing' WHERE chart_id = $1`, c.ChartID); err != nil {
+				return nil, fmt.Errorf("reconcile: mark chart %s missing: %w", c.FullName(), err)
+			}
+		}
+		c.Status = repository.StatusMissing
+		result.NewlyMissingCharts = append(result.NewlyMissingCharts, c)
+	}
+
+	return result, nil
+}
+
+// setChartApps rebuilds chart_app for chartID from scratch.
+func (r *appRepo) setChartApps(ctx context.Context, chartID string, appIDs []string) error {
+	if _, err := r.ex.Exec(ctx, `DELETE FROM chart_app WHERE chart_id = $1`, chartID); err != nil {
+		return fmt.Errorf("reconcile: clear chart_app for %s: %w", chartID, err)
+	}
+	for _, appID := range appIDs {
+		if _, err := r.ex.Exec(ctx, `INSERT INTO chart_app (chart_id, app_id) VALUES ($1, $2)`, chartID, appID); err != nil {
+			return fmt.Errorf("reconcile: insert chart_app (%s, %s): %w", chartID, appID, err)
+		}
+	}
+	return nil
+}
+
+// resolveChartApps resolves ChartManifest.apps (bare app names) to app_ids.
+// Same-domain matches are preferred (checked first against appIDByKey, which
+// includes apps created/updated earlier in this same reconcile call);
+// otherwise a cross-domain match is accepted only if unique. Fails the whole
+// reconcile with ErrInvalidArgument if any name is unknown.
+func (r *appRepo) resolveChartApps(ctx context.Context, appIDByKey map[string]string, cm *appmetapb.ChartManifest) ([]string, error) {
+	ids := make([]string, 0, len(cm.Apps))
+	for _, name := range cm.Apps {
+		if id, ok := appIDByKey[cm.Domain+"|"+name]; ok {
+			ids = append(ids, id)
+			continue
+		}
+
+		rows, err := r.ex.Query(ctx, `SELECT app_id FROM app WHERE name = $1`, name)
+		if err != nil {
+			return nil, fmt.Errorf("reconcile: resolve chart app %q: %w", name, err)
+		}
+		var matches []string
+		for rows.Next() {
+			var id string
+			if err := rows.Scan(&id); err != nil {
+				rows.Close()
+				return nil, fmt.Errorf("reconcile: resolve chart app %q: %w", name, err)
+			}
+			matches = append(matches, id)
+		}
+		rows.Close()
+
+		switch len(matches) {
+		case 0:
+			return nil, fmt.Errorf("%w: chart %s/%s references unknown app %q", repository.ErrInvalidArgument, cm.Domain, cm.Name, name)
+		case 1:
+			ids = append(ids, matches[0])
+		default:
+			return nil, fmt.Errorf("%w: chart %s/%s app name %q is ambiguous across domains", repository.ErrInvalidArgument, cm.Domain, cm.Name, name)
+		}
+	}
+	return ids, nil
+}
+
+func normalizeDeployUnit(du appmetapb.DeployUnit) appmetapb.DeployUnit {
+	if du == appmetapb.DeployUnit_DEPLOY_UNIT_UNSPECIFIED {
+		return appmetapb.DeployUnit_DEPLOY_UNIT_CHART
+	}
+	return du
+}
+
+func imageRepository(am *appmetapb.AppManifest) string {
+	if am.Registry == "" && am.Organization == "" && am.RepoName == "" {
+		return ""
+	}
+	return am.Registry + "/" + am.Organization + "/" + am.RepoName
+}
+
+// ============================================================================
+// Reads
+// ============================================================================
+
+func (r *appRepo) getAppByDomainName(ctx context.Context, domain, name string) (*repository.App, error) {
+	row := r.ex.QueryRow(ctx, `SELECT `+appColumns+` FROM app WHERE domain = $1 AND name = $2`, domain, name)
+	a, err := scanApp(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, repository.ErrNotFound
+		}
+		return nil, err
+	}
+	return &a, nil
+}
+
+func (r *appRepo) getChartByDomainName(ctx context.Context, domain, name string) (*repository.Chart, error) {
+	row := r.ex.QueryRow(ctx, `SELECT `+chartColumns+` FROM chart WHERE domain = $1 AND name = $2`, domain, name)
+	c, err := scanChart(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, repository.ErrNotFound
+		}
+		return nil, err
+	}
+	if ids, err := r.chartAppIDs(ctx, c.ChartID); err == nil {
+		c.AppIDs = ids
+	}
+	return &c, nil
+}
+
+func (r *appRepo) chartAppIDs(ctx context.Context, chartID string) ([]string, error) {
+	rows, err := r.ex.Query(ctx, `SELECT app_id FROM chart_app WHERE chart_id = $1`, chartID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}
+
+func (r *appRepo) ListApps(ctx context.Context, filter repository.AppListFilter) ([]repository.App, error) {
+	statuses := filter.Statuses
+	if len(statuses) == 0 {
+		statuses = []repository.Status{repository.StatusActive, repository.StatusMissing}
+	}
+	statusStrs := make([]string, len(statuses))
+	for i, s := range statuses {
+		statusStrs[i] = string(s)
+	}
+
+	query := `SELECT ` + appColumns + ` FROM app WHERE status = ANY($1)`
+	args := []any{statusStrs}
+	if filter.Domain != "" {
+		args = append(args, filter.Domain)
+		query += fmt.Sprintf(" AND domain = $%d", len(args))
+	}
+	if filter.DeployUnit != appmetapb.DeployUnit_DEPLOY_UNIT_UNSPECIFIED {
+		args = append(args, deployUnitToDB(filter.DeployUnit))
+		query += fmt.Sprintf(" AND deploy_unit = $%d", len(args))
+	}
+	query += " ORDER BY domain, name"
+
+	rows, err := r.ex.Query(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []repository.App
+	for rows.Next() {
+		a, err := scanApp(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, a)
+	}
+	return out, rows.Err()
+}
+
+func (r *appRepo) GetAppByID(ctx context.Context, appID string) (*repository.App, error) {
+	row := r.ex.QueryRow(ctx, `SELECT `+appColumns+` FROM app WHERE app_id = $1`, appID)
+	a, err := scanApp(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, repository.ErrNotFound
+		}
+		return nil, err
+	}
+	return &a, nil
+}
+
+func (r *appRepo) GetAppByFullName(ctx context.Context, fullName string) (*repository.App, error) {
+	row := r.ex.QueryRow(ctx, `SELECT `+appColumns+` FROM app WHERE domain || '-' || name = $1`, fullName)
+	a, err := scanApp(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, repository.ErrNotFound
+		}
+		return nil, err
+	}
+	return &a, nil
+}
+
+func (r *appRepo) ChartsForApp(ctx context.Context, appID string) ([]repository.Chart, error) {
+	rows, err := r.ex.Query(ctx, `
+		SELECT `+chartColumns+` FROM chart c
+		JOIN chart_app ca ON ca.chart_id = c.chart_id
+		WHERE ca.app_id = $1
+		ORDER BY c.domain, c.name`, appID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []repository.Chart
+	for rows.Next() {
+		c, err := scanChart(rows)
+		if err != nil {
+			return nil, err
+		}
+		if ids, err := r.chartAppIDs(ctx, c.ChartID); err == nil {
+			c.AppIDs = ids
+		}
+		out = append(out, c)
+	}
+	return out, rows.Err()
+}
+
+func (r *appRepo) ListCharts(ctx context.Context, filter repository.ChartListFilter) ([]repository.Chart, error) {
+	statuses := filter.Statuses
+	if len(statuses) == 0 {
+		statuses = []repository.Status{repository.StatusActive, repository.StatusMissing}
+	}
+	statusStrs := make([]string, len(statuses))
+	for i, s := range statuses {
+		statusStrs[i] = string(s)
+	}
+
+	query := `SELECT ` + chartColumns + ` FROM chart WHERE status = ANY($1)`
+	args := []any{statusStrs}
+	if filter.Domain != "" {
+		args = append(args, filter.Domain)
+		query += fmt.Sprintf(" AND domain = $%d", len(args))
+	}
+	query += " ORDER BY domain, name"
+
+	rows, err := r.ex.Query(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []repository.Chart
+	for rows.Next() {
+		c, err := scanChart(rows)
+		if err != nil {
+			return nil, err
+		}
+		if ids, err := r.chartAppIDs(ctx, c.ChartID); err == nil {
+			c.AppIDs = ids
+		}
+		out = append(out, c)
+	}
+	return out, rows.Err()
+}
+
+func (r *appRepo) GetChartByID(ctx context.Context, chartID string) (*repository.Chart, error) {
+	row := r.ex.QueryRow(ctx, `SELECT `+chartColumns+` FROM chart WHERE chart_id = $1`, chartID)
+	c, err := scanChart(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, repository.ErrNotFound
+		}
+		return nil, err
+	}
+	if ids, err := r.chartAppIDs(ctx, c.ChartID); err == nil {
+		c.AppIDs = ids
+	}
+	return &c, nil
+}
+
+func (r *appRepo) GetChartByFullName(ctx context.Context, fullName string) (*repository.Chart, error) {
+	row := r.ex.QueryRow(ctx, `SELECT `+chartColumns+` FROM chart WHERE domain || '-' || name = $1`, fullName)
+	c, err := scanChart(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, repository.ErrNotFound
+		}
+		return nil, err
+	}
+	if ids, err := r.chartAppIDs(ctx, c.ChartID); err == nil {
+		c.AppIDs = ids
+	}
+	return &c, nil
+}
+
+// ============================================================================
+// SetAppStatus
+// ============================================================================
+
+func (r *appRepo) SetAppStatus(ctx context.Context, appID string, status repository.Status, reason string) (*repository.App, error) {
+	row := r.ex.QueryRow(ctx, `
+		SELECT `+appColumns+`, (SELECT MAX(last_seen_at) FROM app) AS max_last_seen
+		FROM app WHERE app_id = $1`, appID)
+
+	var a repository.App
+	var deployUnit, dbStatus string
+	var maxLastSeen time.Time
+	if err := row.Scan(&a.AppID, &a.Domain, &a.Name, &a.Description, &a.Language, &a.AppType, &deployUnit, &a.BazelLabel, &a.ImageRepository, &dbStatus, &a.FirstSeenAt, &a.LastSeenAt, &maxLastSeen); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, repository.ErrNotFound
+		}
+		return nil, err
+	}
+	a.DeployUnit = deployUnitFromDB(deployUnit)
+	a.Status = repository.Status(dbStatus)
+
+	// "present in the most recent reconcile" is derived, not stored: an app
+	// was touched by the latest Reconcile call iff its last_seen_at equals
+	// the table-wide max (every app present in one reconcile shares the same
+	// last_seen_at, set from a single now := time.Now() in Reconcile).
+	if status == repository.StatusActive && a.LastSeenAt.Before(maxLastSeen) {
+		return nil, repository.ErrFailedPrecondition
+	}
+
+	if _, err := r.ex.Exec(ctx, `UPDATE app SET status = $2 WHERE app_id = $1`, appID, string(status)); err != nil {
+		return nil, err
+	}
+	a.Status = status
+	return &a, nil
+}

--- a/tools/app_registry/server/repository/postgres/artifact.go
+++ b/tools/app_registry/server/repository/postgres/artifact.go
@@ -42,6 +42,9 @@ func (r *buildRepo) RecordBuild(ctx context.Context, b repository.Build) (*repos
 		INSERT INTO build (build_id, git_sha, git_ref, workflow_run_id, workflow_attempt, actor, started_at, recorded_at)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
 		b.BuildID, b.GitSHA, b.GitRef, b.WorkflowRunID, b.WorkflowAttempt, b.Actor, b.StartedAt, b.RecordedAt); err != nil {
+		if de, ok := translatePgError(err, fmt.Sprintf("build for workflow run %s attempt %d already recorded", b.WorkflowRunID, b.WorkflowAttempt)); ok {
+			return nil, false, de
+		}
 		return nil, false, fmt.Errorf("record build %s attempt %d: %w", b.WorkflowRunID, b.WorkflowAttempt, err)
 	}
 	return &b, false, nil
@@ -128,6 +131,10 @@ func (r *artifactRepo) RecordArtifact(ctx context.Context, a repository.Artifact
 		INSERT INTO artifact (artifact_id, kind, app_id, chart_id, repository, version, digest, build_id, published_at)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
 		a.ArtifactID, string(a.Kind), appID, chartID, a.Repository, a.Version, a.Digest, a.BuildID, a.PublishedAt); err != nil {
+		msg := fmt.Sprintf("artifact %s %s already recorded", r.ownerFullName(ctx, a), a.Version)
+		if de, ok := translatePgError(err, msg); ok {
+			return nil, false, de
+		}
 		return nil, false, fmt.Errorf("record artifact %s: %w", a.Digest, err)
 	}
 
@@ -151,6 +158,10 @@ func (r *artifactRepo) RecordArtifact(ctx context.Context, a repository.Artifact
 				INSERT INTO artifact_link (chart_artifact_id, image_artifact_id, app_id, repository, version, digest)
 				VALUES ($1, $2, $3, $4, $5, $6)`,
 				a.ArtifactID, imgArtifactID, imgApp, ci.Repository, ci.Version, ci.Digest); err != nil {
+				msg := fmt.Sprintf("artifact %s already pins image digest %s", a.Digest, ci.Digest)
+				if de, ok := translatePgError(err, msg); ok {
+					return nil, false, de
+				}
 				return nil, false, fmt.Errorf("link chart artifact %s to image %s: %w", a.ArtifactID, ci.Digest, err)
 			}
 			links = append(links, repository.ArtifactLink{
@@ -168,6 +179,27 @@ func (r *artifactRepo) RecordArtifact(ctx context.Context, a repository.Artifact
 		return nil, false, err
 	}
 	return out, false, nil
+}
+
+// ownerFullName resolves a.AppID/a.ChartID to "domain-name" for error
+// messages that must describe a conflict in domain terms. It is only called
+// on the (rare) error path, never the hot insert path, so the extra query is
+// cheap where it matters. Falls back to the raw id if the lookup fails.
+func (r *artifactRepo) ownerFullName(ctx context.Context, a repository.Artifact) string {
+	var row pgx.Row
+	var fallback string
+	if a.Kind == repository.ArtifactKindImage {
+		row = r.ex.QueryRow(ctx, `SELECT domain || '-' || name FROM app WHERE app_id = $1`, a.AppID)
+		fallback = a.AppID
+	} else {
+		row = r.ex.QueryRow(ctx, `SELECT domain || '-' || name FROM chart WHERE chart_id = $1`, a.ChartID)
+		fallback = a.ChartID
+	}
+	var name string
+	if err := row.Scan(&name); err != nil {
+		return fallback
+	}
+	return name
 }
 
 func (r *artifactRepo) loadContains(ctx context.Context, chartArtifactID string) ([]repository.ArtifactLink, error) {

--- a/tools/app_registry/server/repository/postgres/artifact.go
+++ b/tools/app_registry/server/repository/postgres/artifact.go
@@ -1,0 +1,308 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/whale-net/everything/tools/app_registry/server/repository"
+	appmetapb "github.com/whale-net/everything/tools/appmeta/proto"
+)
+
+// ============================================================================
+// BuildRepository
+// ============================================================================
+
+type buildRepo struct{ ex dbtx }
+
+const buildColumns = `build_id, git_sha, git_ref, workflow_run_id, workflow_attempt, actor, started_at, recorded_at`
+
+func scanBuild(row pgx.Row) (repository.Build, error) {
+	var b repository.Build
+	if err := row.Scan(&b.BuildID, &b.GitSHA, &b.GitRef, &b.WorkflowRunID, &b.WorkflowAttempt, &b.Actor, &b.StartedAt, &b.RecordedAt); err != nil {
+		return repository.Build{}, err
+	}
+	return b, nil
+}
+
+func (r *buildRepo) RecordBuild(ctx context.Context, b repository.Build) (*repository.Build, bool, error) {
+	row := r.ex.QueryRow(ctx, `SELECT `+buildColumns+` FROM build WHERE workflow_run_id = $1 AND workflow_attempt = $2`, b.WorkflowRunID, b.WorkflowAttempt)
+	if existing, err := scanBuild(row); err == nil {
+		return &existing, true, nil
+	} else if !errors.Is(err, pgx.ErrNoRows) {
+		return nil, false, err
+	}
+
+	b.BuildID = uuid.NewString()
+	b.RecordedAt = time.Now().UTC()
+	if _, err := r.ex.Exec(ctx, `
+		INSERT INTO build (build_id, git_sha, git_ref, workflow_run_id, workflow_attempt, actor, started_at, recorded_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+		b.BuildID, b.GitSHA, b.GitRef, b.WorkflowRunID, b.WorkflowAttempt, b.Actor, b.StartedAt, b.RecordedAt); err != nil {
+		return nil, false, fmt.Errorf("record build %s attempt %d: %w", b.WorkflowRunID, b.WorkflowAttempt, err)
+	}
+	return &b, false, nil
+}
+
+func (r *buildRepo) GetBuild(ctx context.Context, buildID string) (*repository.Build, error) {
+	row := r.ex.QueryRow(ctx, `SELECT `+buildColumns+` FROM build WHERE build_id = $1`, buildID)
+	b, err := scanBuild(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, repository.ErrNotFound
+		}
+		return nil, err
+	}
+	return &b, nil
+}
+
+// ============================================================================
+// ArtifactRepository
+// ============================================================================
+
+type artifactRepo struct{ ex dbtx }
+
+// artifactRow is what every artifact SELECT returns: the artifact plus the
+// owning app's/chart's deploy_unit, which is all repository.DerivePromotability
+// needs. Promotability is never persisted — see ARCHITECTURE.md "Promotability".
+const artifactSelectBase = `
+	SELECT a.artifact_id, a.kind, a.app_id, a.chart_id, a.repository, a.version, a.digest, a.build_id, a.published_at,
+	       COALESCE(app.deploy_unit, chart.deploy_unit) AS owner_deploy_unit
+	FROM artifact a
+	LEFT JOIN app ON a.app_id = app.app_id
+	LEFT JOIN chart ON a.chart_id = chart.chart_id`
+
+func scanArtifact(row pgx.Row) (repository.Artifact, error) {
+	var a repository.Artifact
+	var kind string
+	var appID, chartID *string
+	var ownerDeployUnit *string
+	if err := row.Scan(&a.ArtifactID, &kind, &appID, &chartID, &a.Repository, &a.Version, &a.Digest, &a.BuildID, &a.PublishedAt, &ownerDeployUnit); err != nil {
+		return repository.Artifact{}, err
+	}
+	a.Kind = repository.ArtifactKind(kind)
+	if appID != nil {
+		a.AppID = *appID
+	}
+	if chartID != nil {
+		a.ChartID = *chartID
+	}
+	var du appmetapb.DeployUnit
+	if ownerDeployUnit != nil {
+		du = deployUnitFromDB(*ownerDeployUnit)
+	}
+	a.Promotability = repository.DerivePromotability(a.Kind, du)
+	return a, nil
+}
+
+func (r *artifactRepo) RecordArtifact(ctx context.Context, a repository.Artifact, contains []repository.ContainedImageInput) (*repository.Artifact, bool, error) {
+	row := r.ex.QueryRow(ctx, artifactSelectBase+` WHERE a.digest = $1`, a.Digest)
+	if existing, err := scanArtifact(row); err == nil {
+		if existing.Kind == repository.ArtifactKindChart {
+			links, lerr := r.loadContains(ctx, existing.ArtifactID)
+			if lerr != nil {
+				return nil, false, lerr
+			}
+			existing.Contains = links
+		}
+		return &existing, true, nil
+	} else if !errors.Is(err, pgx.ErrNoRows) {
+		return nil, false, err
+	}
+
+	a.ArtifactID = uuid.NewString()
+	if a.PublishedAt.IsZero() {
+		a.PublishedAt = time.Now().UTC()
+	}
+
+	var appID, chartID any
+	if a.Kind == repository.ArtifactKindImage {
+		appID = a.AppID
+	} else {
+		chartID = a.ChartID
+	}
+	if _, err := r.ex.Exec(ctx, `
+		INSERT INTO artifact (artifact_id, kind, app_id, chart_id, repository, version, digest, build_id, published_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+		a.ArtifactID, string(a.Kind), appID, chartID, a.Repository, a.Version, a.Digest, a.BuildID, a.PublishedAt); err != nil {
+		return nil, false, fmt.Errorf("record artifact %s: %w", a.Digest, err)
+	}
+
+	if a.Kind == repository.ArtifactKindChart {
+		links := make([]repository.ArtifactLink, 0, len(contains))
+		for _, ci := range contains {
+			imgRow := r.ex.QueryRow(ctx, `SELECT artifact_id, app_id FROM artifact WHERE digest = $1 AND kind = 'image'`, ci.Digest)
+			var imgArtifactID string
+			var imgAppID *string
+			if err := imgRow.Scan(&imgArtifactID, &imgAppID); err != nil {
+				if errors.Is(err, pgx.ErrNoRows) {
+					return nil, false, fmt.Errorf("%w: chart pins unrecorded image digest %s", repository.ErrInvalidArgument, ci.Digest)
+				}
+				return nil, false, err
+			}
+			imgApp := ""
+			if imgAppID != nil {
+				imgApp = *imgAppID
+			}
+			if _, err := r.ex.Exec(ctx, `
+				INSERT INTO artifact_link (chart_artifact_id, image_artifact_id, app_id, repository, version, digest)
+				VALUES ($1, $2, $3, $4, $5, $6)`,
+				a.ArtifactID, imgArtifactID, imgApp, ci.Repository, ci.Version, ci.Digest); err != nil {
+				return nil, false, fmt.Errorf("link chart artifact %s to image %s: %w", a.ArtifactID, ci.Digest, err)
+			}
+			links = append(links, repository.ArtifactLink{
+				ImageArtifactID: imgArtifactID, AppID: imgApp,
+				Repository: ci.Repository, Version: ci.Version, Digest: ci.Digest,
+			})
+		}
+		a.Contains = links
+	}
+
+	// Re-derive promotability against the freshly-read owner deploy_unit,
+	// rather than trusting whatever the caller set on the input struct.
+	out, err := r.GetArtifact(ctx, repository.ArtifactLookup{ArtifactID: a.ArtifactID})
+	if err != nil {
+		return nil, false, err
+	}
+	return out, false, nil
+}
+
+func (r *artifactRepo) loadContains(ctx context.Context, chartArtifactID string) ([]repository.ArtifactLink, error) {
+	rows, err := r.ex.Query(ctx, `SELECT image_artifact_id, app_id, repository, version, digest FROM artifact_link WHERE chart_artifact_id = $1`, chartArtifactID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []repository.ArtifactLink
+	for rows.Next() {
+		var l repository.ArtifactLink
+		if err := rows.Scan(&l.ImageArtifactID, &l.AppID, &l.Repository, &l.Version, &l.Digest); err != nil {
+			return nil, err
+		}
+		out = append(out, l)
+	}
+	return out, rows.Err()
+}
+
+func (r *artifactRepo) ListArtifacts(ctx context.Context, filter repository.ArtifactListFilter) ([]repository.Artifact, error) {
+	query := artifactSelectBase + ` WHERE 1=1`
+	var args []any
+
+	if filter.Kind != "" {
+		args = append(args, string(filter.Kind))
+		query += fmt.Sprintf(" AND a.kind = $%d", len(args))
+	}
+	if filter.OwnerFullName != "" {
+		args = append(args, filter.OwnerFullName)
+		query += fmt.Sprintf(" AND (app.domain || '-' || app.name = $%d OR chart.domain || '-' || chart.name = $%d)", len(args), len(args))
+	}
+	query += " ORDER BY a.published_at"
+
+	rows, err := r.ex.Query(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []repository.Artifact
+	for rows.Next() {
+		a, err := scanArtifact(rows)
+		if err != nil {
+			return nil, err
+		}
+		if filter.PromotableOnly && a.Promotability != repository.PromotabilityPromotable {
+			continue
+		}
+		out = append(out, a)
+	}
+	return out, rows.Err()
+}
+
+func (r *artifactRepo) GetArtifact(ctx context.Context, lookup repository.ArtifactLookup) (*repository.Artifact, error) {
+	a, err := r.findArtifact(ctx, lookup)
+	if err != nil {
+		return nil, err
+	}
+	if a.Kind == repository.ArtifactKindChart {
+		links, err := r.loadContains(ctx, a.ArtifactID)
+		if err != nil {
+			return nil, err
+		}
+		a.Contains = links
+	}
+	return a, nil
+}
+
+func (r *artifactRepo) findArtifact(ctx context.Context, lookup repository.ArtifactLookup) (*repository.Artifact, error) {
+	var row pgx.Row
+	switch {
+	case lookup.ArtifactID != "":
+		row = r.ex.QueryRow(ctx, artifactSelectBase+` WHERE a.artifact_id = $1`, lookup.ArtifactID)
+	case lookup.Digest != "":
+		row = r.ex.QueryRow(ctx, artifactSelectBase+` WHERE a.digest = $1`, lookup.Digest)
+	case lookup.OwnerFullName != "":
+		row = r.ex.QueryRow(ctx, artifactSelectBase+`
+			WHERE a.kind = $1 AND a.version = $2
+			  AND (app.domain || '-' || app.name = $3 OR chart.domain || '-' || chart.name = $3)`,
+			string(lookup.Kind), lookup.Version, lookup.OwnerFullName)
+	default:
+		return nil, repository.ErrInvalidArgument
+	}
+
+	a, err := scanArtifact(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, repository.ErrNotFound
+		}
+		return nil, err
+	}
+	return &a, nil
+}
+
+func (r *artifactRepo) ResolveArtifact(ctx context.Context, lookup repository.ArtifactLookup) (*repository.Artifact, []repository.Artifact, []repository.Build, error) {
+	a, err := r.findArtifact(ctx, lookup)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if a.Kind != repository.ArtifactKindChart {
+		return nil, nil, nil, fmt.Errorf("%w: artifact %s is not a chart", repository.ErrInvalidArgument, a.ArtifactID)
+	}
+
+	rows, err := r.ex.Query(ctx, artifactSelectBase+`
+		JOIN artifact_link al ON al.image_artifact_id = a.artifact_id
+		WHERE al.chart_artifact_id = $1`, a.ArtifactID)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	var images []repository.Artifact
+	var buildIDs []string
+	for rows.Next() {
+		img, err := scanArtifact(rows)
+		if err != nil {
+			rows.Close()
+			return nil, nil, nil, err
+		}
+		images = append(images, img)
+		buildIDs = append(buildIDs, img.BuildID)
+	}
+	rows.Close()
+
+	var builds []repository.Build
+	for _, id := range buildIDs {
+		b, err := (&buildRepo{ex: r.ex}).GetBuild(ctx, id)
+		if err != nil {
+			continue
+		}
+		builds = append(builds, *b)
+	}
+
+	links, err := r.loadContains(ctx, a.ArtifactID)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	a.Contains = links
+
+	return a, images, builds, nil
+}

--- a/tools/app_registry/server/repository/postgres/artifact.go
+++ b/tools/app_registry/server/repository/postgres/artifact.go
@@ -127,11 +127,17 @@ func (r *artifactRepo) RecordArtifact(ctx context.Context, a repository.Artifact
 	} else {
 		chartID = a.ChartID
 	}
+	// Resolve the owner's display name *before* the insert. A constraint
+	// violation aborts the surrounding transaction, so any query issued
+	// afterwards fails too and ownerFullName would degrade to the raw UUID —
+	// which is exactly what a client should never be shown.
+	ownerName := r.ownerFullName(ctx, a)
+
 	if _, err := r.ex.Exec(ctx, `
 		INSERT INTO artifact (artifact_id, kind, app_id, chart_id, repository, version, digest, build_id, published_at)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
 		a.ArtifactID, string(a.Kind), appID, chartID, a.Repository, a.Version, a.Digest, a.BuildID, a.PublishedAt); err != nil {
-		msg := fmt.Sprintf("artifact %s %s already recorded", r.ownerFullName(ctx, a), a.Version)
+		msg := fmt.Sprintf("artifact %s %s already recorded", ownerName, a.Version)
 		if de, ok := translatePgError(err, msg); ok {
 			return nil, false, de
 		}

--- a/tools/app_registry/server/repository/postgres/errors.go
+++ b/tools/app_registry/server/repository/postgres/errors.go
@@ -1,0 +1,57 @@
+package postgres
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/whale-net/everything/tools/app_registry/server/repository"
+)
+
+// Postgres SQLSTATE codes for the integrity-constraint violation classes
+// this package translates. See
+// https://www.postgresql.org/docs/current/errcodes-appendix.html.
+const (
+	sqlStateUniqueViolation     = "23505"
+	sqlStateCheckViolation      = "23514"
+	sqlStateForeignKeyViolation = "23503"
+)
+
+// translatePgError is the single place a Postgres integrity-constraint
+// violation becomes a repository domain error. Every write path in this
+// package must route constraint-violation errors through it (rather than
+// returning the raw pgx error) so:
+//
+//   - handlers map to the correct gRPC code via errors.Is on the sentinel,
+//     never by string-matching pgx's error text or SQLSTATE — see
+//     handlers/errors.go's mapRepoErr.
+//   - AR-5's AllocateVersion can distinguish "someone else took this
+//     version, retry" (ErrAlreadyExists -> codes.AlreadyExists, a caller
+//     should retry) from a genuine server bug (codes.Internal, retrying is
+//     pointless).
+//   - clients never see an index name or a SQLSTATE; msg is the only text
+//     that reaches them, and it must describe the conflict in domain terms.
+//
+// It uses errors.As against *pgconn.PgError, not string matching, so it
+// keeps working regardless of how pgx wraps the underlying error.
+//
+// ok is false when err is not one of the three violation classes this
+// package maps; callers should fall back to their normal generic wrap in
+// that case (translatePgError deliberately does not swallow errors it
+// doesn't recognize).
+func translatePgError(err error, msg string) (domainErr error, ok bool) {
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) {
+		return nil, false
+	}
+	switch pgErr.Code {
+	case sqlStateUniqueViolation:
+		return fmt.Errorf("%w: %s", repository.ErrAlreadyExists, msg), true
+	case sqlStateCheckViolation:
+		return fmt.Errorf("%w: %s", repository.ErrInvalidArgument, msg), true
+	case sqlStateForeignKeyViolation:
+		return fmt.Errorf("%w: %s", repository.ErrFailedPrecondition, msg), true
+	default:
+		return nil, false
+	}
+}

--- a/tools/app_registry/server/repository/postgres/errors_test.go
+++ b/tools/app_registry/server/repository/postgres/errors_test.go
@@ -1,0 +1,74 @@
+package postgres
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/whale-net/everything/tools/app_registry/server/repository"
+)
+
+// TestTranslatePgError_MapsEachSQLSTATE is the direct, mechanism-level test
+// for the central translation point Fix 1 requires: every write path in this
+// package must route Postgres integrity-constraint violations through
+// translatePgError rather than returning the raw pgx error, so a caller's
+// retry logic (see AR-5's AllocateVersion) can tell "someone else took this,
+// retry" apart from "the server is broken."
+//
+// This uses errors.As against a synthetic *pgconn.PgError deliberately —
+// asserting the code matches on the wrapped SQLSTATE, never on message text,
+// proves the implementation isn't secretly string-matching.
+func TestTranslatePgError_MapsEachSQLSTATE(t *testing.T) {
+	cases := []struct {
+		name    string
+		code    string
+		wantErr error
+	}{
+		{"unique_violation", sqlStateUniqueViolation, repository.ErrAlreadyExists},
+		{"check_violation", sqlStateCheckViolation, repository.ErrInvalidArgument},
+		{"foreign_key_violation", sqlStateForeignKeyViolation, repository.ErrFailedPrecondition},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pgErr := &pgconn.PgError{
+				Code:           tc.code,
+				Message:        "duplicate key value violates unique constraint \"artifact_version_idx\"",
+				ConstraintName: "artifact_version_idx",
+			}
+			// Wrap the way pgx actually returns it, to prove errors.As sees
+			// through wrapping rather than requiring an exact type match.
+			wrapped := fmt.Errorf("exec failed: %w", pgErr)
+
+			domainErr, ok := translatePgError(wrapped, "artifact demo-svc v1.2.3 already recorded")
+			if !ok {
+				t.Fatalf("expected translatePgError to recognize SQLSTATE %s", tc.code)
+			}
+			if !errors.Is(domainErr, tc.wantErr) {
+				t.Fatalf("expected %v, got %v", tc.wantErr, domainErr)
+			}
+			// The index name and SQLSTATE must never reach the message.
+			got := domainErr.Error()
+			for _, leak := range []string{"artifact_version_idx", tc.code, "SQLSTATE"} {
+				if strings.Contains(got, leak) {
+					t.Fatalf("domain error leaks database internals (%q): %q", leak, got)
+				}
+			}
+		})
+	}
+}
+
+// TestTranslatePgError_PassesThroughNonIntegrityErrors proves a non-pgError
+// (or a pgError with an unmapped code) is left for the caller's generic
+// Internal-error wrap, rather than being silently swallowed or misclassified.
+func TestTranslatePgError_PassesThroughNonIntegrityErrors(t *testing.T) {
+	if _, ok := translatePgError(errors.New("connection reset"), "irrelevant"); ok {
+		t.Fatal("expected a non-pgError to be left untranslated")
+	}
+
+	other := &pgconn.PgError{Code: "40001"} // serialization_failure — not one of ours
+	if _, ok := translatePgError(other, "irrelevant"); ok {
+		t.Fatal("expected an unmapped SQLSTATE to be left untranslated")
+	}
+}

--- a/tools/app_registry/server/repository/postgres/idempotency.go
+++ b/tools/app_registry/server/repository/postgres/idempotency.go
@@ -1,0 +1,31 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+
+	"github.com/jackc/pgx/v5"
+)
+
+type idempotencyRepo struct{ ex dbtx }
+
+func (r *idempotencyRepo) Get(ctx context.Context, key string) ([]byte, bool, error) {
+	var response []byte
+	err := r.ex.QueryRow(ctx, `SELECT response_bytes FROM idempotency_key WHERE idempotency_key = $1`, key).Scan(&response)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+	return response, true, nil
+}
+
+func (r *idempotencyRepo) Put(ctx context.Context, key, method string, response []byte) error {
+	_, err := r.ex.Exec(ctx, `
+		INSERT INTO idempotency_key (idempotency_key, method, response_bytes)
+		VALUES ($1, $2, $3)
+		ON CONFLICT (idempotency_key) DO NOTHING`,
+		key, method, response)
+	return err
+}

--- a/tools/app_registry/server/repository/postgres/repository.go
+++ b/tools/app_registry/server/repository/postgres/repository.go
@@ -1,14 +1,75 @@
 // Package postgres implements the App Registry's repository interfaces
-// against Postgres via pgx. Empty in AR-1 — see ../repository.go.
+// against Postgres via pgx, following the manmanv2/api/repository/postgres
+// pattern: one file per entity, domain structs (not proto types) in and out.
+//
+// NOTE ON TEST COVERAGE: this package compiles under `bazel build` and its
+// SQL is exercised transitively by any manual/local run against a real
+// Postgres instance, but there is no automated `bazel test` coverage against
+// a live database in this change — see server/repository/fake/fake.go's
+// doc comment for why, and the AR-2a report for the explicit breakdown of
+// what runs in CI. The business logic this SQL implements (reconcile
+// diffing, promotability derivation, idempotency, chart/image validation) is
+// covered by handlers tests against repository/fake instead.
 package postgres
 
 import (
+	"context"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/whale-net/everything/tools/app_registry/server/repository"
 )
 
-// NewRepository creates a Repository backed by the given connection pool.
-func NewRepository(pool *pgxpool.Pool) *repository.Repository {
-	_ = pool // wired into per-entity repositories starting AR-2
-	return &repository.Repository{}
+// dbtx is the subset of *pgxpool.Pool and pgx.Tx this package needs. Every
+// per-entity repository is constructed with one, so the same query code runs
+// unchanged whether it's part of a WithTx transaction or a bare read against
+// the pool.
+type dbtx interface {
+	Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error)
+	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+}
+
+// Registry is the pgx-backed repository.Registry.
+type Registry struct {
+	pool *pgxpool.Pool
+	ex   dbtx
+}
+
+// NewRepository creates a Registry backed by the given connection pool.
+func NewRepository(pool *pgxpool.Pool) *Registry {
+	return &Registry{pool: pool, ex: pool}
+}
+
+func (r *Registry) Apps() repository.AppRepository                { return &appRepo{ex: r.ex} }
+func (r *Registry) Builds() repository.BuildRepository            { return &buildRepo{ex: r.ex} }
+func (r *Registry) Artifacts() repository.ArtifactRepository      { return &artifactRepo{ex: r.ex} }
+func (r *Registry) Idempotency() repository.IdempotencyRepository { return &idempotencyRepo{ex: r.ex} }
+
+// WithTx runs fn inside a single Postgres transaction, committing iff fn
+// returns nil and rolling back otherwise. This is the atomicity boundary
+// ARCHITECTURE.md "Idempotency" depends on: the business write and the
+// idempotency-key row land in the same commit.
+func (r *Registry) WithTx(ctx context.Context, fn func(ctx context.Context, reg repository.Registry) error) error {
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback(ctx)
+		}
+	}()
+
+	txReg := &Registry{pool: r.pool, ex: tx}
+	if err := fn(ctx, txReg); err != nil {
+		return err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return err
+	}
+	committed = true
+	return nil
 }

--- a/tools/app_registry/server/repository/promotability.go
+++ b/tools/app_registry/server/repository/promotability.go
@@ -1,0 +1,27 @@
+package repository
+
+import appmetapb "github.com/whale-net/everything/tools/appmeta/proto"
+
+// DerivePromotability implements ARCHITECTURE.md "Promotability". ownerDeployUnit
+// is the DeployUnit of the App (for an image artifact) or Chart (for a chart
+// artifact) that owns the artifact — never a value stored on the artifact
+// itself. Shared by every repository implementation so the rule has exactly
+// one definition.
+//
+//	App/Chart deploy_unit | Image artifacts | Chart artifacts
+//	chart                 | VIA_CHART       | PROMOTABLE
+//	image                 | PROMOTABLE      | n/a (charts don't have deploy_unit=image)
+//	none                  | NOT_PROMOTABLE  | n/a
+func DerivePromotability(kind ArtifactKind, ownerDeployUnit appmetapb.DeployUnit) Promotability {
+	switch ownerDeployUnit {
+	case appmetapb.DeployUnit_DEPLOY_UNIT_CHART:
+		if kind == ArtifactKindImage {
+			return PromotabilityViaChart
+		}
+		return PromotabilityPromotable
+	case appmetapb.DeployUnit_DEPLOY_UNIT_IMAGE:
+		return PromotabilityPromotable
+	default: // DEPLOY_UNIT_NONE, DEPLOY_UNIT_UNSPECIFIED
+		return PromotabilityNotPromotable
+	}
+}

--- a/tools/app_registry/server/repository/repository.go
+++ b/tools/app_registry/server/repository/repository.go
@@ -55,12 +55,13 @@ type AppRepository interface {
 	GetChartByID(ctx context.Context, chartID string) (*Chart, error)
 	GetChartByFullName(ctx context.Context, fullName string) (*Chart, error)
 
-	// SetAppStatus is the human-triage path. status must be StatusActive or
-	// StatusArchived. Transitioning to StatusActive is rejected with
-	// ErrFailedPrecondition unless appID was present in the most recent
-	// Reconcile call — see postgres implementation for how presence is
-	// derived without a schema change.
-	SetAppStatus(ctx context.Context, appID string, status Status, reason string) (*App, error)
+	// SetAppStatus is the human-triage path and supports exactly one
+	// transition: StatusMissing -> StatusArchived. missing -> active happens
+	// automatically via Reconcile's "recovered" path, so it is never legal
+	// here. archived -> archived is a no-op success (idempotent retry); any
+	// other starting status, or a target other than StatusArchived, fails
+	// with ErrFailedPrecondition.
+	SetAppStatus(ctx context.Context, appID string, target Status, reason string) (*App, error)
 }
 
 // BuildRepository covers the `build` table.

--- a/tools/app_registry/server/repository/repository.go
+++ b/tools/app_registry/server/repository/repository.go
@@ -1,10 +1,114 @@
 // Package repository defines the storage interfaces the handlers depend on.
-// AR-1 ships no business logic, so this is deliberately empty beyond the
-// aggregate struct — AR-2/AR-3 add one interface per entity here (AppRepository,
-// ArtifactRepository, ...) following the manmanv2/api/repository pattern, and
-// postgres/ gains the pgx-backed implementation for each.
+// AR-2 fills in the AppRegistry/ArtifactRegistry subset; AR-3/AR-4 add
+// EnvironmentRepository/PromotionRepository following the same shape.
+//
+// postgres/ is the pgx-backed implementation; fake/ is an in-memory
+// implementation used by handler-level logic tests (see fake/fake.go for why
+// there is no Postgres-backed test in this package under Bazel).
 package repository
 
-// Repository aggregates the per-entity repository interfaces. Empty in AR-1;
-// fields are added alongside the RPCs that need them.
-type Repository struct{}
+import (
+	"context"
+	"errors"
+
+	appmetapb "github.com/whale-net/everything/tools/appmeta/proto"
+)
+
+// Domain errors. Handlers map these to gRPC codes via errors.Is; repository
+// implementations must wrap one of these with %w so the mapping works
+// regardless of which implementation (postgres or fake) is behind the
+// interface.
+var (
+	// ErrNotFound: the requested row does not exist.
+	ErrNotFound = errors.New("not found")
+	// ErrAlreadyExists: a unique constraint would be violated.
+	ErrAlreadyExists = errors.New("already exists")
+	// ErrInvalidArgument: caller input is structurally invalid (e.g. a
+	// chart pinning an unrecorded image digest, an unknown chart-app name).
+	ErrInvalidArgument = errors.New("invalid argument")
+	// ErrFailedPrecondition: the request is well-formed but illegal given
+	// current state (e.g. SetAppStatus(ACTIVE) on an app absent from the
+	// latest reconcile).
+	ErrFailedPrecondition = errors.New("failed precondition")
+)
+
+// AppRepository covers App and Chart identity — the two tables ReconcileApps
+// writes together, since a chart's chart_app join depends on app rows
+// existing first.
+type AppRepository interface {
+	// Reconcile performs the FULL replace described in ARCHITECTURE.md: every
+	// app/chart in the manifest set is created or updated and set ACTIVE;
+	// anything known but absent is marked MISSING (ARCHIVED rows are left
+	// alone); anything MISSING that reappears is reported as recovered.
+	// chart.apps entries are resolved to app_ids and the call fails with
+	// ErrInvalidArgument if any name is unknown. dryRun computes the result
+	// without writing.
+	Reconcile(ctx context.Context, apps []*appmetapb.AppManifest, charts []*appmetapb.ChartManifest, dryRun bool) (*ReconcileResult, error)
+
+	ListApps(ctx context.Context, filter AppListFilter) ([]App, error)
+	GetAppByID(ctx context.Context, appID string) (*App, error)
+	GetAppByFullName(ctx context.Context, fullName string) (*App, error)
+	// ChartsForApp returns the charts composing appID, for GetAppResponse.
+	ChartsForApp(ctx context.Context, appID string) ([]Chart, error)
+
+	ListCharts(ctx context.Context, filter ChartListFilter) ([]Chart, error)
+	GetChartByID(ctx context.Context, chartID string) (*Chart, error)
+	GetChartByFullName(ctx context.Context, fullName string) (*Chart, error)
+
+	// SetAppStatus is the human-triage path. status must be StatusActive or
+	// StatusArchived. Transitioning to StatusActive is rejected with
+	// ErrFailedPrecondition unless appID was present in the most recent
+	// Reconcile call — see postgres implementation for how presence is
+	// derived without a schema change.
+	SetAppStatus(ctx context.Context, appID string, status Status, reason string) (*App, error)
+}
+
+// BuildRepository covers the `build` table.
+type BuildRepository interface {
+	// RecordBuild upserts on the (workflow_run_id, workflow_attempt) unique
+	// constraint and reports whether the row already existed.
+	RecordBuild(ctx context.Context, b Build) (*Build, bool, error)
+	GetBuild(ctx context.Context, buildID string) (*Build, error)
+}
+
+// ArtifactRepository covers `artifact` and `artifact_link`.
+type ArtifactRepository interface {
+	// RecordArtifact inserts an artifact, or — if one with the same digest
+	// already exists — returns it unchanged with alreadyRecorded=true (the
+	// digest is the natural key; this mirrors BuildRepository.RecordBuild).
+	// For kind == chart, every entry in contains must already be recorded
+	// (matched by digest) or the call fails with ErrInvalidArgument — a
+	// chart may not pin an unknown artifact.
+	RecordArtifact(ctx context.Context, a Artifact, contains []ContainedImageInput) (artifact *Artifact, alreadyRecorded bool, err error)
+
+	ListArtifacts(ctx context.Context, filter ArtifactListFilter) ([]Artifact, error)
+	GetArtifact(ctx context.Context, lookup ArtifactLookup) (*Artifact, error)
+
+	// ResolveArtifact walks a chart artifact to its pinned image artifacts
+	// and their originating builds. lookup identifies the chart artifact by
+	// artifact_id or digest.
+	ResolveArtifact(ctx context.Context, lookup ArtifactLookup) (artifact *Artifact, images []Artifact, builds []Build, err error)
+}
+
+// IdempotencyRepository stores key -> serialized response for write RPCs.
+// See ARCHITECTURE.md "Idempotency".
+type IdempotencyRepository interface {
+	// Get returns the stored response bytes for key, if present.
+	Get(ctx context.Context, key string) (response []byte, found bool, err error)
+	// Put stores key -> response. Called only after the write it guards has
+	// succeeded, in the same transaction (see Registry.WithTx).
+	Put(ctx context.Context, key, method string, response []byte) error
+}
+
+// Registry aggregates the per-entity repositories and provides a
+// unit-of-work boundary. Handlers call WithTx to make a business operation
+// (reconcile, idempotency check-and-store, etc.) atomic: fn receives a
+// Registry bound to a single database transaction.
+type Registry interface {
+	Apps() AppRepository
+	Builds() BuildRepository
+	Artifacts() ArtifactRepository
+	Idempotency() IdempotencyRepository
+
+	WithTx(ctx context.Context, fn func(ctx context.Context, r Registry) error) error
+}


### PR DESCRIPTION
Phase AR-2a — server-side recording. The registry now knows what CI published.
Stacked on #496.

## Implemented

- **AppRegistry**: `ReconcileApps` (full replace — absent apps become `missing`, reappearing ones recover to `active`, `dry_run` writes nothing), `ListApps`, `GetApp`, `ListCharts`, `SetAppStatus`
- **ArtifactRegistry**: `RecordBuild`, `RecordArtifact`, `ListArtifacts`, `GetArtifact`, `ResolveArtifact`. A chart pinning an unrecorded image digest is rejected.
- **Idempotency**: the write and its `idempotency_key` row commit in one transaction; a replayed key returns the stored response without re-executing.
- **Promotability** derived on read from the owning app's `deploy_unit` — never stored, never computed client-side.
- `AllocateVersion` intentionally left `Unimplemented` (AR-5).

Three layers: repository interfaces + unit-of-work, a pgx implementation, and an in-memory fake.

## Verified against real Postgres

Deployed to a local Kubernetes cluster via Tilt and driven through `grpcurl` — the pgx layer has no automated coverage (see caveat below), so this was done by hand:

| Check | Result |
|---|---|
| Reconcile create → absent marks `missing` → reappear recovers `active` | correct, confirmed in psql |
| Idempotent replay | returns original response, **no double-write** (row count checked) |
| Promotability for `DEPLOY_UNIT_IMAGE` | `PROMOTABLE` |
| Chart pinning unrecorded digest | `InvalidArgument: chart pins unrecorded image digest sha256:...` |
| Duplicate `(owner, kind, version)` | `AlreadyExists: artifact manmanv2-host-manager v1.2.3 already recorded` |
| `SetAppStatus` active→archived | `FailedPrecondition: app manmanv2-control-api is active; only a missing app can be archived` |

## Two bugs the real-Postgres run caught that green tests did not

**1. Constraint violations surfaced as `Internal` with a leaked SQLSTATE.** The
index fired correctly, but `Internal` means "server bug" — callers would retry a
request that can never succeed, and AR-5's `AllocateVersion` needs to
distinguish "someone took this version" from "the server broke". Now mapped
centrally via `errors.As(*pgconn.PgError)`: `23505 → AlreadyExists`,
`23514 → InvalidArgument`, `23503 → FailedPrecondition`, with domain-terms
messages that never quote an index name or SQLSTATE.

**2. The duplicate-version message printed a raw UUID.** `ownerFullName` ran
*after* the failed INSERT — and a constraint violation aborts the surrounding
transaction, so the lookup failed and fell back to the UUID. Resolved before the
insert instead.

Neither was catchable by the fakes: they have no transactions, so the lookup
always succeeds and the test asserted a message production never emitted. The
fake now also enforces the same `(owner, kind, version)` uniqueness as
`artifact_version_idx`, so fake-based tests predict real behaviour.

## `SetAppStatus` simplified

Only `missing → archived` is legal; reconcile already handles recovery. The
`last_seen_at == MAX(last_seen_at)` heuristic that guarded the removed →ACTIVE
case is deleted outright. `archived → archived` is an idempotent no-op, which
makes the absent `idempotency_key` on `SetAppStatusRequest` moot.

## Coverage caveat — read before merging

`server/repository/postgres/*.go` **is not covered by any automated test.**
Handler logic is tested against the in-memory fake; the SQL is compile-checked
only. That follows existing repo precedent (`manmanv2` does the same), and the
manual verification above is what stands in for it today.

#498 (`libs/go/dbtest`) exists to close this properly — both bugs above are
exactly the class it would catch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)