### PR TITLE
AR-2b: compose-time chart image lockfile + AppManifestSet emission

### DIFF
--- a/tools/app_registry/ARCHITECTURE.md
+++ b/tools/app_registry/ARCHITECTURE.md
@@ -138,13 +138,31 @@ consolidation.
 
 ## Chart → image lockfile
 
-`tools/helm/composer.go` already resolves the exact image tags it bakes into a
-chart. It must additionally resolve them to **digests** and emit a lockfile that
-CI forwards to `RecordArtifact(kind = CHART, contains = [...])`.
+Resolving a chart's pinned images to **digests** requires a container registry
+call. A Bazel action must never make that call — it would break hermeticity
+and make chart output non-reproducible, undoing #dd23e807 (which specifically
+made chart builds deterministic). So this is two steps, split across two
+different environments, not one:
 
-Without this, chart promotion cannot answer "which image digest is running",
-and the incident query degrades to rendering charts by hand. This is the
-highest-value part of the recording phase and should not be deferred.
+1. **Compose time (hermetic, no network).** `tools/helm/composer.go` already
+   resolves the exact image repository and tag it bakes into a chart's
+   `values.yaml`. As of AR-2b it additionally writes those same references —
+   full app name, repository, and tag — to `image-lockfile.json` alongside
+   `Chart.yaml` inside the generated chart. This is a pure function of the
+   `AppManifest`s the composer already reads: no digests, no registry access,
+   sorted for deterministic output. `tools/release_helper_go`'s
+   `read-chart-lockfile <chart-name>` command builds a chart and reads this
+   file back out, giving the release path a stable way to get at it without
+   re-deriving anything from the manifests.
+2. **Publish time (has registry access, not yet implemented — AR-2c).** After
+   `release-helm-charts`'s `needs: [plan-release, release, ...]` has pushed
+   every image, a CI step resolves each lockfile entry's repository+tag to a
+   digest and forwards the result to `RecordArtifact(kind = CHART, contains =
+   [...])`.
+
+Without step 2, chart promotion cannot answer "which image digest is
+running," and the incident query degrades to rendering charts by hand. This is
+the highest-value part of the recording phase and should not be deferred.
 
 The server rejects a chart artifact that references an image digest it has never
 recorded — a chart may not pin an unknown artifact.

