### PR TITLE
AR-3a: role model, auth enforcement, and CLI service-account credentials

### DIFF
--- a/libs/go/grpcauth/BUILD.bazel
+++ b/libs/go/grpcauth/BUILD.bazel
@@ -11,11 +11,11 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "@com_github_coreos_go_oidc_v3//oidc",
-        "@org_golang_x_oauth2//:oauth2",
-        "@org_golang_x_oauth2//clientcredentials",
         "@org_golang_google_grpc//:grpc",
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//metadata",
         "@org_golang_google_grpc//status",
+        "@org_golang_x_oauth2//:oauth2",
+        "@org_golang_x_oauth2//clientcredentials",
     ],
 )

--- a/libs/go/grpcauth/KEYCLOAK.md
+++ b/libs/go/grpcauth/KEYCLOAK.md
@@ -1,0 +1,305 @@
+# Keycloak setup for `grpcauth` — a step-by-step guide
+
+How to set up Keycloak so a Go service using `libs/go/grpcauth` can authenticate
+callers and authorize them by role. Written for someone who has a Keycloak
+instance running and has never configured a client before.
+
+This is the **reference pattern for service-to-service auth in this repo**. It is
+written generically; `app-registry` is used as the worked example throughout
+because it is the first service to use roles. Section
+["Applying this to a new service"](#applying-this-to-a-new-service) is the
+checklist to copy.
+
+---
+
+## 1. The mental model
+
+Five Keycloak concepts, and what each one does for you:
+
+| Keycloak thing | What it is | What it does here |
+|---|---|---|
+| **Realm** | An isolated tenant — its own users, roles, clients, signing keys | One realm per platform. The realm URL is your OIDC **issuer**. |
+| **Client** | An application that can obtain tokens | One client per *caller identity* — `app-registry-builder`, `app-registry-promoter-prod`, … |
+| **Service account** | A machine "user" that Keycloak attaches to a confidential client | How CI gets a token with no human involved (`grant_type=client_credentials`) |
+| **Realm role** | A named permission, global to the realm | What `grpcauth` reads to authorize. **This is the one that matters.** |
+| **Audience (`aud`)** | Which API a token is *for* | What `grpcauth` validates so a token minted for another service is rejected here |
+
+The flow, end to end:
+
+```
+GitHub Actions job
+  │  client_id + client_secret  (GitHub Environment secret)
+  ▼
+Keycloak token endpoint  ──►  JWT  { sub, aud: ["app-registry-api"],
+  │                                   realm_access.roles: ["app-registry-builder"] }
+  ▼
+gRPC call, Authorization: Bearer <JWT>
+  ▼
+app-registry-api
+  ├─ grpcauth interceptor: fetch JWKS from issuer, verify signature,
+  │  check aud == GRPC_OIDC_CLIENT_ID, put Claims in ctx
+  └─ handler: claims.Roles contains "app-registry-builder"? → allow
+```
+
+### Two gotchas that will cost you an afternoon
+
+Read these before clicking anything. Both are properties of
+[`auth.go`](auth.go), not of Keycloak.
+
+> **Gotcha 1 — `grpcauth` reads REALM roles only.**
+> It parses `realm_access.roles` from the token and nothing else. Keycloak also
+> has *client roles*, which land in `resource_access.<client-id>.roles` — those
+> are **invisible to `grpcauth`**. The admin console makes client roles just as
+> easy to create, and they will silently do nothing. Always use **Realm roles**.
+>
+> Because realm roles are global to the realm, **prefix them with the service
+> name** (`app-registry-builder`, not `builder`) or you will collide with
+> another service's roles later.
+
+> **Gotcha 2 — Keycloak does not put your API in `aud` by default.**
+> `grpcauth` verifies `aud` contains the server's `GRPC_OIDC_CLIENT_ID`. A
+> client-credentials token from a fresh Keycloak client has `aud: ["account"]`,
+> so **every call fails with `Unauthenticated` until you add an audience
+> mapper** (step 4). This is the single most common failure.
+
+---
+
+## 2. Decide your roles before you start
+
+Write the role table down first. Changing it later means re-editing every client.
+
+For `app-registry`, from [ARCHITECTURE.md](../../../tools/app_registry/ARCHITECTURE.md#authorization):
+
+| Realm role | Grants | Held by |
+|---|---|---|
+| `app-registry-builder` | `AppRegistry` writes, `ArtifactRegistry` writes | CI, all workflows |
+| `app-registry-promoter-dev` | `PromotionRegistry` writes, `dev` only | CI job targeting the `dev` GH Environment; humans |
+| `app-registry-promoter-stage` | `PromotionRegistry` writes, `stage` only | GH Environment `stage`; humans |
+| `app-registry-promoter-prod` | `PromotionRegistry` writes, `prod` only | GH Environment `prod`; a small human group |
+| `app-registry-admin` | `EnvironmentRegistry`, `SetAppStatus` | Humans only |
+| *(any authenticated)* | all reads | everyone with a valid token |
+
+**The security property this buys you:** the builder credential is a *different
+Keycloak client* from the promoter credentials, and its token simply does not
+carry a `promoter` role. A compromised build job cannot promote to prod, no
+matter what it does with the secret it holds.
+
+**Environment scoping comes from GitHub, not Keycloak.** The
+`app-registry-promoter-prod` client secret is stored as a secret on the GitHub
+**Environment** named `prod`. Only a workflow job that declares
+`environment: prod` can read it — and that declaration is what triggers your
+required reviewers. Keycloak just enforces what the role means once the token
+exists.
+
+---
+
+## 3. Create the API client (the audience)
+
+You need a client representing the **API being called**, so other clients can
+name it as their audience. It never logs in and holds no secret you use.
+
+1. Admin console → your realm → **Clients** → **Create client**
+2. Client type `OpenID Connect`, **Client ID**: `app-registry-api` → Next
+3. **Client authentication**: On. **Authorization**: Off.
+4. Authentication flow: **uncheck everything** — Standard flow, Direct access
+   grants, Service accounts roles. This client never obtains a token. → Next
+5. Leave URLs blank → **Save**
+
+That's it. Its only job is to be a name that shows up in the audience-mapper
+dropdown, and to be the value of `GRPC_OIDC_CLIENT_ID` on the server.
+
+> If you would rather not create this client, every audience mapper below has an
+> **Included Custom Audience** free-text field you can use instead. Creating the
+> client is better: it keeps the audience name from drifting via typo.
+
+## 4. Create a caller client (repeat per identity)
+
+Worked example: `app-registry-builder`. Repeat the whole section for
+`app-registry-promoter-dev`, `-stage`, `-prod`, and `app-registry-admin`.
+
+### 4a. Create the client
+
+1. **Clients** → **Create client**
+2. **Client ID**: `app-registry-builder` → Next
+3. **Client authentication**: **On** ← makes it confidential, i.e. it gets a
+   secret. Required for `client_credentials`.
+4. Authentication flow — check **Service accounts roles** only. Uncheck
+   Standard flow and Direct access grants: this identity is a machine, it must
+   not be able to do a browser login or a username/password grant. → Next
+5. Leave URLs blank → **Save**
+
+### 4b. Get the secret
+
+**Credentials** tab → copy **Client secret**. This is
+`GRPC_AUTH_CLIENT_SECRET`.
+
+Store it immediately in the right place (see step 6) — for promoter clients that
+means a **GitHub Environment** secret, not a repository secret. A repository
+secret is readable by any workflow and destroys the whole property you are
+building.
+
+### 4c. Create and assign the realm role
+
+First create the role once per realm:
+
+1. **Realm roles** → **Create role**
+2. **Role name**: `app-registry-builder`, description: what it grants → **Save**
+
+Then attach it to this client's service account:
+
+3. Back to **Clients** → `app-registry-builder` → **Service accounts roles** tab
+4. **Assign role** → change the filter dropdown to **Filter by realm roles**
+   ← *easy to miss; it defaults to client roles, which `grpcauth` ignores*
+5. Tick `app-registry-builder` → **Assign**
+
+### 4d. Add the audience mapper (do not skip)
+
+1. Still on the client → **Client scopes** tab
+2. Click the dedicated scope, named `app-registry-builder-dedicated`
+3. **Add mapper** → **By configuration** → **Audience**
+4. Fill in:
+   - **Name**: `app-registry-api-audience`
+   - **Included Client Audience**: `app-registry-api` (the client from step 3)
+   - **Add to access token**: **On**
+5. **Save**
+
+Now this client's tokens carry `aud: ["app-registry-api", "account"]` and the
+server will accept them.
+
+## 5. Human users
+
+Humans authenticate as themselves, not via a client secret.
+
+- **One person:** Users → select user → **Role mapping** → **Assign role** →
+  *Filter by realm roles* → assign.
+- **A team (preferred):** Groups → **Create group** e.g. `prod-promoters` →
+  the group's **Role mapping** tab → assign `app-registry-promoter-prod`. Then
+  add and remove people from the group. Membership changes need no role edits,
+  and the group is the thing you audit.
+
+Human tokens come from a normal interactive login through whatever client your
+CLI/UI uses, so that client also needs the audience mapper from step 4d.
+
+---
+
+## 6. Wire it up
+
+### Server — `app-registry-api`
+
+```bash
+GRPC_AUTH_MODE=oidc
+GRPC_OIDC_ISSUER=https://auth.example.com/realms/whale       # no trailing slash
+GRPC_OIDC_CLIENT_ID=app-registry-api                          # the expected aud
+```
+
+The server reaches the issuer's `/.well-known/openid-configuration` and JWKS
+endpoint **at startup and periodically after**. If Keycloak is unreachable at
+boot, `grpcauth.NewServerInterceptors` returns an error and the process exits —
+make sure network policy allows the pod to reach Keycloak.
+
+### CI — GitHub Actions
+
+```yaml
+jobs:
+  record:                       # builder identity — no environment needed
+    env:
+      GRPC_AUTH_MODE: oidc
+      GRPC_AUTH_TOKEN_URL: https://auth.example.com/realms/whale/protocol/openid-connect/token
+      GRPC_AUTH_CLIENT_ID: app-registry-builder
+      GRPC_AUTH_CLIENT_SECRET: ${{ secrets.APP_REGISTRY_BUILDER_SECRET }}
+
+  promote:
+    environment: prod           # ← this line is the access control
+    env:
+      GRPC_AUTH_MODE: oidc
+      GRPC_AUTH_TOKEN_URL: https://auth.example.com/realms/whale/protocol/openid-connect/token
+      GRPC_AUTH_CLIENT_ID: app-registry-promoter-prod
+      GRPC_AUTH_CLIENT_SECRET: ${{ secrets.APP_REGISTRY_PROMOTER_SECRET }}
+```
+
+Both jobs reference `secrets.APP_REGISTRY_PROMOTER_SECRET`-style names, but the
+promoter one resolves **only** inside the `prod` environment. Configure required
+reviewers on that environment and the promotion gate is a human approval.
+
+### Local development
+
+Leave `GRPC_AUTH_MODE=none` (the default). The server injects
+`Claims{Subject: "dev-user", Roles: ["admin"]}` and every check passes. **Client
+and server modes must match** — a `none` client against an `oidc` server fails
+every call with `Unauthenticated`.
+
+---
+
+## 7. Verify before you debug the app
+
+Get a token by hand. This isolates Keycloak problems from application problems.
+
+```bash
+TOKEN=$(curl -s -X POST \
+  https://auth.example.com/realms/whale/protocol/openid-connect/token \
+  -d grant_type=client_credentials \
+  -d client_id=app-registry-builder \
+  -d client_secret=<secret> | jq -r .access_token)
+
+# decode the payload (no verification — just to read it)
+echo "$TOKEN" | cut -d. -f2 | base64 -d 2>/dev/null | jq '{sub, aud, realm_access}'
+```
+
+You are looking for exactly this:
+
+```json
+{
+  "sub": "9f2c...",
+  "aud": ["app-registry-api", "account"],   ← step 4d worked
+  "realm_access": { "roles": ["app-registry-builder", "default-roles-whale"] }
+}                                            ↑ step 4c worked, and it is REALM roles
+```
+
+If `aud` is only `["account"]`, redo step 4d. If `realm_access.roles` lacks your
+role but `resource_access` has it, you assigned a client role — redo step 4c with
+the filter switched to **realm roles**.
+
+---
+
+## 8. Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Every call `Unauthenticated`, token looks fine | `aud` missing the API | Audience mapper, step 4d |
+| Every call `Unauthenticated`, no token sent | Client `GRPC_AUTH_MODE` unset/`none` while server is `oidc` | Set both to `oidc` |
+| Role checks fail, token has the role | Role is under `resource_access`, not `realm_access` | Re-assign as a **realm** role |
+| `unauthorized_client` from the token endpoint | Service accounts flow disabled, or client is public | Step 4a: Client authentication On, Service accounts roles checked |
+| `invalid_client` | Wrong secret, or secret rotated | Re-copy from the Credentials tab |
+| Server won't start, OIDC provider error | Issuer URL wrong or unreachable | Must be `https://host/realms/<realm>` exactly, no trailing slash; check egress from the pod |
+| Works locally, fails in cluster | Cluster can't reach Keycloak, or an internal issuer URL whose hostname doesn't match the `iss` claim | The issuer URL must match the `iss` in issued tokens *character for character* |
+| Token expires mid-long-job | Access token lifespan too short | `grpcauth`'s service-account dial option refreshes automatically; if you are calling the token endpoint by hand, refresh it yourself |
+
+---
+
+## Applying this to a new service
+
+The checklist, stripped of the example:
+
+1. **Define roles first**, prefixed with the service name. Fewer is better — a
+   role you cannot describe in one sentence should not exist.
+2. **One realm role per distinct permission level**, not per caller. Multiple
+   clients can hold the same role.
+3. **One Keycloak client per caller identity.** Split identities exactly where
+   you want a privilege boundary — the separation *is* the security control.
+4. Create an **API client** whose only purpose is to be the audience name.
+5. Per caller client: confidential + service accounts only → realm role →
+   **audience mapper**.
+6. Humans get roles via **groups**, never individually.
+7. Server: `GRPC_AUTH_MODE=oidc`, `GRPC_OIDC_ISSUER`, `GRPC_OIDC_CLIENT_ID` =
+   the API client id.
+8. Secrets for privileged identities go in **GitHub Environment** secrets with
+   required reviewers, never repository secrets.
+9. Verify with the curl in step 7 **before** touching application code.
+10. Enforce in handlers, and write a test that asserts the *low*-privilege role
+    is **rejected** — the negative test is the one that proves the boundary.
+
+## Related
+
+- [README.md](README.md) — `grpcauth` API, env vars, dial options
+- [auth.go](auth.go) — the verifier; `realm_access.roles` parsing lives here
+- [`tools/app_registry/ARCHITECTURE.md`](../../../tools/app_registry/ARCHITECTURE.md) — the role split this guide implements

--- a/libs/go/grpcauth/README.md
+++ b/libs/go/grpcauth/README.md
@@ -11,6 +11,11 @@ Go library for gRPC authentication/authorization in the manmanv2 platform. Provi
 
 Set `GRPC_AUTH_MODE` consistently across all components. A mismatch (e.g. server=oidc, client=none) causes `codes.Unauthenticated` on every call.
 
+**Setting up the Keycloak side — see [KEYCLOAK.md](KEYCLOAK.md).** Step-by-step
+realm/client/role configuration, the reference pattern for service-to-service
+auth in this repo, and the two gotchas that break every first attempt (roles must
+be *realm* roles; you must add an audience mapper).
+
 ## Usage
 
 ### Server — add interceptors

--- a/libs/go/grpcauth/README.md
+++ b/libs/go/grpcauth/README.md
@@ -44,6 +44,22 @@ if ok {
 }
 ```
 
+If your service uses service-prefixed role names (e.g. `app-registry-builder`
+rather than plain `admin`), set `ServerConfig.DevRoles` to the full list of
+roles your handlers check — otherwise `AuthModeNone`'s fake claims (which
+default to `Roles: ["admin"]`) satisfy none of them, and local/Tilt
+development breaks silently. See `tools/app_registry/server/main.go` for a
+worked example.
+
+Testing handlers directly (bypassing the interceptor) against injected
+claims:
+```go
+ctx := grpcauth.ContextWithClaims(context.Background(), &grpcauth.Claims{
+    Subject: "test-user",
+    Roles:   []string{"app-registry-builder"},
+})
+```
+
 ### Client — service account (Host, Log-Processor → API)
 
 Machine-to-machine: fetches a client credentials token once and auto-refreshes it.
@@ -137,6 +153,7 @@ type ServerConfig struct {
     Mode      AuthMode
     IssuerURL string
     ClientID  string
+    DevRoles  []string // AuthModeNone only; defaults to ["admin"]
 }
 
 type ClientConfig struct {

--- a/libs/go/grpcauth/auth.go
+++ b/libs/go/grpcauth/auth.go
@@ -32,6 +32,15 @@ type ServerConfig struct {
 	Mode      AuthMode
 	IssuerURL string // required for OIDC
 	ClientID  string // expected audience
+
+	// DevRoles overrides the roles carried by the fake Claims injected in
+	// AuthModeNone. Defaults to []string{"admin"} when left empty. Set this
+	// when a service's authorization checks use service-prefixed role names
+	// (e.g. "app-registry-builder") that plain "admin" would never satisfy —
+	// otherwise local/Tilt development and any dev-mode CI path silently fail
+	// every role check. Ignored in AuthModeOIDC, where roles come from the
+	// verified token.
+	DevRoles []string
 }
 
 // ClientConfig holds client-side auth configuration
@@ -50,6 +59,16 @@ type claimsKey struct{}
 func ClaimsFromContext(ctx context.Context) (*Claims, bool) {
 	claims, ok := ctx.Value(claimsKey{}).(*Claims)
 	return claims, ok
+}
+
+// ContextWithClaims returns a context carrying claims exactly as the server
+// interceptor would have set it. Exported so tests in other packages can
+// exercise authorization logic against handlers called directly (bypassing
+// NewServerInterceptors, e.g. against an in-memory fake repository) without
+// duplicating the unexported context key. See
+// tools/app_registry/server/auth for a worked example.
+func ContextWithClaims(ctx context.Context, claims *Claims) context.Context {
+	return context.WithValue(ctx, claimsKey{}, claims)
 }
 
 // oidcVerifier implements TokenVerifier using go-oidc

--- a/libs/go/grpcauth/interceptors.go
+++ b/libs/go/grpcauth/interceptors.go
@@ -23,9 +23,13 @@ func NewServerInterceptors(ctx context.Context, config ServerConfig) (grpc.Unary
 		verifier = v
 	}
 
+	devRoles := config.DevRoles
+	if len(devRoles) == 0 {
+		devRoles = []string{"admin"}
+	}
 	devClaims := &Claims{
 		Subject: "dev-user",
-		Roles:   []string{"admin"},
+		Roles:   devRoles,
 	}
 
 	unary := func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {

--- a/tools/app_registry/ARCHITECTURE.md
+++ b/tools/app_registry/ARCHITECTURE.md
@@ -202,19 +202,34 @@ exist. This is real scope — see AR-1 in [PLAN.md](PLAN.md).
 
 ## Authorization
 
-Enforced with `libs/go/grpcauth` (OIDC), split along the service boundary:
+Enforced with `libs/go/grpcauth` (Keycloak-issued OIDC service accounts, per
+[`KEYCLOAK.md`](../../libs/go/grpcauth/KEYCLOAK.md)), split along the service
+boundary. Role names are realm roles in Keycloak, service-prefixed, enforced
+in `server/auth`:
 
 | Role | Services | Credential |
 |---|---|---|
-| `builder` | `AppRegistry` (writes), `ArtifactRegistry` (writes) | GitHub Actions OIDC, unrestricted workflows |
-| `promoter` | `PromotionRegistry` (writes) | **Environment-scoped** GitHub OIDC subject, or a human's token |
-| `admin` | `EnvironmentRegistry`, `SetAppStatus` | Human only |
+| `app-registry-builder` | `AppRegistry` (writes), `ArtifactRegistry` (writes) | Keycloak service account, CI/all workflows |
+| `app-registry-promoter-dev` | `PromotionRegistry` (writes), `dev` only | Keycloak service account scoped to the `dev` GitHub Environment; humans |
+| `app-registry-promoter-stage` | `PromotionRegistry` (writes), `stage` only | Keycloak service account scoped to the `stage` GitHub Environment; humans |
+| `app-registry-promoter-prod` | `PromotionRegistry` (writes), `prod` only | Keycloak service account scoped to the `prod` GitHub Environment; a small human group |
+| `app-registry-admin` | `EnvironmentRegistry`, `SetAppStatus` | Human only |
 | reader | all reads | Any authenticated principal |
 
+Roles are flat and explicit — `app-registry-admin` does not imply
+`app-registry-builder` or any promoter role, and a promoter role for one
+environment does not imply another. A principal must hold literally every
+role a call requires; see `server/auth.Require`'s doc comment.
+
 **The critical constraint:** the credential every build job already holds must
-not be able to promote. Promotion workflows use a GitHub Environment-scoped OIDC
-subject so the `builder` token cannot self-promote. Per-environment
-`allowed_principals` narrows this further for prod.
+not be able to promote. Each identity is a *different Keycloak client*, so the
+builder token simply does not carry a promoter role — no matter what a
+compromised build job does with the secret it holds. **Environment scoping
+comes from GitHub, not Keycloak:** the `app-registry-promoter-prod` client
+secret lives on the GitHub Environment named `prod`, so only a workflow job
+declaring `environment: prod` can read it, and that declaration is what
+triggers required reviewers. Per-environment `allowed_principals` narrows this
+further.
 
 `reason` is required on promotions to any environment above rank 0.
 

--- a/tools/app_registry/ENV.md
+++ b/tools/app_registry/ENV.md
@@ -35,13 +35,45 @@ Standard `libs/go/logging` environment auto-detection also applies
 (`APP_NAME`, `APP_DOMAIN`, `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_*_DISABLED`,
 etc.) — see that package's doc comment for the full list.
 
+### Role model (AR-3a)
+
+Server-side enforcement lives in `server/auth`; see
+[`ARCHITECTURE.md`](ARCHITECTURE.md) "Authorization" for the role table and
+[`libs/go/grpcauth/KEYCLOAK.md`](../../libs/go/grpcauth/KEYCLOAK.md) for how
+to configure the Keycloak side. In short: `AppRegistry.ReconcileApps`,
+`ArtifactRegistry.RecordBuild`/`RecordArtifact` require
+`app-registry-builder`; `AppRegistry.SetAppStatus` requires
+`app-registry-admin`; all read RPCs require only that the caller is
+authenticated (any role). `EnvironmentRegistry`/`PromotionRegistry` stay
+`Unimplemented` until AR-3b/3c, but `server/auth.RequirePromoter` already
+exists for them to call unmodified.
+
+**`GRPC_AUTH_MODE=none` and local/CI dev claims:** `libs/go/grpcauth`'s
+dev-mode claims default to `Roles: ["admin"]`, which satisfies none of this
+service's `app-registry-*` role checks. `server/main.go` overrides this via
+`grpcauth.ServerConfig.DevRoles`, set to `server/auth.AllRoles()` — so in
+`none` mode (the Tiltfile default, and the default for any CI path that
+hasn't opted into `oidc`) every request is treated as holding every
+app-registry role, and local dev / the AR-2c CI recording path keep working
+unchanged. This only matters in `none` mode; `oidc` mode always uses the
+token's real roles.
+
 ## CLI (`app-registry`)
 
 | Variable | Default | Description |
 |----------|---------|--------------|
 | `APP_REGISTRY_ADDRESS` | `localhost:50051` | `app-registry-api` address; overridden by `--address` |
 | `GRPC_AUTH_MODE` | `none` | `none` or `oidc` — must match the server |
+| `GRPC_AUTH_TOKEN_URL` | `""` | Keycloak token endpoint; required when `GRPC_AUTH_MODE=oidc` (e.g. `https://auth.example.com/realms/whale/protocol/openid-connect/token`) |
+| `GRPC_AUTH_CLIENT_ID` | `""` | Keycloak service-account client ID (e.g. `app-registry-builder`); required when `GRPC_AUTH_MODE=oidc` |
+| `GRPC_AUTH_CLIENT_SECRET` | `""` | Keycloak service-account client secret; required when `GRPC_AUTH_MODE=oidc` |
 | `GRPC_USE_TLS` / `GRPC_TLS_SKIP_VERIFY` / `GRPC_CA_CERT_PATH` / `GRPC_TLS_SERVER_NAME` | — | TLS options — see `libs/go/grpcclient` |
+
+The CLI fetches and auto-refreshes a client-credentials token via
+`grpcauth.NewServiceAccountDialOption`, the same mechanism
+`manmanv2/host` and `manmanv2/log-processor` use to reach their API. See
+KEYCLOAK.md section 6 "CI — GitHub Actions" for the shape of a workflow job
+setting these four variables.
 
 ## Local Development (Tilt)
 

--- a/tools/app_registry/PLAN.md
+++ b/tools/app_registry/PLAN.md
@@ -26,8 +26,8 @@ The registry is being deployed to `dev` by the repo owner. `app-registry-api`
 and `app-registry-migration` images publish from `apps=all`.
 `APP_REGISTRY_CICD_OPT_IN` is still unset, so CI makes no registry calls.
 
-**Next up:** AR-2d (Postgres repository test coverage — the top carry-over item)
-then AR-3, which is blocked on settling auth.
+**Next up:** AR-3b (`EnvironmentRegistry`). AR-2d and AR-3a are done and stacked
+on top of `main`.
 
 ### AR-2c — merged
 
@@ -274,16 +274,40 @@ compress this — it is the phase that earns the trust AR-5 spends.
 
 **Goal:** promotion state is recorded and queryable. Still nothing consumes it.
 
-**Scope**
-- Implement `EnvironmentRegistry` (all RPCs); seed `dev`/`stage`/`prod`.
-- Implement `PromotionRegistry.Promote`, `Rollback`, `GetEnvironmentState`,
-  `ListPromotions`, `ListPromotionEvents`.
+**Split into a 4-PR stack**, auth first so the "a builder cannot promote" exit
+criterion is testable from the moment promotion exists:
+
+| PR | Scope |
+|---|---|
+| **AR-3a** | Auth only — role model, interceptor plumbing, enforcement on the RPCs that exist today, CLI service-account credentials. No promotion logic. |
+| **AR-3b** | `EnvironmentRegistry` (all RPCs), `dev`/`stage`/`prod` seeding, environment-scoped `allowed_principals`. |
+| **AR-3c** | `PromotionRegistry` — SCD2 close-and-open, event log, promotability enforcement, `allow_override` + drift reporting. |
+| **AR-3d** | CLI (`promote`, `rollback`, `status`, `history`, `diff`) and the human-triggered `promote.yml` workflow. |
+
+### Credential model (decided)
+
+**Keycloak service accounts**, not GitHub Actions OIDC. `libs/go/grpcauth`
+validates a single Keycloak-style issuer and reads roles from
+`realm_access.roles`; teaching it GitHub's issuer and `sub`-claim scoping is real
+scope in a library `manmanv2` also depends on, and is not worth it here.
+
+- One Keycloak client per caller identity: `app-registry-builder`,
+  `app-registry-promoter-{dev,stage,prod}`, `app-registry-admin`.
+- One realm role per identity, service-name-prefixed.
+- **Environment scoping comes from GitHub Environments**, not the token: the
+  `promoter-prod` client secret lives on the `prod` GitHub Environment, so only a
+  job declaring `environment: prod` can read it — and that declaration is what
+  triggers required reviewers. The builder credential is a different client whose
+  token carries no promoter role, so it cannot promote regardless.
+- **Setup guide: [`libs/go/grpcauth/KEYCLOAK.md`](../../libs/go/grpcauth/KEYCLOAK.md)**
+  — realm/client/role configuration step by step, and the reference pattern for
+  service-to-service auth in this repo.
+- Reconsider GitHub OIDC natively (secretless CI) only after this is proven.
+
+**Remaining scope**
 - SCD2 close-and-open in one transaction; promotion event log.
 - Promotability enforcement, including `allow_override` and drift reporting.
-- Environment-scoped authorization; `reason` required above rank 0.
-- CLI: `promote`, `rollback`, `status <env>`, `history`, `diff <env> <env>`.
-- A human-triggered `promote.yml` GitHub workflow using an
-  **environment-scoped OIDC subject**, distinct from the builder credential.
+- `reason` required above rank 0.
 
 **Exit criteria**
 - Promote/rollback round-trips correctly; `GetEnvironmentState --at <T>` returns

--- a/tools/app_registry/TOC.md
+++ b/tools/app_registry/TOC.md
@@ -3,15 +3,16 @@
 gRPC service that records published artifacts and tracks per-environment
 promotion state.
 
-**Status: AR-2c complete, nothing merged.** Recording works end to end —
-`ReconcileApps`, `RecordBuild`/`RecordArtifact` and the chart image lockfile are
-implemented and verified against real Postgres. The release workflow now calls
-the CLI's write path after image/chart pushes, gated behind
-`APP_REGISTRY_CICD_OPT_IN`. Promotions, environments and writeback (AR-3/AR-4)
-are still `Unimplemented`.
+**Status: AR-M through AR-2c merged to `main`; AR-3 (Promotion) underway.**
+Recording works end to end — `ReconcileApps`, `RecordBuild`/`RecordArtifact`
+and the chart image lockfile are implemented and verified against real
+Postgres. The release workflow calls the CLI's write path after image/chart
+pushes, gated behind `APP_REGISTRY_CICD_OPT_IN`. The registry is being
+deployed to `dev`. AR-3 is split into a 4-PR stack (auth, environments,
+promotions, CLI); environments and promotions stay `Unimplemented` until
+AR-3b/3c land.
 
-All phases sit in open PRs, held while the service is deployed and its secrets
-configured. **See [PLAN.md](PLAN.md) → "Current status" for the branch/PR map,
+**See [PLAN.md](PLAN.md) → "Current status" for the branch/PR map,
 what is next, and the carry-over items** — start there when picking this up.
 
 ## Documents
@@ -38,6 +39,7 @@ what is next, and the carry-over items** — start there when picking this up.
 
 ## Related
 
+- [`../../libs/go/grpcauth/KEYCLOAK.md`](../../libs/go/grpcauth/KEYCLOAK.md) — Keycloak setup for the role model enforced in `server/auth`; the reference pattern for service-to-service auth in this repo
 - [`../../docs/RELEASE.md`](../../docs/RELEASE.md) — the existing release system this registry indexes
 - [`../appmeta/README.md`](../appmeta/README.md) — **shared manifest schema** (`AppManifest`, `DeployUnit`); the registry consumes it rather than defining its own
 - [`../bazel/release.bzl`](../bazel/release.bzl) — `release_app` manifests, the source of app identity

--- a/tools/app_registry/TODO-AR-3a.md
+++ b/tools/app_registry/TODO-AR-3a.md
@@ -1,0 +1,63 @@
+# TODO-AR-3a — Auth
+
+Execution tracking for AR-3a (see [PLAN.md](PLAN.md) → "AR-3 — Promotion").
+Scope: role model and its enforcement on the RPCs that exist today, plus the
+plumbing AR-3b/3c build promotion logic on top of. No promotion/environment
+business logic.
+
+## Done
+
+- [x] `server/auth` package: role constants (`app-registry-builder`,
+      `app-registry-promoter-{dev,stage,prod}`, `app-registry-admin`,
+      matching KEYCLOAK.md exactly) + `Require`/`RequirePromoter`/
+      `RequireAuthenticated` helpers over `grpcauth.ClaimsFromContext`.
+      `codes.Unauthenticated` with no claims, `codes.PermissionDenied` with
+      the wrong role. Roles are flat — no implication between them,
+      documented on `Require`.
+- [x] Enforced on today's RPCs:
+      `AppRegistry.ReconcileApps`/`ArtifactRegistry.RecordBuild`/
+      `RecordArtifact` → `RoleBuilder`; `AppRegistry.SetAppStatus` →
+      `RoleAdmin`; `ListApps`/`GetApp`/`ListCharts`/`ListArtifacts`/
+      `GetArtifact`/`ResolveArtifact` → `RequireAuthenticated` only.
+- [x] `libs/go/grpcauth`: added `ServerConfig.DevRoles` (AuthModeNone dev
+      claims default to `["admin"]`, which satisfies none of
+      `app-registry-*`'s checks — app-registry's `main.go` overrides it with
+      `server/auth.AllRoles()`) and `ContextWithClaims` (exported so
+      handler tests can inject claims without an unexported context key).
+      Both additive/backward compatible — `manmanv2` unaffected.
+- [x] CLI (`cli/cmd/client.go`): wired `grpcauth.NewServiceAccountDialOption`
+      from `GRPC_AUTH_MODE`/`GRPC_AUTH_TOKEN_URL`/`GRPC_AUTH_CLIENT_ID`/
+      `GRPC_AUTH_CLIENT_SECRET`, same call shape as `manmanv2/host` and
+      `manmanv2/log-processor`. `GRPC_AUTH_MODE=none` (default) unchanged.
+- [x] `server/main_test.go`'s `startTestServer` now wires the real auth
+      interceptor (`AuthModeNone` + `DevRoles: registryauth.AllRoles()`),
+      matching production wiring in `main.go`, instead of no interceptor at
+      all.
+- [x] Docs: `ARCHITECTURE.md` Authorization section role names now match
+      KEYCLOAK.md; `ENV.md` documents the CLI's new auth vars and the
+      `DevRoles` local-dev fix; `TOC.md` links KEYCLOAK.md and its status
+      paragraph reflects AR-M–AR-2c merged / AR-3 underway.
+- [x] Tests: `server/auth/auth_test.go` (unit, the role-check logic itself)
+      and `server/handlers/authz_test.go` (per protected RPC: correct role
+      allowed, wrong role → `PermissionDenied`, no claims →
+      `Unauthenticated`). Existing `app_test.go`/`artifact_test.go` business
+      logic tests now run authenticated as `auth.AllRoles()` via a shared
+      `authedCtx()` helper — they were never about authorization and keep
+      exercising the same behavior as before this phase.
+
+## Verification
+
+```
+bazel test //tools/app_registry/... //libs/go/grpcauth/...   # 4/4 pass
+bazel build //tools/...                                       # green
+```
+
+## Explicitly not done (AR-3b/3c/3d)
+
+- `EnvironmentRegistry`/`PromotionRegistry` business logic — still
+  `Unimplemented`. `RequirePromoter(ctx, env)` already exists for AR-3b/3c to
+  call unmodified.
+- No changes to `.github/workflows/release.yml` — CI still runs with
+  `GRPC_AUTH_MODE` unset (`none`), which now works correctly because of the
+  `DevRoles` fix above. Wiring real Keycloak secrets into CI is out of scope
+  here; see KEYCLOAK.md section 6 for the shape when that lands.

--- a/tools/app_registry/cli/cmd/BUILD.bazel
+++ b/tools/app_registry/cli/cmd/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
     importpath = "github.com/whale-net/everything/tools/app_registry/cli/cmd",
     visibility = ["//visibility:public"],
     deps = [
+        "//libs/go/grpcauth",
         "//libs/go/grpcclient",
         "//tools/app_registry/protos:appregistrypb",
         "//tools/appmeta/proto:appmetapb",

--- a/tools/app_registry/cli/cmd/client.go
+++ b/tools/app_registry/cli/cmd/client.go
@@ -3,8 +3,10 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
+	"github.com/whale-net/everything/libs/go/grpcauth"
 	"github.com/whale-net/everything/libs/go/grpcclient"
 	pb "github.com/whale-net/everything/tools/app_registry/protos"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -26,7 +28,22 @@ type registryClient struct {
 }
 
 func newRegistryClient(ctx context.Context) (*registryClient, error) {
-	conn, err := grpcclient.NewClient(ctx, serverAddr)
+	authOpt, err := grpcauth.NewServiceAccountDialOption(grpcauth.ClientConfig{
+		Mode:         grpcauth.AuthMode(getEnv("GRPC_AUTH_MODE", "none")),
+		TokenURL:     os.Getenv("GRPC_AUTH_TOKEN_URL"),
+		ClientID:     os.Getenv("GRPC_AUTH_CLIENT_ID"),
+		ClientSecret: os.Getenv("GRPC_AUTH_CLIENT_SECRET"),
+		// RequireTransportSecurity left false: TLS is handled independently
+		// by grpcclient.NewClient via GRPC_USE_TLS (see ENV.md); this only
+		// controls whether PerRPCCredentials refuses to send the bearer
+		// token over a plaintext transport, same as manmanv2/host and
+		// manmanv2/log-processor.
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create auth dial option: %w", err)
+	}
+
+	conn, err := grpcclient.NewClient(ctx, serverAddr, authOpt)
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to app-registry-api at %s: %w", serverAddr, err)
 	}
@@ -42,6 +59,16 @@ func newRegistryClient(ctx context.Context) (*registryClient, error) {
 
 func (c *registryClient) Close() error {
 	return c.conn.Close()
+}
+
+// getEnv reads an environment variable, falling back to defaultValue when
+// unset or empty — matches the convention manmanv2/host and
+// manmanv2/log-processor use for their auth env vars.
+func getEnv(key, defaultValue string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return defaultValue
 }
 
 // printResponse formats a proto response per the --format flag. table is not

--- a/tools/app_registry/server/BUILD.bazel
+++ b/tools/app_registry/server/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "//libs/go/grpcauth",
         "//libs/go/logging",
         "//tools/app_registry/protos:appregistrypb",
+        "//tools/app_registry/server/auth",
         "//tools/app_registry/server/handlers",
         "//tools/app_registry/server/repository",
         "//tools/app_registry/server/repository/postgres",
@@ -55,7 +56,9 @@ go_test(
     srcs = ["main_test.go"],
     embed = [":api_lib"],
     deps = [
+        "//libs/go/grpcauth",
         "//tools/app_registry/protos:appregistrypb",
+        "//tools/app_registry/server/auth",
         "//tools/app_registry/server/repository/fake",
         "@org_golang_google_grpc//:grpc",
         "@org_golang_google_grpc//codes",

--- a/tools/app_registry/server/auth/BUILD.bazel
+++ b/tools/app_registry/server/auth/BUILD.bazel
@@ -1,0 +1,25 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "auth",
+    srcs = ["auth.go"],
+    importpath = "github.com/whale-net/everything/tools/app_registry/server/auth",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//libs/go/grpcauth",
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//status",
+    ],
+)
+
+go_test(
+    name = "auth_test",
+    size = "small",
+    srcs = ["auth_test.go"],
+    embed = [":auth"],
+    deps = [
+        "//libs/go/grpcauth",
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//status",
+    ],
+)

--- a/tools/app_registry/server/auth/auth.go
+++ b/tools/app_registry/server/auth/auth.go
@@ -1,0 +1,86 @@
+// Package auth implements the App Registry's role model and its enforcement,
+// on top of libs/go/grpcauth. See ../../../../libs/go/grpcauth/KEYCLOAK.md
+// for the Keycloak-side design this package assumes (realm roles only,
+// service-name-prefixed) and ../../ARCHITECTURE.md "Authorization" for the
+// role table.
+package auth
+
+import (
+	"context"
+
+	"github.com/whale-net/everything/libs/go/grpcauth"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// Realm role names, exactly as configured in Keycloak — see KEYCLOAK.md
+// section 2 "Decide your roles before you start". Keep these in sync with
+// ARCHITECTURE.md's Authorization table; both must match the Keycloak realm
+// role names character for character or every check silently fails.
+const (
+	RoleBuilder       = "app-registry-builder"
+	RolePromoterDev   = "app-registry-promoter-dev"
+	RolePromoterStage = "app-registry-promoter-stage"
+	RolePromoterProd  = "app-registry-promoter-prod"
+	RoleAdmin         = "app-registry-admin"
+)
+
+// AllRoles lists every role this service defines. Used to build the
+// AuthModeNone dev-claims override (see main.go) so local development and
+// dev-mode CI hold every role, and by tests that want an "authenticated as
+// everything" principal.
+func AllRoles() []string {
+	return []string{RoleBuilder, RolePromoterDev, RolePromoterStage, RolePromoterProd, RoleAdmin}
+}
+
+// Require returns nil if ctx's claims hold role, codes.Unauthenticated if
+// ctx carries no claims at all (the interceptor never ran, or auth mode is
+// misconfigured), and codes.PermissionDenied if the principal is
+// authenticated but lacks role.
+//
+// Roles are flat and explicit by design — no role implies another. admin
+// does NOT imply builder or promoter, and a promoter role does not imply
+// another environment's promoter role. A principal must hold literally
+// every role a call requires. This keeps "who can do what" answerable by
+// grep instead of by chasing an implication graph, and it is the property
+// KEYCLOAK.md's credential model relies on: a builder credential's token
+// simply does not carry a promoter role, so a compromised build job cannot
+// promote no matter what it does with the secret it holds.
+func Require(ctx context.Context, role string) error {
+	claims, ok := grpcauth.ClaimsFromContext(ctx)
+	if !ok {
+		return status.Error(codes.Unauthenticated, "request carries no credentials")
+	}
+	if !hasRole(claims, role) {
+		return status.Errorf(codes.PermissionDenied, "requires role %q", role)
+	}
+	return nil
+}
+
+// RequirePromoter maps an environment name to its promoter role
+// (app-registry-promoter-<env>) and requires it. AR-3b/3c call this
+// unmodified for PromotionRegistry writes — the whole point of doing auth
+// first is that this mapping needs no change once promotion logic exists.
+func RequirePromoter(ctx context.Context, env string) error {
+	return Require(ctx, "app-registry-promoter-"+env)
+}
+
+// RequireAuthenticated returns codes.Unauthenticated if ctx carries no
+// claims, and nil otherwise — no specific role is checked. For read RPCs,
+// which ARCHITECTURE.md's Authorization table opens to any authenticated
+// principal.
+func RequireAuthenticated(ctx context.Context) error {
+	if _, ok := grpcauth.ClaimsFromContext(ctx); !ok {
+		return status.Error(codes.Unauthenticated, "request carries no credentials")
+	}
+	return nil
+}
+
+func hasRole(claims *grpcauth.Claims, role string) bool {
+	for _, r := range claims.Roles {
+		if r == role {
+			return true
+		}
+	}
+	return false
+}

--- a/tools/app_registry/server/auth/auth_test.go
+++ b/tools/app_registry/server/auth/auth_test.go
@@ -1,0 +1,67 @@
+package auth
+
+import (
+	"context"
+	"testing"
+
+	"github.com/whale-net/everything/libs/go/grpcauth"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func ctxWithRoles(roles ...string) context.Context {
+	return grpcauth.ContextWithClaims(context.Background(), &grpcauth.Claims{
+		Subject: "test-user",
+		Roles:   roles,
+	})
+}
+
+func TestRequire_NoClaimsIsUnauthenticated(t *testing.T) {
+	err := Require(context.Background(), RoleBuilder)
+	if status.Code(err) != codes.Unauthenticated {
+		t.Fatalf("expected Unauthenticated with no claims, got %v", err)
+	}
+}
+
+func TestRequire_CorrectRoleAllowed(t *testing.T) {
+	err := Require(ctxWithRoles(RoleBuilder), RoleBuilder)
+	if err != nil {
+		t.Fatalf("expected nil error for a principal holding the role, got %v", err)
+	}
+}
+
+func TestRequire_WrongRoleIsPermissionDenied(t *testing.T) {
+	err := Require(ctxWithRoles(RolePromoterProd), RoleBuilder)
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("expected PermissionDenied for a principal lacking the role, got %v", err)
+	}
+}
+
+// TestRequire_AdminDoesNotImplyBuilder pins the "flat and explicit roles, no
+// implication" decision documented on Require: a principal holding only
+// RoleAdmin must still be rejected from a builder-only check.
+func TestRequire_AdminDoesNotImplyBuilder(t *testing.T) {
+	err := Require(ctxWithRoles(RoleAdmin), RoleBuilder)
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("expected admin-only claims to be rejected by a builder check, got %v", err)
+	}
+}
+
+func TestRequirePromoter_MapsEnvironmentToRole(t *testing.T) {
+	if err := RequirePromoter(ctxWithRoles(RolePromoterProd), "prod"); err != nil {
+		t.Fatalf("expected prod promoter to pass the prod check, got %v", err)
+	}
+	err := RequirePromoter(ctxWithRoles(RolePromoterDev), "prod")
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("expected dev promoter to be rejected from the prod check, got %v", err)
+	}
+}
+
+func TestRequireAuthenticated(t *testing.T) {
+	if err := RequireAuthenticated(context.Background()); status.Code(err) != codes.Unauthenticated {
+		t.Fatalf("expected Unauthenticated with no claims, got %v", err)
+	}
+	if err := RequireAuthenticated(ctxWithRoles()); err != nil {
+		t.Fatalf("expected any authenticated principal (even with no roles) to pass, got %v", err)
+	}
+}

--- a/tools/app_registry/server/handlers/BUILD.bazel
+++ b/tools/app_registry/server/handlers/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//tools/app_registry/protos:appregistrypb",
+        "//tools/app_registry/server/auth",
         "//tools/app_registry/server/repository",
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//status",
@@ -28,10 +29,13 @@ go_test(
     srcs = [
         "app_test.go",
         "artifact_test.go",
+        "authz_test.go",
     ],
     embed = [":handlers"],
     deps = [
+        "//libs/go/grpcauth",
         "//tools/app_registry/protos:appregistrypb",
+        "//tools/app_registry/server/auth",
         "//tools/app_registry/server/repository/fake",
         "//tools/appmeta/proto:appmetapb",
         "@org_golang_google_grpc//codes",

--- a/tools/app_registry/server/handlers/app.go
+++ b/tools/app_registry/server/handlers/app.go
@@ -7,6 +7,7 @@ import (
 	"context"
 
 	pb "github.com/whale-net/everything/tools/app_registry/protos"
+	"github.com/whale-net/everything/tools/app_registry/server/auth"
 	"github.com/whale-net/everything/tools/app_registry/server/repository"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -25,6 +26,9 @@ func NewAppServer(repo repository.Registry) *AppServer {
 }
 
 func (s *AppServer) ReconcileApps(ctx context.Context, req *pb.ReconcileAppsRequest) (*pb.ReconcileAppsResponse, error) {
+	if err := auth.Require(ctx, auth.RoleBuilder); err != nil {
+		return nil, err
+	}
 	if req.Manifests == nil {
 		return nil, status.Error(codes.InvalidArgument, "manifests is required")
 	}
@@ -76,6 +80,9 @@ func reconcileResultToPB(r *repository.ReconcileResult, dryRun bool) *pb.Reconci
 }
 
 func (s *AppServer) ListApps(ctx context.Context, req *pb.ListAppsRequest) (*pb.ListAppsResponse, error) {
+	if err := auth.RequireAuthenticated(ctx); err != nil {
+		return nil, err
+	}
 	apps, err := s.repo.Apps().ListApps(ctx, repository.AppListFilter{
 		Domain:     req.Domain,
 		Statuses:   appStatusesFromPB(req.Statuses),
@@ -91,6 +98,9 @@ func (s *AppServer) ListApps(ctx context.Context, req *pb.ListAppsRequest) (*pb.
 }
 
 func (s *AppServer) GetApp(ctx context.Context, req *pb.GetAppRequest) (*pb.GetAppResponse, error) {
+	if err := auth.RequireAuthenticated(ctx); err != nil {
+		return nil, err
+	}
 	app, err := s.lookupApp(ctx, req.AppId, req.FullName)
 	if err != nil {
 		return nil, mapRepoErr(err)
@@ -117,6 +127,9 @@ func (s *AppServer) lookupApp(ctx context.Context, appID, fullName string) (*rep
 }
 
 func (s *AppServer) ListCharts(ctx context.Context, req *pb.ListChartsRequest) (*pb.ListChartsResponse, error) {
+	if err := auth.RequireAuthenticated(ctx); err != nil {
+		return nil, err
+	}
 	charts, err := s.repo.Apps().ListCharts(ctx, repository.ChartListFilter{
 		Domain:   req.Domain,
 		Statuses: appStatusesFromPB(req.Statuses),
@@ -135,6 +148,9 @@ func (s *AppServer) ListCharts(ctx context.Context, req *pb.ListChartsRequest) (
 // automatically via its "recovered" path, so ACTIVE is not a legal target
 // here — see ARCHITECTURE.md "Triage".
 func (s *AppServer) SetAppStatus(ctx context.Context, req *pb.SetAppStatusRequest) (*pb.SetAppStatusResponse, error) {
+	if err := auth.Require(ctx, auth.RoleAdmin); err != nil {
+		return nil, err
+	}
 	if req.AppId == "" {
 		return nil, status.Error(codes.InvalidArgument, "app_id is required")
 	}

--- a/tools/app_registry/server/handlers/app_test.go
+++ b/tools/app_registry/server/handlers/app_test.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"context"
 	"testing"
 
 	pb "github.com/whale-net/everything/tools/app_registry/protos"
@@ -25,7 +24,7 @@ func oneApp(domain, name string) *appmetapb.AppManifest {
 // TestReconcileApps_FullLifecycle walks create -> update -> absent-marks-MISSING
 // -> reappear-recovers-ACTIVE, matching the AR-2a scope's required coverage.
 func TestReconcileApps_FullLifecycle(t *testing.T) {
-	ctx := context.Background()
+	ctx := authedCtx()
 	srv := NewAppServer(fake.New())
 
 	// 1. create
@@ -92,7 +91,7 @@ func TestReconcileApps_FullLifecycle(t *testing.T) {
 // without mutating the registry: a subsequent real reconcile still sees the
 // app as newly created.
 func TestReconcileApps_DryRunWritesNothing(t *testing.T) {
-	ctx := context.Background()
+	ctx := authedCtx()
 	srv := NewAppServer(fake.New())
 
 	dryResp, err := srv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
@@ -132,7 +131,7 @@ func TestReconcileApps_DryRunWritesNothing(t *testing.T) {
 // not re-execute the write — asserted by row count, per AR-2a's required
 // coverage.
 func TestReconcileApps_IdempotencyReplaysWithoutDoubleWrite(t *testing.T) {
-	ctx := context.Background()
+	ctx := authedCtx()
 	srv := NewAppServer(fake.New())
 
 	req := &pb.ReconcileAppsRequest{
@@ -169,7 +168,7 @@ func TestReconcileApps_IdempotencyReplaysWithoutDoubleWrite(t *testing.T) {
 // ChartManifest.apps (bare app names) to app IDs and fail the reconcile if
 // any is unknown."
 func TestReconcileApps_UnknownChartAppFailsWholeReconcile(t *testing.T) {
-	ctx := context.Background()
+	ctx := authedCtx()
 	srv := NewAppServer(fake.New())
 
 	_, err := srv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
@@ -196,7 +195,7 @@ func TestReconcileApps_UnknownChartAppFailsWholeReconcile(t *testing.T) {
 // TestReconcileApps_ChartComposesApps covers the happy path of resolving a
 // chart's bare app names to app_ids.
 func TestReconcileApps_ChartComposesApps(t *testing.T) {
-	ctx := context.Background()
+	ctx := authedCtx()
 	srv := NewAppServer(fake.New())
 
 	resp, err := srv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
@@ -221,7 +220,7 @@ func TestReconcileApps_ChartComposesApps(t *testing.T) {
 // human triggers through this RPC: missing -> archived. missing -> active
 // happens automatically via Reconcile's "recovered" path instead.
 func TestSetAppStatus_MissingToArchivedSucceeds(t *testing.T) {
-	ctx := context.Background()
+	ctx := authedCtx()
 	srv := NewAppServer(fake.New())
 
 	created, err := srv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
@@ -266,7 +265,7 @@ func TestSetAppStatus_MissingToArchivedSucceeds(t *testing.T) {
 // TestSetAppStatus_RejectsActiveToArchived covers the FailedPrecondition
 // path: an app must be MISSING before it can be archived.
 func TestSetAppStatus_RejectsActiveToArchived(t *testing.T) {
-	ctx := context.Background()
+	ctx := authedCtx()
 	srv := NewAppServer(fake.New())
 
 	created, err := srv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
@@ -294,7 +293,7 @@ func TestSetAppStatus_RejectsActiveToArchived(t *testing.T) {
 // at all" — dropped along with the last_seen_at heuristic that used to guard
 // it, since Reconcile's recovered path is the only way back to ACTIVE.
 func TestSetAppStatus_RejectsActiveTarget(t *testing.T) {
-	ctx := context.Background()
+	ctx := authedCtx()
 	srv := NewAppServer(fake.New())
 	_, err := srv.SetAppStatus(ctx, &pb.SetAppStatusRequest{
 		AppId: "x", Status: pb.AppStatus_APP_STATUS_ACTIVE, Reason: "manual reactivate",
@@ -305,7 +304,7 @@ func TestSetAppStatus_RejectsActiveTarget(t *testing.T) {
 }
 
 func TestSetAppStatus_RequiresReason(t *testing.T) {
-	ctx := context.Background()
+	ctx := authedCtx()
 	srv := NewAppServer(fake.New())
 	_, err := srv.SetAppStatus(ctx, &pb.SetAppStatusRequest{AppId: "x", Status: pb.AppStatus_APP_STATUS_ARCHIVED})
 	if status.Code(err) != codes.InvalidArgument {

--- a/tools/app_registry/server/handlers/artifact.go
+++ b/tools/app_registry/server/handlers/artifact.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	pb "github.com/whale-net/everything/tools/app_registry/protos"
+	"github.com/whale-net/everything/tools/app_registry/server/auth"
 	"github.com/whale-net/everything/tools/app_registry/server/repository"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -29,6 +30,9 @@ func NewArtifactServer(repo repository.Registry) *ArtifactServer {
 }
 
 func (s *ArtifactServer) RecordBuild(ctx context.Context, req *pb.RecordBuildRequest) (*pb.RecordBuildResponse, error) {
+	if err := auth.Require(ctx, auth.RoleBuilder); err != nil {
+		return nil, err
+	}
 	if req.WorkflowRunId == "" {
 		return nil, status.Error(codes.InvalidArgument, "workflow_run_id is required")
 	}
@@ -73,6 +77,9 @@ func (s *ArtifactServer) RecordBuild(ctx context.Context, req *pb.RecordBuildReq
 }
 
 func (s *ArtifactServer) RecordArtifact(ctx context.Context, req *pb.RecordArtifactRequest) (*pb.RecordArtifactResponse, error) {
+	if err := auth.Require(ctx, auth.RoleBuilder); err != nil {
+		return nil, err
+	}
 	if req.BuildId == "" {
 		return nil, status.Error(codes.InvalidArgument, "build_id is required")
 	}
@@ -150,6 +157,9 @@ func (s *ArtifactServer) resolveOwner(ctx context.Context, r repository.Registry
 }
 
 func (s *ArtifactServer) ListArtifacts(ctx context.Context, req *pb.ListArtifactsRequest) (*pb.ListArtifactsResponse, error) {
+	if err := auth.RequireAuthenticated(ctx); err != nil {
+		return nil, err
+	}
 	artifacts, err := s.repo.Artifacts().ListArtifacts(ctx, repository.ArtifactListFilter{
 		OwnerFullName:  req.OwnerFullName,
 		Kind:           artifactKindFromPB(req.Kind),
@@ -165,6 +175,9 @@ func (s *ArtifactServer) ListArtifacts(ctx context.Context, req *pb.ListArtifact
 }
 
 func (s *ArtifactServer) GetArtifact(ctx context.Context, req *pb.GetArtifactRequest) (*pb.GetArtifactResponse, error) {
+	if err := auth.RequireAuthenticated(ctx); err != nil {
+		return nil, err
+	}
 	lookup, err := artifactLookupFromGetRequest(req)
 	if err != nil {
 		return nil, err
@@ -200,6 +213,9 @@ func artifactLookupFromGetRequest(req *pb.GetArtifactRequest) (repository.Artifa
 var errMissingArtifactLookup = status.Error(codes.InvalidArgument, "artifact_id, digest, or owner_full_name+kind+version is required")
 
 func (s *ArtifactServer) ResolveArtifact(ctx context.Context, req *pb.ResolveArtifactRequest) (*pb.ResolveArtifactResponse, error) {
+	if err := auth.RequireAuthenticated(ctx); err != nil {
+		return nil, err
+	}
 	var lookup repository.ArtifactLookup
 	switch {
 	case req.ArtifactId != "":

--- a/tools/app_registry/server/handlers/artifact_test.go
+++ b/tools/app_registry/server/handlers/artifact_test.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"context"
 	"testing"
 
 	pb "github.com/whale-net/everything/tools/app_registry/protos"
@@ -19,7 +18,7 @@ func setup(t *testing.T) (*AppServer, *ArtifactServer, map[string]*pb.App) {
 	repo := fake.New()
 	appSrv := NewAppServer(repo)
 	artifactSrv := NewArtifactServer(repo)
-	ctx := context.Background()
+	ctx := authedCtx()
 
 	reconcile, err := appSrv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
 		Manifests: manifestSet([]*appmetapb.AppManifest{
@@ -48,7 +47,7 @@ func setup(t *testing.T) (*AppServer, *ArtifactServer, map[string]*pb.App) {
 
 func recordBuild(t *testing.T, srv *ArtifactServer, runID string) *pb.Build {
 	t.Helper()
-	resp, err := srv.RecordBuild(context.Background(), &pb.RecordBuildRequest{
+	resp, err := srv.RecordBuild(authedCtx(), &pb.RecordBuildRequest{
 		GitSha: "abc123", WorkflowRunId: runID, IdempotencyKey: runID + "-build",
 	})
 	if err != nil {
@@ -62,7 +61,7 @@ func recordBuild(t *testing.T, srv *ArtifactServer, runID string) *pb.Build {
 // charts always being PROMOTABLE.
 func TestRecordArtifact_PromotabilityDerivation(t *testing.T) {
 	_, artifactSrv, apps := setup(t)
-	ctx := context.Background()
+	ctx := authedCtx()
 	build := recordBuild(t, artifactSrv, "run-promo")
 
 	cases := []struct {
@@ -93,7 +92,7 @@ func TestRecordArtifact_PromotabilityDerivation(t *testing.T) {
 
 func TestRecordArtifact_ChartIsAlwaysPromotable(t *testing.T) {
 	_, artifactSrv, _ := setup(t)
-	ctx := context.Background()
+	ctx := authedCtx()
 	build := recordBuild(t, artifactSrv, "run-chart-promo")
 
 	imgResp, err := artifactSrv.RecordArtifact(ctx, &pb.RecordArtifactRequest{
@@ -125,7 +124,7 @@ func TestRecordArtifact_ChartIsAlwaysPromotable(t *testing.T) {
 // a chart artifact may not reference an image digest that was never recorded.
 func TestRecordArtifact_RejectsChartPinningUnrecordedImage(t *testing.T) {
 	_, artifactSrv, _ := setup(t)
-	ctx := context.Background()
+	ctx := authedCtx()
 	build := recordBuild(t, artifactSrv, "run-reject")
 
 	_, err := artifactSrv.RecordArtifact(ctx, &pb.RecordArtifactRequest{
@@ -155,7 +154,7 @@ func TestRecordArtifact_RejectsChartPinningUnrecordedImage(t *testing.T) {
 // does, so this test predicts real behaviour.
 func TestRecordArtifact_DuplicateOwnerKindVersionIsAlreadyExists(t *testing.T) {
 	_, artifactSrv, _ := setup(t)
-	ctx := context.Background()
+	ctx := authedCtx()
 	build := recordBuild(t, artifactSrv, "run-dup")
 
 	first := &pb.RecordArtifactRequest{
@@ -188,7 +187,7 @@ func TestRecordArtifact_DuplicateOwnerKindVersionIsAlreadyExists(t *testing.T) {
 // a chart artifact returns the correct pinned image artifacts and builds.
 func TestResolveArtifact_ReturnsImagesForChart(t *testing.T) {
 	_, artifactSrv, _ := setup(t)
-	ctx := context.Background()
+	ctx := authedCtx()
 	build := recordBuild(t, artifactSrv, "run-resolve")
 
 	img, err := artifactSrv.RecordArtifact(ctx, &pb.RecordArtifactRequest{
@@ -229,7 +228,7 @@ func TestResolveArtifact_ReturnsImagesForChart(t *testing.T) {
 // row, asserted by ListArtifacts count.
 func TestRecordArtifact_IdempotencyReplaysWithoutDoubleWrite(t *testing.T) {
 	_, artifactSrv, _ := setup(t)
-	ctx := context.Background()
+	ctx := authedCtx()
 	build := recordBuild(t, artifactSrv, "run-idem")
 
 	req := &pb.RecordArtifactRequest{
@@ -255,7 +254,7 @@ func TestRecordArtifact_IdempotencyReplaysWithoutDoubleWrite(t *testing.T) {
 
 func TestRecordBuild_IdempotencyReplaysWithoutDoubleWrite(t *testing.T) {
 	_, artifactSrv, _ := setup(t)
-	ctx := context.Background()
+	ctx := authedCtx()
 
 	req := &pb.RecordBuildRequest{GitSha: "abc", WorkflowRunId: "dup-run", IdempotencyKey: "dup-key"}
 	first, err := artifactSrv.RecordBuild(ctx, req)
@@ -273,7 +272,7 @@ func TestRecordBuild_IdempotencyReplaysWithoutDoubleWrite(t *testing.T) {
 
 func TestRecordArtifact_RejectsMissingIdempotencyKey(t *testing.T) {
 	_, artifactSrv, _ := setup(t)
-	ctx := context.Background()
+	ctx := authedCtx()
 	build := recordBuild(t, artifactSrv, "run-noidem")
 
 	_, err := artifactSrv.RecordArtifact(ctx, &pb.RecordArtifactRequest{
@@ -287,7 +286,7 @@ func TestRecordArtifact_RejectsMissingIdempotencyKey(t *testing.T) {
 
 func TestArtifactServer_AllocateVersionStillUnimplemented(t *testing.T) {
 	_, artifactSrv, _ := setup(t)
-	_, err := artifactSrv.AllocateVersion(context.Background(), &pb.AllocateVersionRequest{})
+	_, err := artifactSrv.AllocateVersion(authedCtx(), &pb.AllocateVersionRequest{})
 	if status.Code(err) != codes.Unimplemented {
 		t.Fatalf("expected Unimplemented, got %v", err)
 	}

--- a/tools/app_registry/server/handlers/authz_test.go
+++ b/tools/app_registry/server/handlers/authz_test.go
@@ -1,0 +1,279 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/whale-net/everything/libs/go/grpcauth"
+	pb "github.com/whale-net/everything/tools/app_registry/protos"
+	"github.com/whale-net/everything/tools/app_registry/server/auth"
+	"github.com/whale-net/everything/tools/app_registry/server/repository/fake"
+	appmetapb "github.com/whale-net/everything/tools/appmeta/proto"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// authedCtx returns a context authenticated as a principal holding every
+// app-registry role. The handler-behaviour tests in app_test.go and
+// artifact_test.go are not about authorization — they use this so business
+// logic keeps being exercised the same way it was before auth existed. The
+// authorization boundary itself is asserted by the tests in this file.
+func authedCtx() context.Context {
+	return ctxWithRoles(auth.AllRoles()...)
+}
+
+func ctxWithRoles(roles ...string) context.Context {
+	return grpcauth.ContextWithClaims(context.Background(), &grpcauth.Claims{
+		Subject: "test-user",
+		Roles:   roles,
+	})
+}
+
+func requireCode(t *testing.T, err error, want codes.Code, rpc string) {
+	t.Helper()
+	if status.Code(err) != want {
+		t.Fatalf("%s: expected %v, got %v", rpc, want, err)
+	}
+}
+
+// TestReconcileApps_Authorization covers AppRegistry.ReconcileApps, which
+// requires RoleBuilder per ARCHITECTURE.md's Authorization table.
+func TestReconcileApps_Authorization(t *testing.T) {
+	req := &pb.ReconcileAppsRequest{
+		Manifests:      manifestSet([]*appmetapb.AppManifest{oneApp("demo", "svc")}, nil),
+		IdempotencyKey: "authz-reconcile",
+	}
+
+	t.Run("correct role allowed", func(t *testing.T) {
+		srv := NewAppServer(fake.New())
+		_, err := srv.ReconcileApps(ctxWithRoles(auth.RoleBuilder), req)
+		if err != nil {
+			t.Fatalf("expected builder to be allowed, got %v", err)
+		}
+	})
+
+	t.Run("wrong role is PermissionDenied", func(t *testing.T) {
+		srv := NewAppServer(fake.New())
+		_, err := srv.ReconcileApps(ctxWithRoles(auth.RoleAdmin), req)
+		requireCode(t, err, codes.PermissionDenied, "ReconcileApps")
+	})
+
+	t.Run("no claims is Unauthenticated", func(t *testing.T) {
+		srv := NewAppServer(fake.New())
+		_, err := srv.ReconcileApps(context.Background(), req)
+		requireCode(t, err, codes.Unauthenticated, "ReconcileApps")
+	})
+}
+
+// TestSetAppStatus_Authorization covers AppRegistry.SetAppStatus, which
+// requires RoleAdmin. Builder does not imply admin — see auth.Require's doc
+// comment on the flat-roles decision.
+func TestSetAppStatus_Authorization(t *testing.T) {
+	newSrvWithMissingApp := func(t *testing.T) (*AppServer, string) {
+		t.Helper()
+		srv := NewAppServer(fake.New())
+		created, err := srv.ReconcileApps(ctxWithRoles(auth.RoleBuilder), &pb.ReconcileAppsRequest{
+			Manifests:      manifestSet([]*appmetapb.AppManifest{oneApp("demo", "svc")}, nil),
+			IdempotencyKey: "authz-setstatus-1",
+		})
+		if err != nil {
+			t.Fatalf("reconcile: %v", err)
+		}
+		if _, err := srv.ReconcileApps(ctxWithRoles(auth.RoleBuilder), &pb.ReconcileAppsRequest{
+			Manifests:      manifestSet(nil, nil),
+			IdempotencyKey: "authz-setstatus-2",
+		}); err != nil {
+			t.Fatalf("reconcile dropping svc: %v", err)
+		}
+		return srv, created.CreatedApps[0].AppId
+	}
+
+	req := func(appID string) *pb.SetAppStatusRequest {
+		return &pb.SetAppStatusRequest{AppId: appID, Status: pb.AppStatus_APP_STATUS_ARCHIVED, Reason: "cleanup"}
+	}
+
+	t.Run("correct role allowed", func(t *testing.T) {
+		srv, appID := newSrvWithMissingApp(t)
+		_, err := srv.SetAppStatus(ctxWithRoles(auth.RoleAdmin), req(appID))
+		if err != nil {
+			t.Fatalf("expected admin to be allowed, got %v", err)
+		}
+	})
+
+	t.Run("wrong role is PermissionDenied", func(t *testing.T) {
+		srv, appID := newSrvWithMissingApp(t)
+		// A builder-only principal — holds the role every other write RPC in
+		// this package requires, but not admin.
+		_, err := srv.SetAppStatus(ctxWithRoles(auth.RoleBuilder), req(appID))
+		requireCode(t, err, codes.PermissionDenied, "SetAppStatus")
+	})
+
+	t.Run("no claims is Unauthenticated", func(t *testing.T) {
+		srv, appID := newSrvWithMissingApp(t)
+		_, err := srv.SetAppStatus(context.Background(), req(appID))
+		requireCode(t, err, codes.Unauthenticated, "SetAppStatus")
+	})
+}
+
+// TestAppReads_RequireAuthenticationOnly covers ListApps, GetApp, and
+// ListCharts: any authenticated principal may call them, no specific role.
+func TestAppReads_RequireAuthenticationOnly(t *testing.T) {
+	srv := NewAppServer(fake.New())
+	reconciled, err := srv.ReconcileApps(ctxWithRoles(auth.RoleBuilder), &pb.ReconcileAppsRequest{
+		Manifests:      manifestSet([]*appmetapb.AppManifest{oneApp("demo", "svc")}, nil),
+		IdempotencyKey: "authz-reads",
+	})
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	appID := reconciled.CreatedApps[0].AppId
+
+	// A principal with an unrelated single role still passes — reads check
+	// authentication, not any particular role.
+	readerCtx := ctxWithRoles(auth.RolePromoterDev)
+
+	t.Run("ListApps", func(t *testing.T) {
+		if _, err := srv.ListApps(readerCtx, &pb.ListAppsRequest{}); err != nil {
+			t.Fatalf("expected any authenticated principal to list apps, got %v", err)
+		}
+		if _, err := srv.ListApps(context.Background(), &pb.ListAppsRequest{}); status.Code(err) != codes.Unauthenticated {
+			t.Fatalf("expected Unauthenticated with no claims, got %v", err)
+		}
+	})
+
+	t.Run("GetApp", func(t *testing.T) {
+		if _, err := srv.GetApp(readerCtx, &pb.GetAppRequest{AppId: appID}); err != nil {
+			t.Fatalf("expected any authenticated principal to get an app, got %v", err)
+		}
+		if _, err := srv.GetApp(context.Background(), &pb.GetAppRequest{AppId: appID}); status.Code(err) != codes.Unauthenticated {
+			t.Fatalf("expected Unauthenticated with no claims, got %v", err)
+		}
+	})
+
+	t.Run("ListCharts", func(t *testing.T) {
+		if _, err := srv.ListCharts(readerCtx, &pb.ListChartsRequest{}); err != nil {
+			t.Fatalf("expected any authenticated principal to list charts, got %v", err)
+		}
+		if _, err := srv.ListCharts(context.Background(), &pb.ListChartsRequest{}); status.Code(err) != codes.Unauthenticated {
+			t.Fatalf("expected Unauthenticated with no claims, got %v", err)
+		}
+	})
+}
+
+// TestRecordBuild_Authorization and TestRecordArtifact_Authorization cover
+// ArtifactRegistry's write RPCs, which require RoleBuilder. A promoter
+// credential — holding real power elsewhere in the system — must not be
+// able to record builds/artifacts; that is precisely the boundary
+// KEYCLOAK.md's credential model depends on.
+func TestRecordBuild_Authorization(t *testing.T) {
+	req := &pb.RecordBuildRequest{GitSha: "abc123", WorkflowRunId: "run-authz", IdempotencyKey: "authz-build"}
+
+	t.Run("correct role allowed", func(t *testing.T) {
+		srv := NewArtifactServer(fake.New())
+		_, err := srv.RecordBuild(ctxWithRoles(auth.RoleBuilder), req)
+		if err != nil {
+			t.Fatalf("expected builder to be allowed, got %v", err)
+		}
+	})
+
+	t.Run("wrong role is PermissionDenied", func(t *testing.T) {
+		srv := NewArtifactServer(fake.New())
+		_, err := srv.RecordBuild(ctxWithRoles(auth.RolePromoterProd), req)
+		requireCode(t, err, codes.PermissionDenied, "RecordBuild")
+	})
+
+	t.Run("no claims is Unauthenticated", func(t *testing.T) {
+		srv := NewArtifactServer(fake.New())
+		_, err := srv.RecordBuild(context.Background(), req)
+		requireCode(t, err, codes.Unauthenticated, "RecordBuild")
+	})
+}
+
+func TestRecordArtifact_Authorization(t *testing.T) {
+	newSrvWithBuild := func(t *testing.T) (*ArtifactServer, string) {
+		t.Helper()
+		srv := NewArtifactServer(fake.New())
+		appSrv := NewAppServer(fake.New())
+		_ = appSrv
+		build, err := srv.RecordBuild(ctxWithRoles(auth.RoleBuilder), &pb.RecordBuildRequest{
+			GitSha: "abc123", WorkflowRunId: "run-authz-artifact", IdempotencyKey: "authz-artifact-build",
+		})
+		if err != nil {
+			t.Fatalf("record build: %v", err)
+		}
+		return srv, build.Build.BuildId
+	}
+
+	req := func(buildID string) *pb.RecordArtifactRequest {
+		return &pb.RecordArtifactRequest{
+			BuildId: buildID, Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE,
+			OwnerFullName: "demo-svc", Digest: "sha256:authz", Version: "v1.0.0",
+			IdempotencyKey: "authz-record-artifact",
+		}
+	}
+
+	t.Run("wrong role is PermissionDenied", func(t *testing.T) {
+		srv, buildID := newSrvWithBuild(t)
+		// A promoter credential — real power elsewhere, not here.
+		_, err := srv.RecordArtifact(ctxWithRoles(auth.RolePromoterDev), req(buildID))
+		requireCode(t, err, codes.PermissionDenied, "RecordArtifact")
+	})
+
+	t.Run("no claims is Unauthenticated", func(t *testing.T) {
+		srv, buildID := newSrvWithBuild(t)
+		_, err := srv.RecordArtifact(context.Background(), req(buildID))
+		requireCode(t, err, codes.Unauthenticated, "RecordArtifact")
+	})
+
+	// The "correct role allowed" case for RecordArtifact is already covered
+	// end-to-end by artifact_test.go (owner resolution requires a real app),
+	// which now runs authenticated as auth.AllRoles() via authedCtx().
+}
+
+// TestArtifactReads_RequireAuthenticationOnly covers ListArtifacts,
+// GetArtifact, and ResolveArtifact: any authenticated principal, no
+// specific role.
+func TestArtifactReads_RequireAuthenticationOnly(t *testing.T) {
+	srv := NewArtifactServer(fake.New())
+	build, err := srv.RecordBuild(ctxWithRoles(auth.RoleBuilder), &pb.RecordBuildRequest{
+		GitSha: "abc123", WorkflowRunId: "run-authz-reads", IdempotencyKey: "authz-reads-build",
+	})
+	if err != nil {
+		t.Fatalf("record build: %v", err)
+	}
+
+	readerCtx := ctxWithRoles(auth.RolePromoterStage)
+
+	t.Run("ListArtifacts", func(t *testing.T) {
+		if _, err := srv.ListArtifacts(readerCtx, &pb.ListArtifactsRequest{}); err != nil {
+			t.Fatalf("expected any authenticated principal to list artifacts, got %v", err)
+		}
+		if _, err := srv.ListArtifacts(context.Background(), &pb.ListArtifactsRequest{}); status.Code(err) != codes.Unauthenticated {
+			t.Fatalf("expected Unauthenticated with no claims, got %v", err)
+		}
+	})
+
+	t.Run("GetArtifact", func(t *testing.T) {
+		_, err := srv.GetArtifact(readerCtx, &pb.GetArtifactRequest{ArtifactId: "nonexistent"})
+		if status.Code(err) == codes.Unauthenticated || status.Code(err) == codes.PermissionDenied {
+			t.Fatalf("expected authorization to pass (NotFound expected next), got %v", err)
+		}
+		_, err = srv.GetArtifact(context.Background(), &pb.GetArtifactRequest{ArtifactId: "nonexistent"})
+		if status.Code(err) != codes.Unauthenticated {
+			t.Fatalf("expected Unauthenticated with no claims, got %v", err)
+		}
+	})
+
+	t.Run("ResolveArtifact", func(t *testing.T) {
+		_, err := srv.ResolveArtifact(readerCtx, &pb.ResolveArtifactRequest{ArtifactId: "nonexistent"})
+		if status.Code(err) == codes.Unauthenticated || status.Code(err) == codes.PermissionDenied {
+			t.Fatalf("expected authorization to pass (NotFound expected next), got %v", err)
+		}
+		_, err = srv.ResolveArtifact(context.Background(), &pb.ResolveArtifactRequest{ArtifactId: "nonexistent"})
+		if status.Code(err) != codes.Unauthenticated {
+			t.Fatalf("expected Unauthenticated with no claims, got %v", err)
+		}
+	})
+
+	_ = build
+}

--- a/tools/app_registry/server/main.go
+++ b/tools/app_registry/server/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/whale-net/everything/libs/go/grpcauth"
 	"github.com/whale-net/everything/libs/go/logging"
 	pb "github.com/whale-net/everything/tools/app_registry/protos"
+	registryauth "github.com/whale-net/everything/tools/app_registry/server/auth"
 	"github.com/whale-net/everything/tools/app_registry/server/handlers"
 	"github.com/whale-net/everything/tools/app_registry/server/repository"
 	"github.com/whale-net/everything/tools/app_registry/server/repository/postgres"
@@ -61,11 +62,17 @@ func run() error {
 	repo := postgres.NewRepository(pool)
 	log.Println("Database connection established")
 
-	// Create auth interceptors
+	// Create auth interceptors. DevRoles matters only in AuthModeNone: it
+	// makes the injected dev Claims carry every app-registry role, not
+	// grpcauth's generic default of ["admin"] (which satisfies none of our
+	// service-prefixed role checks — see server/auth). Without this, local
+	// Tilt and any CI path running with GRPC_AUTH_MODE=none would fail every
+	// write RPC's role check. See ENV.md.
 	unaryInt, streamInt, err := grpcauth.NewServerInterceptors(ctx, grpcauth.ServerConfig{
 		Mode:      grpcauth.AuthMode(grpcAuthMode),
 		IssuerURL: grpcOIDCIssuer,
 		ClientID:  grpcOIDCClientID,
+		DevRoles:  registryauth.AllRoles(),
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create auth interceptors: %w", err)

--- a/tools/app_registry/server/main_test.go
+++ b/tools/app_registry/server/main_test.go
@@ -6,7 +6,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/whale-net/everything/libs/go/grpcauth"
 	pb "github.com/whale-net/everything/tools/app_registry/protos"
+	registryauth "github.com/whale-net/everything/tools/app_registry/server/auth"
 	"github.com/whale-net/everything/tools/app_registry/server/repository/fake"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -19,16 +21,30 @@ import (
 const bufSize = 1024 * 1024
 
 // startTestServer builds the real registerServices() wiring behind a
-// bufconn listener — no TCP port, no Postgres, no gRPC auth. This is the
-// exact registration surface run() uses in production; only the transport
-// and the (absent) DB pool differ, so a missing RegisterXxxServer call or a
-// health server that never flips to SERVING would be caught here exactly as
-// it would in the real binary.
+// bufconn listener — no TCP port, no Postgres. This is the exact
+// registration surface run() uses in production; only the transport and the
+// (absent) DB pool differ, so a missing RegisterXxxServer call or a health
+// server that never flips to SERVING would be caught here exactly as it
+// would in the real binary. The auth interceptor runs in AuthModeNone with
+// DevRoles set to every app-registry role, matching run()'s production
+// wiring (see main.go) — every RPC call below is implicitly authenticated
+// as a superuser, same as local Tilt.
 func startTestServer(t *testing.T) *grpc.ClientConn {
 	t.Helper()
 
+	unaryInt, streamInt, err := grpcauth.NewServerInterceptors(context.Background(), grpcauth.ServerConfig{
+		Mode:     grpcauth.AuthModeNone,
+		DevRoles: registryauth.AllRoles(),
+	})
+	if err != nil {
+		t.Fatalf("failed to create auth interceptors: %v", err)
+	}
+
 	lis := bufconn.Listen(bufSize)
-	grpcServer := grpc.NewServer()
+	grpcServer := grpc.NewServer(
+		grpc.ChainUnaryInterceptor(unaryInt),
+		grpc.ChainStreamInterceptor(streamInt),
+	)
 	registerServices(grpcServer, fake.New())
 
 	go func() {

--- a/tools/app_registry/server/repository/postgres/BUILD.bazel
+++ b/tools/app_registry/server/repository/postgres/BUILD.bazel
@@ -61,9 +61,11 @@ go_test(
     ],
     deps = [
         "//libs/go/dbtest",
+        "//libs/go/grpcauth",
         "//libs/go/migrate",
         "//tools/app_registry/migrate/schema",
         "//tools/app_registry/protos:appregistrypb",
+        "//tools/app_registry/server/auth",
         "//tools/app_registry/server/handlers",
         "//tools/app_registry/server/repository",
         "@com_github_jackc_pgx_v5//pgxpool",

--- a/tools/app_registry/server/repository/postgres/postgres_integration_test.go
+++ b/tools/app_registry/server/repository/postgres/postgres_integration_test.go
@@ -25,13 +25,26 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/whale-net/everything/libs/go/dbtest"
+	"github.com/whale-net/everything/libs/go/grpcauth"
 	"github.com/whale-net/everything/libs/go/migrate"
 	"github.com/whale-net/everything/tools/app_registry/migrate/schema"
+	"github.com/whale-net/everything/tools/app_registry/server/auth"
 	"github.com/whale-net/everything/tools/app_registry/server/handlers"
 	"github.com/whale-net/everything/tools/app_registry/server/repository"
 
 	pb "github.com/whale-net/everything/tools/app_registry/protos"
 )
+
+// authedCtx returns a context carrying a principal holding every app-registry
+// role, as the server interceptor would supply. Tests here exercise repository
+// and idempotency behaviour, not authorization -- the authorization checks
+// themselves are covered by server/auth and server/handlers/authz_test.go.
+func authedCtx() context.Context {
+	return grpcauth.ContextWithClaims(context.Background(), &grpcauth.Claims{
+		Subject: "integration-test",
+		Roles:   auth.AllRoles(),
+	})
+}
 
 // newTestRegistry starts a real Postgres container, applies the real
 // App Registry migrations (migrate/schema.Migrations, the same embed.FS the
@@ -188,7 +201,7 @@ func TestRecordArtifact_ChartLinkFailureRollsBackTransaction(t *testing.T) {
 // returned an equivalent result.
 func TestRecordBuild_IdempotencyKeyReplay_DoesNotDoubleWrite(t *testing.T) {
 	reg, pool := newTestRegistry(t)
-	ctx := context.Background()
+	ctx := authedCtx()
 	srv := handlers.NewArtifactServer(reg)
 
 	first, err := srv.RecordBuild(ctx, &pb.RecordBuildRequest{


### PR DESCRIPTION
Second layer of the AR-3 stack. **Auth only — no promotion or environment logic.** Those are AR-3b/3c.

Sequenced first so AR-3's exit criterion, "the builder credential is verifiably unable to promote", is testable from the moment promotion exists rather than retrofitted afterwards.

## Credential model

Keycloak service accounts, not GitHub Actions OIDC. `libs/go/grpcauth` validates a single Keycloak-style issuer and reads roles from `realm_access.roles`; teaching it GitHub's issuer and `sub`-claim scoping is real scope in a library manmanv2 also depends on.

Environment scoping comes from **GitHub Environments**, not the token: the `promoter-prod` client secret lives on the `prod` GitHub Environment, so only a job declaring `environment: prod` can read it — and that declaration is what triggers required reviewers. The builder is a separate Keycloak client whose token carries no promoter role, so a compromised build job cannot promote regardless of what it does with the secret it holds.

## What's here

- **`libs/go/grpcauth/KEYCLOAK.md`** (first commit) — step-by-step Keycloak setup, written to be the reference pattern for service-to-service auth in this repo. Documents the two gotchas that come from `auth.go` rather than Keycloak: roles must be *realm* roles (client roles land in `resource_access` where the library never looks), and an audience mapper is mandatory or every call 401s.
- **`server/auth`** — the five role constants, `Require` / `RequirePromoter(ctx, env)` / `RequireAuthenticated`. `RequirePromoter` is the seam AR-3b/3c call unmodified.
- Enforcement: builder for `ReconcileApps`/`RecordBuild`/`RecordArtifact`, admin for `SetAppStatus`, authenticated-only for reads.
- CLI service-account credentials from `GRPC_AUTH_TOKEN_URL`/`CLIENT_ID`/`CLIENT_SECRET`.

**Roles are flat — no implication.** admin does not imply builder; one promoter env does not imply another. Pinned by a test. Keeps "who can do what" answerable by grep, and it is the property the credential model rests on.

## Two things worth reviewer attention

1. **`GRPC_AUTH_MODE=none` now grants every app-registry role.** grpcauth's dev claims carry only `admin`, which satisfies none of the prefixed role checks — without this, Tilt and the AR-2c CI recording path would break. Fix is a new `ServerConfig.DevRoles`, defaulting to `["admin"]` so manmanv2 is unaffected. **Consequence: a deployed server left in `none` mode is wide open, and `none` is the default.** Worth deciding separately whether the server should refuse to start in `none` mode outside local dev.
2. **This changes a shared library.** `ContextWithClaims` and `DevRoles` were added to `libs/go/grpcauth` — the alternatives were duplicating an unexported context key and breaking local dev respectively.

## Testing

- `server/auth/auth_test.go` and `server/handlers/authz_test.go` — for every protected RPC: correct role allowed, **wrong role → `PermissionDenied`**, no claims → `Unauthenticated`. The negative cases are the point.
- `main_test.go` now wires the real interceptor; it previously had none, which would have silently masked auth regressions.
- `bazel test //tools/app_registry/... //libs/go/grpcauth/...` green; `bazel test //manmanv2/...` 18/18 green (the other grpcauth consumer); `bazel build //tools/...` green.
- The AR-2d Postgres integration test needed an authed context — caught by actually running it against the stacked result, not assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
