### PR TITLE
ci: run container-backed database tests in their own job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,77 @@ jobs:
         # Shutdown Bazel server to prevent hanging
         bazel shutdown
 
+  # Container-backed database tests - real Postgres via libs/go/dbtest
+  #
+  # These targets are tagged `manual`, so `bazel test //...` (the Test job above)
+  # deliberately skips them and stays green on a machine with no Docker daemon.
+  # That means nothing runs them unless a job like this one names them explicitly.
+  # See libs/go/dbtest/README.md.
+  #
+  # Targets are discovered by querying for tests that depend on //libs/go/dbtest,
+  # rather than hardcoding a list, so a new dbtest-backed test is covered the
+  # moment it is written. Runs in parallel with the test jobs above.
+  test-database:
+    name: Test Database Integration
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Setup Build Environment
+      uses: ./.github/actions/setup-build-env
+      with:
+        cache-suffix: 'ci'
+        setup-docker: 'true'
+        bazel-remote-cache-url: ${{ secrets.BAZEL_REMOTE_CACHE_URL }}
+        bazel-remote-cache-user: ${{ secrets.BAZEL_REMOTE_CACHE_USER }}
+        bazel-remote-cache-password: ${{ secrets.BAZEL_REMOTE_CACHE_PASSWORD }}
+
+    - name: Run container-backed database tests
+      run: |
+        set -euo pipefail
+
+        echo "::group::Discovering dbtest-backed targets"
+        # Scoped to the subtrees that can contain them; a bare //... fails to
+        # load unrelated external repositories in this workspace.
+        #
+        # No --config=ci here: only build:ci and test:ci are defined in
+        # .bazelrc, and `bazel query --config=ci` hard-errors with
+        # "Config value 'ci' is not defined in any .rc file".
+        SCOPE='//libs/... + //tools/... + //manmanv2/...'
+        TARGETS=$(bazel query \
+          "tests($SCOPE) intersect rdeps($SCOPE, //libs/go/dbtest:dbtest)" \
+          | tr '\n' ' ')
+        echo "Targets: ${TARGETS:-<none>}"
+        echo "::endgroup::"
+
+        # An empty result means the query broke, not that there is no work:
+        # //libs/go/dbtest:postgres_constraints_test always matches. Failing
+        # here is the point — a silently-empty run would report this job green
+        # while testing nothing.
+        if [ -z "${TARGETS// /}" ]; then
+          echo "::error::No dbtest-backed test targets found. The discovery query is broken - it should always match at least //libs/go/dbtest:postgres_constraints_test."
+          exit 1
+        fi
+
+        echo "::group::Database Integration Tests"
+        # No --test_tag_filters: combining it with explicit labels makes Bazel
+        # report "No test targets were found" (see libs/go/dbtest/README.md).
+        bazel test --config=ci $TARGETS --test_output=streamed
+        echo "::endgroup::"
+        bazel shutdown
+
+    - name: Upload test results
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: test-results-database
+        path: bazel-testlogs/
+        retention-days: 7
+
   # Plan Docker builds - determine which apps need building
   plan-docker:
     name: Plan Docker Builds

--- a/libs/go/dbtest/README.md
+++ b/libs/go/dbtest/README.md
@@ -121,21 +121,39 @@ OOM-killed) will leak the Postgres container instead of it being force-cleaned. 
 abnormal termination. Prefer leaving Ryuk enabled unless you hit a concrete failure that requires
 disabling it.
 
-## What a CI job needs
+## CI
 
-Mirror `//tools/scripts:test_cross_compilation`'s job (`setup-docker: 'true'`), then:
+**These tests already run in CI** — the `Test Database Integration` job in
+[`.github/workflows/ci.yml`](../../../.github/workflows/ci.yml). **You do not need to add
+anything to CI when you write a new dbtest-backed test.** The job discovers its targets by
+query rather than from a hardcoded list:
 
 ```bash
-bazel test //libs/go/dbtest:postgres_constraints_test --test_output=all
+SCOPE='//libs/... + //tools/... + //manmanv2/...'
+bazel query "tests($SCOPE) intersect rdeps($SCOPE, //libs/go/dbtest:dbtest)"
 ```
 
-- Docker must be available to the runner (the "Test Container Architecture" job's
-  `setup-docker: 'true'` step already provides this for other jobs in this repo).
+so any test that depends on this package is picked up the moment it exists. The job fails
+loudly if the query returns nothing, since a silently-empty run would report green while
+testing nothing.
+
+Two gotchas that cost a debugging cycle when this job was written:
+
+- **`bazel query` cannot take `--config=ci`.** Only `build:ci` and `test:ci` are defined in
+  `.bazelrc`, so `bazel query --config=ci` hard-errors with `Config value 'ci' is not defined
+  in any .rc file`. Pass it to `bazel test`, not to the discovery query.
+- **Do not add `--test_tag_filters`.** Combined with explicit labels, Bazel reports
+  `No test targets were found, yet testing was requested` — see the "Running it" section above.
+
+Requirements, if you are mirroring this elsewhere:
+
+- Docker must be available to the runner — `setup-docker: 'true'` on the `setup-build-env`
+  action, the same step `//tools/scripts:test_cross_compilation`'s job uses.
 - Network egress to pull `postgres:16-alpine` (and `testcontainers/ryuk:0.14.0` unless Ryuk is
   disabled) the first time; both are small (Alpine-based) so this is fast even uncached.
 - No new secrets or credentials are required — both images are public.