--- a/tools/app_registry/PLAN.md
+++ b/tools/app_registry/PLAN.md
@@ -6,6 +6,67 @@ agents track execution in a `TODO-<PLAN_ID>.md` alongside this file (e.g.
 
 Read [ARCHITECTURE.md](ARCHITECTURE.md) before executing any phase.
 
+---
+
+## Current status
+
+*Last updated at the end of the AR-2b session. Nothing is merged — every phase
+below is an open PR, held deliberately.*
+
+| Phase | Branch | PR | State |
+|---|---|---|---|
+| AR-M | `ar-m-manifest-schema` | [#495](https://github.com/whale-net/everything/pull/495) | CI green, held |
+| AR-1 | `ar-1-foundations` | [#496](https://github.com/whale-net/everything/pull/496) | CI green, held |
+| AR-2a | `ar-2a-recording` | [#499](https://github.com/whale-net/everything/pull/499) | verified against real Postgres |
+| AR-2b | `ar-2b-lockfile` | [#500](https://github.com/whale-net/everything/pull/500) | verified, charts byte-identical |
+| — | `testcontainers-poc` | [#498](https://github.com/whale-net/everything/pull/498) | independent, off `main` |
+
+Stacked as `main → AR-M → AR-1 → AR-2a → AR-2b` (GitHub stack #501). #498 is
+independent of the stack.
+
+**Why nothing is merged:** the repo owner is deploying the registry and setting
+up its secrets first. AR-M is the only production-behaviour change in the stack
+and is the one worth watching a release cycle on. Note the circularity — AR-M
+cannot be exercised by a release until it is on `main`.
+
+**Merging #496 publishes two new images.** AR-1 adds `app-registry-api` and
+`app-registry-migration` as `release_app` targets, so `apps=all` will build and
+push them. That is intended (you need images to deploy) but is not gated by
+`APP_REGISTRY_CICD_OPT_IN`, which governs whether CI *calls* the registry, not
+whether the registry's own images are built.
+
+### Next up: AR-2c
+
+The remaining AR-2 slice, not started:
+- `.github/workflows/release.yml` — call the CLI after image and chart pushes,
+  every step gated on `if: vars.APP_REGISTRY_CICD_OPT_IN == 'true'`, and
+  `continue-on-error`. Resolve lockfile references to digests after push (AR-2b
+  emits references only — see [#500](https://github.com/whale-net/everything/pull/500)).
+- CLI read commands in `tools/app_registry/cli/`.
+
+Safe to build and merge before the registry is deployed: with the variable
+unset, CI makes no registry calls at all.
+
+### Carry-over items
+
+- **`server/repository/postgres/*.go` has no automated test coverage.** Handler
+  logic is tested against the in-memory fake; the SQL is compile-checked only.
+  Two real bugs (see #499) got through green tests because the fake has no
+  transactions. **Wiring `libs/go/dbtest` (#498) into this package is the
+  highest-value next testing task.**
+- **Auth is unimplemented.** Handlers check no claims; the Tiltfile runs
+  `GRPC_AUTH_MODE=none`. Fine for AR-2 (recording, CI service account), **not**
+  fine for AR-3, whose entire point is that a build credential cannot promote to
+  prod. Settle OIDC config before AR-3.
+- **Transaction-abort hazard for AR-3.** A failed statement aborts the
+  surrounding Postgres transaction, so any error-message or logging code that
+  queries afterwards silently degrades. This bit `RecordArtifact` once already;
+  AR-3's SCD2 close-and-open writes are transactional and will hit the same trap.
+- **Tilt is validated and documented** — see [TESTING.md](TESTING.md). It is the
+  only thing currently exercising the pgx layer.
+- `list-apps --format json` prints `deploy_unit` as an integer. Cosmetic; no CI
+  path reads it.
+
 ## Sequencing rationale
 
 Promotion tracking is additive and low-risk; replacing git-tag version

--- a/tools/app_registry/TOC.md
+++ b/tools/app_registry/TOC.md
@@ -1,8 +1,16 @@
 # App Registry — TOC
 
 gRPC service that records published artifacts and tracks per-environment
-promotion state. AR-1 (foundations) is landed: schema, server/CLI skeletons —
-no business logic yet, every RPC returns `Unimplemented`.
+promotion state.
+
+**Status: AR-2b complete, nothing merged.** Recording works end to end —
+`ReconcileApps`, `RecordBuild`/`RecordArtifact` and the chart image lockfile are
+implemented and verified against real Postgres. Promotions, environments and
+writeback (AR-3/AR-4) are still `Unimplemented`.
+
+All phases sit in open PRs, held while the service is deployed and its secrets
+configured. **See [PLAN.md](PLAN.md) → "Current status" for the branch/PR map,
+what is next, and the carry-over items** — start there when picking this up.
 
 ## Documents
 

--- a/tools/appmeta/README.md
+++ b/tools/appmeta/README.md
@@ -166,7 +166,8 @@ already disagreed.
    `manmanv2/host/DEPLOYMENT.md`). Every other app keeps the `"chart"`
    default.
 
-**Not yet done (out of AR-M's scope, tracked for AR-2):**
-
-5. `release_helper_go` emitting `AppManifestSet` for the registry's
-   `ReconcileApps` to consume directly.
+5. `release_helper_go manifest-set` emits `AppManifestSet` (apps + charts +
+   `git_sha` + `discovered_at`) via `protojson`, so enums serialize as names.
+   This is what AR-2c's registry recording step passes to `ReconcileApps`
+   directly — no conversion code, since discovery already decodes into
+   `appmetapb` types (AR-2b).

--- a/tools/helm/composer.go
+++ b/tools/helm/composer.go
@@ -1,6 +1,7 @@
 package helm
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -34,6 +35,37 @@ func GetImageTag(m *AppMetadata) string {
 		return m.Version
 	}
 	return "latest"
+}
+
+// LockfileFileName is the name of the compose-time image lockfile written
+// alongside Chart.yaml in every generated chart.
+const LockfileFileName = "image-lockfile.json"
+
+// ImageLock is one app's image reference as pinned by the chart at compose
+// time. Digests are deliberately absent: resolving a tag to a digest
+// requires a container registry call, which a Bazel action must never make
+// without breaking hermeticity (see docs/DOCKER.md and
+// tools/app_registry/ARCHITECTURE.md's "Chart -> image lockfile" section).
+// The publish-time step, run after images are pushed, resolves each entry's
+// repository+version to a digest and forwards it to
+// ArtifactRegistry.RecordArtifact — see AR-2c.
+type ImageLock struct {
+	// AppFullName is "<domain>-<name>", matching the values.yaml app key and
+	// the app registry's owner_full_name convention.
+	AppFullName string `json:"app_full_name"`
+	Domain      string `json:"domain"`
+	Name        string `json:"name"`
+	// Repository is the image reference without a tag (registry/org/repo).
+	Repository string `json:"repository"`
+	// Version is the tag baked into the chart's values.yaml (imageTag).
+	Version string `json:"version"`
+}
+
+// ChartLockfile is the compose-time lockfile emitted for a chart: every
+// image reference it pins, with no digests. See ImageLock for why.
+type ChartLockfile struct {
+	ChartName string      `json:"chart_name"`
+	Images    []ImageLock `json:"images"`
 }
 
 // HealthCheckConfig defines health check configuration
@@ -323,6 +355,12 @@ func (c *Composer) GenerateChart() error {
 		return fmt.Errorf("failed to generate values.yaml: %w", err)
 	}
 
+	// Generate the compose-time image lockfile (no digests, no network — see
+	// ChartLockfile).
+	if err := c.generateLockfile(chartDir); err != nil {
+		return fmt.Errorf("failed to generate image lockfile: %w", err)
+	}
+
 	// Generate Kubernetes resource templates
 	if err := c.generateResourceTemplates(templatesDir); err != nil {
 		return fmt.Errorf("failed to generate resource templates: %w", err)
@@ -486,6 +524,44 @@ func (c *Composer) generateValuesYaml(chartDir string) error {
 
 	if err := writeValuesYAML(f, valuesData); err != nil {
 		return fmt.Errorf("failed to write values.yaml: %w", err)
+	}
+
+	return nil
+}
+
+// generateLockfile writes the chart's compose-time image lockfile
+// (LockfileFileName) alongside Chart.yaml. Deterministic and hermetic: it is
+// a pure function of the manifests already loaded via LoadMetadata, sorted
+// by app full name so output does not depend on Go's randomized map/slice
+// iteration order (see dd23e807, which fixed this class of bug for
+// values.yaml). No digests are resolved here — see ImageLock.
+func (c *Composer) generateLockfile(chartDir string) error {
+	lock := ChartLockfile{
+		ChartName: c.config.ChartName,
+		Images:    make([]ImageLock, 0, len(c.apps)),
+	}
+	for _, app := range c.apps {
+		lock.Images = append(lock.Images, ImageLock{
+			AppFullName: fmt.Sprintf("%s-%s", app.Domain, app.Name),
+			Domain:      app.Domain,
+			Name:        app.Name,
+			Repository:  GetImage(app),
+			Version:     GetImageTag(app),
+		})
+	}
+	sort.Slice(lock.Images, func(i, j int) bool {
+		return lock.Images[i].AppFullName < lock.Images[j].AppFullName
+	})
+
+	data, err := json.MarshalIndent(lock, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal image lockfile: %w", err)
+	}
+	data = append(data, '\n')
+
+	outputFile := filepath.Join(chartDir, LockfileFileName)
+	if err := os.WriteFile(outputFile, data, 0644); err != nil {
+		return fmt.Errorf("failed to write image lockfile: %w", err)
 	}
 
 	return nil

--- a/tools/helm/composer_test.go
+++ b/tools/helm/composer_test.go
@@ -710,23 +710,23 @@ func TestBuildAppConfig_InternalAPIExposeIngress(t *testing.T) {
 	composer := NewComposer(config, "/templates")
 
 	tests := []struct {
-		name               string
-		appType            string
+		name                string
+		appType             string
 		expectExposeIngress bool
 	}{
 		{
-			name:               "Internal API defaults to exposeIngress false",
-			appType:            "internal-api",
+			name:                "Internal API defaults to exposeIngress false",
+			appType:             "internal-api",
 			expectExposeIngress: false,
 		},
 		{
-			name:               "External API has exposeIngress false",
-			appType:            "external-api",
+			name:                "External API has exposeIngress false",
+			appType:             "external-api",
 			expectExposeIngress: false,
 		},
 		{
-			name:               "Worker has exposeIngress false",
-			appType:            "worker",
+			name:                "Worker has exposeIngress false",
+			appType:             "worker",
 			expectExposeIngress: false,
 		},
 	}
@@ -871,39 +871,39 @@ func TestGenerateChart_Golden(t *testing.T) {
 	composer := NewComposer(config, "testdata/templates")
 	composer.apps = []*AppMetadata{
 		{
-			Name:        "api",
-			Domain:      "golden",
-			AppType:     "external-api",
-			Language:    "go",
-			Version:     "v1.2.3",
-			Registry:    "ghcr.io",
+			Name:         "api",
+			Domain:       "golden",
+			AppType:      "external-api",
+			Language:     "go",
+			Version:      "v1.2.3",
+			Registry:     "ghcr.io",
 			Organization: "whale-net",
-			RepoName:    "golden-api",
-			Port:        8080,
-			HealthCheck: &appmetapb.HealthCheck{Enabled: true, Path: "/healthz"},
-			Ingress:     &appmetapb.Ingress{Host: "api.golden.local", TlsSecretName: "golden-tls"},
+			RepoName:     "golden-api",
+			Port:         8080,
+			HealthCheck:  &appmetapb.HealthCheck{Enabled: true, Path: "/healthz"},
+			Ingress:      &appmetapb.Ingress{Host: "api.golden.local", TlsSecretName: "golden-tls"},
 		},
 		{
-			Name:     "worker",
-			Domain:   "golden",
-			AppType:  "worker",
-			Language: "python",
-			Version:  "v1.2.3",
-			Registry: "ghcr.io",
+			Name:         "worker",
+			Domain:       "golden",
+			AppType:      "worker",
+			Language:     "python",
+			Version:      "v1.2.3",
+			Registry:     "ghcr.io",
 			Organization: "whale-net",
-			RepoName: "golden-worker",
-			Command:  []string{"python3"},
-			Args:     []string{"-m", "golden.worker"},
+			RepoName:     "golden-worker",
+			Command:      []string{"python3"},
+			Args:         []string{"-m", "golden.worker"},
 		},
 		{
-			Name:     "migrate",
-			Domain:   "golden",
-			AppType:  "job",
-			Language: "go",
-			Version:  "v1.2.3",
-			Registry: "ghcr.io",
+			Name:         "migrate",
+			Domain:       "golden",
+			AppType:      "job",
+			Language:     "go",
+			Version:      "v1.2.3",
+			Registry:     "ghcr.io",
 			Organization: "whale-net",
-			RepoName: "golden-migrate",
+			RepoName:     "golden-migrate",
 		},
 	}
 
@@ -929,5 +929,132 @@ func TestGenerateChart_Golden(t *testing.T) {
 	}
 	if string(got) != string(want) {
 		t.Errorf("generated values.yaml does not match golden file %s.\n--- got ---\n%s\n--- want ---\n%s", goldenPath, got, want)
+	}
+}
+
+// TestGenerateLockfile_Golden renders the compose-time image lockfile from
+// the same fixed AppManifest fixtures as TestGenerateChart_Golden and
+// byte-compares it against a checked-in golden file. Guards two things at
+// once: the lockfile's shape, and that it never varies across builds of
+// identical inputs (Go map iteration is the historical hazard here — see
+// dd23e807).
+//
+// If the lockfile's shape legitimately changes, regenerate the golden file
+// by running this test with UPDATE_GOLDEN=1 and reviewing the diff.
+func TestGenerateLockfile_Golden(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "composer-lockfile-golden")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	config := ChartConfig{
+		ChartName:   "golden-chart",
+		Version:     "0.0.0-dev",
+		Environment: "production",
+		Namespace:   "golden-ns",
+		OutputDir:   tmpDir,
+	}
+	composer := NewComposer(config, "testdata/templates")
+	composer.apps = []*AppMetadata{
+		{
+			Name:         "api",
+			Domain:       "golden",
+			AppType:      "external-api",
+			Language:     "go",
+			Version:      "v1.2.3",
+			Registry:     "ghcr.io",
+			Organization: "whale-net",
+			RepoName:     "golden-api",
+			Port:         8080,
+			HealthCheck:  &appmetapb.HealthCheck{Enabled: true, Path: "/healthz"},
+			Ingress:      &appmetapb.Ingress{Host: "api.golden.local", TlsSecretName: "golden-tls"},
+		},
+		{
+			Name:         "worker",
+			Domain:       "golden",
+			AppType:      "worker",
+			Language:     "python",
+			Version:      "v1.2.3",
+			Registry:     "ghcr.io",
+			Organization: "whale-net",
+			RepoName:     "golden-worker",
+			Command:      []string{"python3"},
+			Args:         []string{"-m", "golden.worker"},
+		},
+		{
+			Name:         "migrate",
+			Domain:       "golden",
+			AppType:      "job",
+			Language:     "go",
+			Version:      "v1.2.3",
+			Registry:     "ghcr.io",
+			Organization: "whale-net",
+			RepoName:     "golden-migrate",
+		},
+	}
+
+	if err := composer.generateLockfile(tmpDir); err != nil {
+		t.Fatalf("generateLockfile failed: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(tmpDir, LockfileFileName))
+	if err != nil {
+		t.Fatalf("read generated image lockfile: %v", err)
+	}
+
+	goldenPath := "testdata/golden_image-lockfile.json"
+	if os.Getenv("UPDATE_GOLDEN") != "" {
+		if err := os.WriteFile(goldenPath, got, 0644); err != nil {
+			t.Fatalf("write golden file: %v", err)
+		}
+		t.Skip("UPDATE_GOLDEN set; wrote " + goldenPath)
+	}
+
+	want, err := os.ReadFile(goldenPath)
+	if err != nil {
+		t.Fatalf("read golden file (run with UPDATE_GOLDEN=1 to create it): %v", err)
+	}
+	if string(got) != string(want) {
+		t.Errorf("generated image lockfile does not match golden file %s.\n--- got ---\n%s\n--- want ---\n%s", goldenPath, got, want)
+	}
+}
+
+// TestGenerateLockfile_Deterministic builds the lockfile several times from
+// the same (deliberately unsorted) app slice and asserts byte-identical
+// output every time — the regression guard for Go's randomized map/slice
+// iteration order leaking into the emitted lockfile.
+func TestGenerateLockfile_Deterministic(t *testing.T) {
+	apps := []*AppMetadata{
+		{Name: "zeta", Domain: "demo", Registry: "ghcr.io", Organization: "whale-net", RepoName: "demo-zeta", Version: "v1.0.0"},
+		{Name: "alpha", Domain: "demo", Registry: "ghcr.io", Organization: "whale-net", RepoName: "demo-alpha", Version: "v1.0.0"},
+		{Name: "mid", Domain: "demo", Registry: "ghcr.io", Organization: "whale-net", RepoName: "demo-mid", Version: "v1.0.0"},
+	}
+
+	var results []string
+	for i := 0; i < 5; i++ {
+		tmpDir, err := os.MkdirTemp("", "composer-lockfile-det")
+		if err != nil {
+			t.Fatalf("Failed to create temp dir: %v", err)
+		}
+		defer os.RemoveAll(tmpDir)
+
+		config := ChartConfig{ChartName: "det-chart", Version: "0.0.0-dev", OutputDir: tmpDir}
+		composer := NewComposer(config, "testdata/templates")
+		composer.apps = apps
+
+		if err := composer.generateLockfile(tmpDir); err != nil {
+			t.Fatalf("generateLockfile failed: %v", err)
+		}
+		data, err := os.ReadFile(filepath.Join(tmpDir, LockfileFileName))
+		if err != nil {
+			t.Fatalf("read lockfile: %v", err)
+		}
+		results = append(results, string(data))
+	}
+
+	for i := 1; i < len(results); i++ {
+		if results[i] != results[0] {
+			t.Errorf("lockfile output not deterministic across runs: run 0 vs run %d differ\n--- run 0 ---\n%s\n--- run %d ---\n%s", i, results[0], i, results[i])
+		}
 	}
 }

--- a/tools/helm/testdata/golden_image-lockfile.json
+++ b/tools/helm/testdata/golden_image-lockfile.json
@@ -1,0 +1,26 @@
+{
+  "chart_name": "golden-chart",
+  "images": [
+    {
+      "app_full_name": "golden-api",
+      "domain": "golden",
+      "name": "api",
+      "repository": "ghcr.io/whale-net/golden-api",
+      "version": "v1.2.3"
+    },
+    {
+      "app_full_name": "golden-migrate",
+      "domain": "golden",
+      "name": "migrate",
+      "repository": "ghcr.io/whale-net/golden-migrate",
+      "version": "v1.2.3"
+    },
+    {
+      "app_full_name": "golden-worker",
+      "domain": "golden",
+      "name": "worker",
+      "repository": "ghcr.io/whale-net/golden-worker",
+      "version": "v1.2.3"
+    }
+  ]
+}

--- a/tools/release_helper_go/BUILD.bazel
+++ b/tools/release_helper_go/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     importpath = "github.com/whale-net/everything/tools/release_helper_go/cmd",
     deps = [
         "//tools/appmeta/proto:appmetapb",
+        "//tools/helm:helm_lib",
         "@com_github_spf13_cobra//:cobra",
         "@in_gopkg_yaml_v3//:yaml_v3",
         "@org_golang_google_protobuf//encoding/protojson",
@@ -30,6 +31,7 @@ go_test(
     srcs = glob(["cmd/*_test.go"]),
     embed = [":cmd"],
     deps = [
+        "//tools/helm:helm_lib",
         "@com_github_spf13_cobra//:cobra",
     ],
 )

--- a/tools/release_helper_go/cmd/build_helm.go
+++ b/tools/release_helper_go/cmd/build_helm.go
@@ -80,18 +80,12 @@ func newBuildHelmChartCmd() *cobra.Command {
 			}
 
 			// Build chart target
-			chartPkg := strings.TrimPrefix(chart.BazelTarget, "//")
-			chartPkg = chartPkg[:strings.Index(chartPkg, ":")]
-			chartTarget := "//" + chartPkg + ":" + strings.TrimPrefix(chart.ChartTarget, ":")
+			chartTarget, chartDir := chartOutputPaths(workspaceRoot, chart)
 
 			fmt.Fprintf(cmd.OutOrStdout(), "Building bazel target: %s\n", chartTarget)
 			if _, err := defaultBazel.Run("build", chartTarget); err != nil {
 				return fmt.Errorf("bazel build %s: %w", chartTarget, err)
 			}
-
-			// Find unpacked chart directory
-			publishedName := strings.TrimPrefix(chart.Name, "helm-")
-			chartDir := filepath.Join(workspaceRoot, "bazel-bin", chartPkg, chart.Name+"_chart", publishedName)
 
 			outDir := outputDir
 			if outDir == "" {
@@ -123,6 +117,22 @@ func newBuildHelmChartCmd() *cobra.Command {
 	cmd.Flags().StringVar(&bumpType, "bump", "patch", "Version bump type: major, minor, or patch")
 
 	return cmd
+}
+
+// chartOutputPaths derives the bazel target and unpacked output directory
+// for a discovered chart, matching how helm_chart in tools/helm/helm.bzl
+// names its outputs (see chart_parent_dir / published_chart_name there).
+// Shared by build-helm-chart and read-chart-lockfile so both agree on where
+// a built chart's files — including composer.go's image-lockfile.json —
+// land.
+func chartOutputPaths(workspaceRoot string, chart HelmChartMetadata) (chartTarget, chartDir string) {
+	chartPkg := strings.TrimPrefix(chart.BazelTarget, "//")
+	chartPkg = chartPkg[:strings.Index(chartPkg, ":")]
+	chartTarget = "//" + chartPkg + ":" + strings.TrimPrefix(chart.ChartTarget, ":")
+
+	publishedName := strings.TrimPrefix(chart.Name, "helm-")
+	chartDir = filepath.Join(workspaceRoot, "bazel-bin", chartPkg, chart.Name+"_chart", publishedName)
+	return chartTarget, chartDir
 }
 
 func findHelmChartByName(name string, charts []HelmChartMetadata) (HelmChartMetadata, error) {

--- a/tools/release_helper_go/cmd/chart_lockfile.go
+++ b/tools/release_helper_go/cmd/chart_lockfile.go
@@ -1,0 +1,68 @@
+package cmd
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/whale-net/everything/tools/helm"
+)
+
+// newReadChartLockfileCmd exposes the compose-time image lockfile
+// tools/helm/composer.go writes into every generated chart (see
+// helm.LockfileFileName / helm.ChartLockfile) to the release path, so AR-2c
+// can resolve digests for it after images are pushed and call
+// ArtifactRegistry.RecordArtifact without re-deriving what the chart pins.
+//
+// It does not talk to a registry and does not resolve digests — see
+// //tools/app_registry/ARCHITECTURE.md's "Chart -> image lockfile" section
+// for why that step is deliberately kept out of the hermetic Bazel action
+// that composes the chart.
+func newReadChartLockfileCmd() *cobra.Command {
+	var skipBuild bool
+
+	cmd := &cobra.Command{
+		Use:          "read-chart-lockfile <chart-name>",
+		Short:        "Print a built chart's compose-time image lockfile as JSON",
+		Args:         cobra.ExactArgs(1),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			chartName := args[0]
+			workspaceRoot, err := defaultWorkspaceRoot()
+			if err != nil {
+				return fmt.Errorf("workspace root: %w", err)
+			}
+
+			allCharts, err := ListAllHelmCharts(defaultBazel, defaultFS, workspaceRoot)
+			if err != nil {
+				return err
+			}
+			chart, err := findHelmChartByName(chartName, allCharts)
+			if err != nil {
+				return err
+			}
+
+			chartTarget, chartDir := chartOutputPaths(workspaceRoot, chart)
+
+			if !skipBuild {
+				fmt.Fprintf(cmd.ErrOrStderr(), "Building bazel target: %s\n", chartTarget)
+				if _, err := defaultBazel.Run("build", chartTarget); err != nil {
+					return fmt.Errorf("bazel build %s: %w", chartTarget, err)
+				}
+			}
+
+			lockfilePath := filepath.Join(chartDir, helm.LockfileFileName)
+			data, err := defaultFS.ReadFile(lockfilePath)
+			if err != nil {
+				return fmt.Errorf("read image lockfile at %s (build the chart first, or omit --skip-build): %w", lockfilePath, err)
+			}
+
+			fmt.Fprintln(cmd.OutOrStdout(), string(data))
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&skipBuild, "skip-build", false, "Read the lockfile from a previously built chart without rebuilding it")
+	return cmd
+}

--- a/tools/release_helper_go/cmd/chart_lockfile_test.go
+++ b/tools/release_helper_go/cmd/chart_lockfile_test.go
@@ -1,0 +1,106 @@
+package cmd
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/whale-net/everything/tools/helm"
+)
+
+func TestReadChartLockfile_BuildsAndPrints(t *testing.T) {
+	charts, fs, bazel := makeTestHelmCharts()
+	var target *fakeHelmChart
+	for i := range charts {
+		if charts[i].name == "helm-manmanv2-control-services" {
+			target = &charts[i]
+		}
+	}
+	if target == nil {
+		t.Fatal("fixture missing helm-manmanv2-control-services")
+	}
+
+	chartDir := filepath.Join(fakeWorkspaceRoot, "bazel-bin", target.pkg, target.name+"_chart", strings.TrimPrefix(target.name, "helm-"))
+	lockfileContent := `{"chart_name":"manmanv2-control-services","images":[]}`
+	fs.add(filepath.Join(chartDir, helm.LockfileFileName), []byte(lockfileContent))
+
+	// Register the bazel build call the command issues before reading.
+	bazel.calls = append(bazel.calls, fakeBazelCall{
+		argsContain: []string{"build", "//" + target.pkg + ":chart"},
+		output:      "",
+	})
+
+	withFS(fs, func() {
+		withBazel(bazel, func() {
+			withWorkspace(fakeWorkspaceRoot, func() {
+				stdout, _, err := runTest([]string{"read-chart-lockfile", "helm-manmanv2-control-services"})
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if !strings.Contains(stdout, lockfileContent) {
+					t.Errorf("expected lockfile content in output, got: %s", stdout)
+				}
+				var sawBuild bool
+				for _, call := range bazel.recorded {
+					if len(call) > 0 && call[0] == "build" {
+						sawBuild = true
+					}
+				}
+				if !sawBuild {
+					t.Error("expected a `bazel build` call before reading the lockfile")
+				}
+			})
+		})
+	})
+}
+
+func TestReadChartLockfile_SkipBuild(t *testing.T) {
+	charts, fs, bazel := makeTestHelmCharts()
+	var target *fakeHelmChart
+	for i := range charts {
+		if charts[i].name == "helm-manmanv2-control-services" {
+			target = &charts[i]
+		}
+	}
+	if target == nil {
+		t.Fatal("fixture missing helm-manmanv2-control-services")
+	}
+
+	chartDir := filepath.Join(fakeWorkspaceRoot, "bazel-bin", target.pkg, target.name+"_chart", strings.TrimPrefix(target.name, "helm-"))
+	lockfileContent := `{"chart_name":"manmanv2-control-services","images":[]}`
+	fs.add(filepath.Join(chartDir, helm.LockfileFileName), []byte(lockfileContent))
+
+	withFS(fs, func() {
+		withBazel(bazel, func() {
+			withWorkspace(fakeWorkspaceRoot, func() {
+				stdout, _, err := runTest([]string{"read-chart-lockfile", "helm-manmanv2-control-services", "--skip-build"})
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if !strings.Contains(stdout, lockfileContent) {
+					t.Errorf("expected lockfile content in output, got: %s", stdout)
+				}
+				for _, call := range bazel.recorded {
+					if len(call) > 0 && call[0] == "build" {
+						t.Errorf("--skip-build must not invoke `bazel build`, but recorded: %v", call)
+					}
+				}
+			})
+		})
+	})
+}
+
+func TestReadChartLockfile_UnknownChart(t *testing.T) {
+	_, fs, bazel := makeTestHelmCharts()
+
+	withFS(fs, func() {
+		withBazel(bazel, func() {
+			withWorkspace(fakeWorkspaceRoot, func() {
+				_, _, err := runTest([]string{"read-chart-lockfile", "no-such-chart", "--skip-build"})
+				if err == nil {
+					t.Fatal("expected error for unknown chart name")
+				}
+			})
+		})
+	})
+}

--- a/tools/release_helper_go/cmd/manifest_set.go
+++ b/tools/release_helper_go/cmd/manifest_set.go
@@ -1,0 +1,80 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/encoding/protojson"
+
+	appmetapb "github.com/whale-net/everything/tools/appmeta/proto"
+)
+
+// newManifestSetCmd discovers every releasable app and helm chart manifest
+// and emits them as a single appmetapb.AppManifestSet. This is the input
+// AR-2c's registry recording step passes to AppRegistry.ReconcileApps: no
+// conversion code is needed because ListAllApps/ListAllHelmCharts already
+// decode into appmetapb types (see //tools/appmeta/README.md, AR-M).
+func newManifestSetCmd() *cobra.Command {
+	var gitSHA string
+
+	cmd := &cobra.Command{
+		Use:   "manifest-set",
+		Short: "Emit the full discovered app/chart manifest set as an AppManifestSet",
+		Long: `Discovers every releasable app_metadata and helm_chart_metadata target via
+the same bazel query/cquery discovery ListAllApps and ListAllHelmCharts use
+for plan/plan-helm-release — which already excludes testonly fixtures — and
+emits the result as an appmetapb.AppManifestSet, marshaled with protojson so
+enums (e.g. deploy_unit) serialize as names rather than integers.
+
+This is what AR-2c pipes to AppRegistry.ReconcileApps: a full-replace set, so
+callers must not filter it before sending.`,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			workspaceRoot, err := defaultWorkspaceRoot()
+			if err != nil {
+				return fmt.Errorf("workspace root: %w", err)
+			}
+
+			apps, err := ListAllApps(defaultBazel, defaultFS, workspaceRoot)
+			if err != nil {
+				return err
+			}
+			charts, err := ListAllHelmCharts(defaultBazel, defaultFS, workspaceRoot)
+			if err != nil {
+				return err
+			}
+
+			sha := strings.TrimSpace(gitSHA)
+			if sha == "" {
+				sha, err = defaultGit.Run("rev-parse", "HEAD")
+				if err != nil {
+					return fmt.Errorf("resolve git sha (pass --git-sha to override): %w", err)
+				}
+				sha = strings.TrimSpace(sha)
+			}
+
+			set := &appmetapb.AppManifestSet{
+				GitSha:       sha,
+				DiscoveredAt: time.Now().Unix(),
+			}
+			for i := range apps {
+				set.Apps = append(set.Apps, apps[i].AppManifest)
+			}
+			for i := range charts {
+				set.Charts = append(set.Charts, charts[i].ChartManifest)
+			}
+
+			out, err := protojson.MarshalOptions{Multiline: true, Indent: "  "}.Marshal(set)
+			if err != nil {
+				return fmt.Errorf("marshal manifest set: %w", err)
+			}
+			fmt.Fprintln(cmd.OutOrStdout(), string(out))
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&gitSHA, "git-sha", "", "Commit SHA to record (default: git rev-parse HEAD)")
+	return cmd
+}

--- a/tools/release_helper_go/cmd/manifest_set_test.go
+++ b/tools/release_helper_go/cmd/manifest_set_test.go
@@ -1,0 +1,132 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+// buildFakeAppAndChartInfra combines buildFakeInfra and buildFakeHelmInfra's
+// fakes into one BazelRunner that answers both discovery sweeps, the way
+// manifest-set needs. Query calls are distinguished by which `kind(...)` they
+// request; cquery calls are distinguished by which provider's Starlark expr
+// they carry (AppMetadataInfo vs HelmChartMetadataInfo) — see
+// appMetadataStarlarkExpr / helmChartMetadataStarlarkExpr.
+func buildFakeAppAndChartInfra(apps []fakeApp, charts []fakeHelmChart) *fakeBazelRunner {
+	appQueryLines := make([]string, len(apps))
+	appCqueryLines := make([]string, len(apps))
+	for i, app := range apps {
+		plainLabel := "//" + app.pkg + ":" + app.targetSuffix
+		appQueryLines[i] = plainLabel
+		body := app.customJSON
+		if len(body) == 0 {
+			body = sampleMetaJSON(app.name, app.domain)
+		}
+		appCqueryLines[i] = "@@" + plainLabel + "\t" + string(body)
+	}
+
+	chartQueryLines := make([]string, len(charts))
+	chartCqueryLines := make([]string, len(charts))
+	for i, c := range charts {
+		plain := "//" + c.pkg + ":" + c.targetName
+		chartQueryLines[i] = plain
+		chartCqueryLines[i] = "@@" + plain + "\t" + string(sampleHelmMetaJSON(c.name, c.domain, c.apps))
+	}
+
+	return newFakeBazel(
+		fakeBazelCall{argsContain: []string{"query", "kind(app_metadata"}, argsNotContain: []string{"cquery"}, output: strings.Join(appQueryLines, "\n")},
+		fakeBazelCall{argsContain: []string{"query", "kind(helm_chart_metadata"}, argsNotContain: []string{"cquery"}, output: strings.Join(chartQueryLines, "\n")},
+		fakeBazelCall{argsContain: []string{"cquery", "AppMetadataInfo"}, output: strings.Join(appCqueryLines, "\n")},
+		fakeBazelCall{argsContain: []string{"cquery", "HelmChartMetadataInfo"}, output: strings.Join(chartCqueryLines, "\n")},
+	)
+}
+
+func TestManifestSet_ContainsAppsAndCharts(t *testing.T) {
+	apps := []fakeApp{
+		{pkg: "demo/hello_go", targetSuffix: "hello-go_metadata", name: "hello-go", domain: "demo"},
+	}
+	charts, _, _ := makeTestHelmCharts()
+	bazel := buildFakeAppAndChartInfra(apps, charts)
+	git := newFakeGit(fakeGitCall{argsContain: []string{"rev-parse", "HEAD"}, output: "deadbeefcafe"})
+
+	withFS(newFakeFS(), func() {
+		withBazel(bazel, func() {
+			withGit(git, func() {
+				withWorkspace(fakeWorkspaceRoot, func() {
+					stdout, _, err := runTest([]string{"manifest-set"})
+					if err != nil {
+						t.Fatalf("unexpected error: %v", err)
+					}
+					if !strings.Contains(stdout, `"name":  "hello-go"`) {
+						t.Errorf("expected app in output, got: %s", stdout)
+					}
+					if !strings.Contains(stdout, `"name":  "helm-manmanv2-control-services"`) {
+						t.Errorf("expected chart in output, got: %s", stdout)
+					}
+					if !strings.Contains(stdout, `"gitSha":  "deadbeefcafe"`) {
+						t.Errorf("expected gitSha from git rev-parse HEAD, got: %s", stdout)
+					}
+					if !strings.Contains(stdout, `"discoveredAt"`) {
+						t.Errorf("expected discoveredAt field, got: %s", stdout)
+					}
+				})
+			})
+		})
+	})
+}
+
+// TestManifestSet_EnumsSerializeAsNames guards the requirement that
+// deploy_unit (and any future enum field) round-trips through protojson as
+// its name, not its wire integer — encoding/json would silently emit the
+// integer instead.
+func TestManifestSet_EnumsSerializeAsNames(t *testing.T) {
+	apps := []fakeApp{
+		{
+			pkg: "manmanv2/host", targetSuffix: "host-manager_metadata", name: "host-manager", domain: "manmanv2",
+			customJSON: []byte(`{"name":"host-manager","domain":"manmanv2","language":"go","registry":"ghcr.io","organization":"whale-net","repo_name":"manmanv2-host-manager","version":"latest","deploy_unit":"DEPLOY_UNIT_IMAGE"}`),
+		},
+	}
+	bazel := buildFakeAppAndChartInfra(apps, nil)
+	git := newFakeGit(fakeGitCall{argsContain: []string{"rev-parse", "HEAD"}, output: "deadbeefcafe"})
+
+	withFS(newFakeFS(), func() {
+		withBazel(bazel, func() {
+			withGit(git, func() {
+				withWorkspace(fakeWorkspaceRoot, func() {
+					stdout, _, err := runTest([]string{"manifest-set"})
+					if err != nil {
+						t.Fatalf("unexpected error: %v", err)
+					}
+					if !strings.Contains(stdout, `"deployUnit":  "DEPLOY_UNIT_IMAGE"`) {
+						t.Errorf("expected deployUnit to serialize as its enum name, got: %s", stdout)
+					}
+					if strings.Contains(stdout, `"deployUnit":  2`) {
+						t.Errorf("deployUnit serialized as an integer, not a name: %s", stdout)
+					}
+				})
+			})
+		})
+	})
+}
+
+func TestManifestSet_GitSHAFlagOverridesGit(t *testing.T) {
+	bazel := buildFakeAppAndChartInfra(nil, nil)
+	// No git calls registered — if the command falls back to `git rev-parse`
+	// despite --git-sha being set, the fake errors and the test fails.
+	git := newFakeGit()
+
+	withFS(newFakeFS(), func() {
+		withBazel(bazel, func() {
+			withGit(git, func() {
+				withWorkspace(fakeWorkspaceRoot, func() {
+					stdout, _, err := runTest([]string{"manifest-set", "--git-sha", "explicit-sha"})
+					if err != nil {
+						t.Fatalf("unexpected error: %v", err)
+					}
+					if !strings.Contains(stdout, `"gitSha":  "explicit-sha"`) {
+						t.Errorf("expected explicit --git-sha to be used, got: %s", stdout)
+					}
+				})
+			})
+		})
+	})
+}

--- a/tools/release_helper_go/cmd/root.go
+++ b/tools/release_helper_go/cmd/root.go
@@ -39,5 +39,7 @@ func init() {
 		newBuildCmd(),
 		newReleaseMultiarchCmd(),
 		newCreateCombinedGithubReleaseCmd(),
+		newManifestSetCmd(),
+		newReadChartLockfileCmd(),
 	)
 }

--- a/tools/release_helper_go/cmd/testhelper_test.go
+++ b/tools/release_helper_go/cmd/testhelper_test.go
@@ -35,6 +35,8 @@ func newTestRoot() *cobra.Command {
 		newListAppsCmd(),
 		newListCmd(),
 		newChangesCmd(),
+		newManifestSetCmd(),
+		newReadChartLockfileCmd(),
 	)
 	return root
 }
@@ -58,7 +60,9 @@ type fakeFS struct {
 	existing map[string]bool   // extra paths that exist but have no content
 }
 
-func newFakeFS() *fakeFS { return &fakeFS{files: make(map[string][]byte), existing: make(map[string]bool)} }
+func newFakeFS() *fakeFS {
+	return &fakeFS{files: make(map[string][]byte), existing: make(map[string]bool)}
+}
 
 func (f *fakeFS) add(path string, content []byte) *fakeFS {
 	f.files[path] = content


### PR DESCRIPTION
Phase AR-2b — the producer side of chart→image recording. Stacked on #499.

## The hermeticity split

ARCHITECTURE.md previously said the composer resolves images "to digests at
publish time". Taken literally that puts a container-registry lookup inside a
Bazel action — which breaks hermeticity and would undo `dd23e807`, the commit
that made chart output deterministic in the first place.

Split in two instead:

- **Compose time (Bazel, hermetic, no network):** the composer emits
  `image-lockfile.json` listing image *references* — `app_full_name`, `domain`,
  `name`, `repository`, `version`. Pure function of the manifests it already
  reads.
- **Publish time (release workflow, AR-2c):** digests get resolved after images
  are pushed and passed to `RecordArtifact`. `release-helm-charts` already has
  `needs: [plan-release, release, ...]`, so images exist by then.

Docs corrected to describe this accurately.

## Changes

- `tools/helm/composer.go` writes `image-lockfile.json` beside `Chart.yaml`,
  sorted by `app_full_name`. It lands inside the chart directory, so it rides
  along in both the tree artifact and the packaged tarball with no `helm.bzl`
  change.
- `release_helper_go` gains `manifest-set` (emits `appmetapb.AppManifestSet` via
  **protojson**, so enums serialise as names — this is what AR-2c pipes to
  `ReconcileApps`) and `read-chart-lockfile`.

## Verification

- **Chart output byte-identical** across `//demo:all_types_chart`,
  `//demo:fastapi_chart`, `//manmanv2:manmanv2_chart` — the only difference is
  the new lockfile itself.
- **Deterministic**: identical `md5sum` across repeated clean builds
  (`366037d1...`), independently reproduced. Go map iteration is the known
  hazard in this file; `dd23e807` fixed exactly this class of bug here before.
- **Deliberate break**: reversing the sort comparator fails the golden test with
  `generated image lockfile does not match golden file`. Reverted.
- `bazel build //...` (444 targets) and `bazel test //tools/...` green.

## Left alone deliberately

`list-apps --format json` still prints `deploy_unit` as an integer — it marshals
a wrapper struct via `encoding/json`, so fixing it isn't a natural side effect
here. No CI path reads it; `manifest-set` is what AR-2c uses and it serialises
correctly (`"deployUnit": "DEPLOY_UNIT_IMAGE"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)