-- Do **not** add this target to a default `bazel test //...` CI step; invoke it explicitly as its
-  own job/step, same as `test_cross_compilation`.
+- Do **not** add these targets to a default `bazel test //...` CI step; they stay `manual` so
+  that step keeps working on a Docker-less machine.
 
 ## Verifying the constraints are actually being checked
 

--- a/tools/app_registry/PLAN.md
+++ b/tools/app_registry/PLAN.md
@@ -91,11 +91,13 @@ because the in-memory fake has no transactions.
   digest pre-check would miss, and `ResolveArtifact`'s chart→image join.
 - **Deferred, not in this pass:** the SCD2 `promotion_current_idx` partial
   unique index — the `promotion` table doesn't exist yet (ships in migration
-  `002`, AR-3). Add its test alongside that migration. Also deferred: the CI
-  job invoking the target explicitly (mirroring
-  `//tools/scripts:test_cross_compilation`'s `setup-docker: 'true'` job) —
-  left for a follow-up since it touches `.github/workflows/` outside this
-  change's `tools/app_registry/` scope.
+  `002`, AR-3). Add its test alongside that migration.
+- **CI now runs this target** — the `Test Database Integration` job in
+  `.github/workflows/ci.yml`, added after AR-3a. It discovers targets by
+  querying for tests that depend on `//libs/go/dbtest`, so new dbtest-backed
+  tests need no CI change. This closed a real gap: because the target is
+  `manual`, nothing ran it, and AR-3a's auth enforcement broke it in a way only
+  caught by running the stacked branches together by hand.
 
 **Exit criteria** — met. Each new test was verified to fail when its
 assertion was deliberately broken (see `TODO-AR-2d.md` and the phase report

--- a/tools/app_registry/TESTING.md
+++ b/tools/app_registry/TESTING.md
@@ -180,6 +180,12 @@ bazel test //tools/app_registry/server/repository/postgres:postgres_integration_
   --test_output=all
 ```
 
+**CI runs this** in the `Test Database Integration` job
+(`.github/workflows/ci.yml`), which discovers dbtest-backed targets by query —
+a new one needs no CI change. Run it locally before pushing anyway: it is the
+only automated check that exercises the pgx layer, and because it is
+`manual`-tagged, `bazel test //...` will not tell you it is broken.
+
 ## Verified
 
 Full chain confirmed on Docker Desktop Kubernetes at AR-1: images build →


### PR DESCRIPTION
`libs/go/dbtest`-backed tests are tagged `manual` so `bazel test //...` stays green on a machine with no Docker daemon. The consequence is that **nothing ran them at all** — there was no CI job naming them explicitly.

This is not hypothetical. AR-3a's auth enforcement broke the app_registry Postgres integration test (`RecordBuild: rpc error: code = Unauthenticated`), and CI could not have caught it. It surfaced only because the two branches were rebased and run together by hand before pushing.

## Approach

The job discovers its targets by query rather than a hardcoded list:

```bash
SCOPE='//libs/... + //tools/... + //manmanv2/...'
bazel query "tests($SCOPE) intersect rdeps($SCOPE, //libs/go/dbtest:dbtest)"
```

So any future dbtest-backed test is covered the moment it is written, with no CI change — which matters, because the failure mode here is silence.

The job **fails when the query returns nothing**. `//libs/go/dbtest:postgres_constraints_test` always matches, so an empty result means the query broke, not that there is no work. Without this guard the job would report green while testing nothing — reintroducing exactly the problem it exists to fix.

## Two gotchas found while writing it

- **`bazel query` rejects `--config=ci`.** Only `build:ci` and `test:ci` are defined in `.bazelrc`; query hard-errors with `Config value 'ci' is not defined in any .rc file`. My first draft had `--config=ci` on the query *and* `2>/dev/null` — which would have swallowed the error and produced an empty target list, i.e. a permanently green no-op job.
- **No `--test_tag_filters`.** Combined with explicit labels, Bazel reports `No test targets were found, yet testing was requested`.

Both are now documented in `libs/go/dbtest/README.md`.

## Verification

Ran the exact command sequence the job runs, locally:

```
Targets: //libs/go/dbtest:postgres_constraints_test //tools/app_registry/server/repository/postgres:postgres_integration_test
//libs/go/dbtest:postgres_constraints_test                               PASSED in 5.8s
//tools/app_registry/server/repository/postgres:postgres_integration_test PASSED in 10.4s
Executed 2 out of 2 tests: 2 tests pass.
```

Independent of the AR-3 stack — branches off `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)