### PR TITLE
AR-3b: EnvironmentRegistry (all RPCs), dev/stage/prod seeding

### DIFF
--- a/tools/app_registry/ENV.md
+++ b/tools/app_registry/ENV.md
@@ -42,11 +42,12 @@ Server-side enforcement lives in `server/auth`; see
 [`libs/go/grpcauth/KEYCLOAK.md`](../../libs/go/grpcauth/KEYCLOAK.md) for how
 to configure the Keycloak side. In short: `AppRegistry.ReconcileApps`,
 `ArtifactRegistry.RecordBuild`/`RecordArtifact` require
-`app-registry-builder`; `AppRegistry.SetAppStatus` requires
-`app-registry-admin`; all read RPCs require only that the caller is
-authenticated (any role). `EnvironmentRegistry`/`PromotionRegistry` stay
-`Unimplemented` until AR-3b/3c, but `server/auth.RequirePromoter` already
-exists for them to call unmodified.
+`app-registry-builder`; `AppRegistry.SetAppStatus` and every
+`EnvironmentRegistry` write (`UpsertEnvironment`/`ArchiveEnvironment`)
+require `app-registry-admin`; all read RPCs require only that the caller is
+authenticated (any role). `PromotionRegistry` stays `Unimplemented` until
+AR-3c, but `server/auth.RequirePromoter` already exists for it to call
+unmodified.
 
 **`GRPC_AUTH_MODE=none` and local/CI dev claims:** `libs/go/grpcauth`'s
 dev-mode claims default to `Roles: ["admin"]`, which satisfies none of this

--- a/tools/app_registry/PLAN.md
+++ b/tools/app_registry/PLAN.md
@@ -26,8 +26,8 @@ The registry is being deployed to `dev` by the repo owner. `app-registry-api`
 and `app-registry-migration` images publish from `apps=all`.
 `APP_REGISTRY_CICD_OPT_IN` is still unset, so CI makes no registry calls.
 
-**Next up:** AR-3b (`EnvironmentRegistry`). AR-2d and AR-3a are done and stacked
-on top of `main`.
+**Next up:** AR-3c (`PromotionRegistry`). AR-2d, AR-3a, and AR-3b are done
+and stacked on top of `main`.
 
 ### AR-2c — merged
 
@@ -285,6 +285,34 @@ criterion is testable from the moment promotion exists:
 | **AR-3b** | `EnvironmentRegistry` (all RPCs), `dev`/`stage`/`prod` seeding, environment-scoped `allowed_principals`. |
 | **AR-3c** | `PromotionRegistry` — SCD2 close-and-open, event log, promotability enforcement, `allow_override` + drift reporting. |
 | **AR-3d** | CLI (`promote`, `rollback`, `status`, `history`, `diff`) and the human-triggered `promote.yml` workflow. |
+
+### AR-3b — `EnvironmentRegistry` — done
+
+- Migration `002_environment_registry` (up/down): `environment` table —
+  `key` unique, `rank`, `requires_approval`, `gitops_path`,
+  `allowed_principals TEXT[]`, `archived`, `created_at`. Seeds
+  `dev`(rank 0)/`stage`(rank 10)/`prod`(rank 20) via
+  `INSERT ... ON CONFLICT (key) DO NOTHING`, safe against a database the
+  registry is already deployed to. **No `promotion` table** — that stays in
+  AR-3c's own migration `003`, which needs `environment.environment_id` to
+  exist first as an FK target. `migrate/README.md`'s "Planned migrations"
+  table corrected accordingly.
+- `repository.EnvironmentRepository` (`Upsert`/`Get`/`List`/`Archive`) +
+  postgres and fake implementations. All four `EnvironmentRegistry` RPCs
+  implemented in `server/handlers/environment.go`: writes require
+  `auth.RoleAdmin`, reads require `auth.RequireAuthenticated`. Neither
+  `UpsertEnvironment` nor `ArchiveEnvironment` carries an `idempotency_key`
+  in the proto, so neither goes through `runIdempotent` — same shape as
+  `AppRegistry.SetAppStatus`.
+- Postgres integration coverage added: migration 002 applying/seeding
+  verified against real Postgres (plus a manual up/down/up round-trip
+  outside `bazel test`), the real `UNIQUE (key)` constraint firing, and a
+  full `Upsert` round-trip including the `TEXT[]` `allowed_principals`
+  column. Caught one real bug in the process: pgx encodes a nil Go
+  `[]string` as SQL `NULL`, which the `NOT NULL allowed_principals` column
+  rejected — fixed by normalizing to `[]string{}` before insert.
+- See [TODO-AR-3b.md](TODO-AR-3b.md) for full execution detail and the
+  deliberate-break verification transcripts.
 
 ### Credential model (decided)
 

--- a/tools/app_registry/TOC.md
+++ b/tools/app_registry/TOC.md
@@ -9,8 +9,8 @@ and the chart image lockfile are implemented and verified against real
 Postgres. The release workflow calls the CLI's write path after image/chart
 pushes, gated behind `APP_REGISTRY_CICD_OPT_IN`. The registry is being
 deployed to `dev`. AR-3 is split into a 4-PR stack (auth, environments,
-promotions, CLI); environments and promotions stay `Unimplemented` until
-AR-3b/3c land.
+promotions, CLI). Auth (AR-3a) and `EnvironmentRegistry` (AR-3b) are done;
+`PromotionRegistry` stays `Unimplemented` until AR-3c lands.
 
 **See [PLAN.md](PLAN.md) → "Current status" for the branch/PR map,
 what is next, and the carry-over items** — start there when picking this up.

--- a/tools/app_registry/TODO-AR-3b.md
+++ b/tools/app_registry/TODO-AR-3b.md
@@ -1,0 +1,137 @@
+# TODO-AR-3b — EnvironmentRegistry
+
+Execution tracking for AR-3b (see [PLAN.md](PLAN.md) → "AR-3 — Promotion").
+Scope: `EnvironmentRegistry` (all RPCs), `dev`/`stage`/`prod` seeding,
+environment-scoped `allowed_principals`. No promotion logic — `promotion`
+table and `PromotionRegistry` stay out of scope for AR-3c.
+
+## Done
+
+- [x] Migration `002_environment_registry` (up/down) in
+      `migrate/schema/migrations/`: `environment` table per
+      ARCHITECTURE.md's Data model — `key` unique, `rank` (plain INTEGER,
+      not unique — nothing requires distinct ranks), `requires_approval`,
+      `gitops_path`, `allowed_principals TEXT[] NOT NULL DEFAULT '{}'`,
+      `archived`, `created_at`. Seeds `dev`(0)/`stage`(10)/`prod`(20) with
+      `requires_approval = false` for all three (the approval gate is
+      unimplemented; a future admin turns it on explicitly once it exists).
+      Seed insert uses `ON CONFLICT (key) DO NOTHING` so it is safe to apply
+      to a database an operator already touched. **Migration-based seeding**
+      was chosen over server-startup seeding — see "Seeding decision" below.
+      Verified with a real Postgres container: up (1→2), down (2→1, table
+      dropped, `app`/`chart` from 001 intact), and re-up all succeed; see
+      report for exact output.
+- [x] `migrate/README.md`'s "Planned migrations" table corrected: `002` was
+      originally documented as carrying `promotion` too; AR-3b's actual
+      scope is environments only, so `promotion`/`promotion_event`/
+      `v_current_promotion` moved to their own `003` (AR-3c), and
+      `writeback_outbox` shifted to `004` (AR-4).
+- [x] `repository.Environment` model + `EnvironmentRepository` interface
+      (`Upsert`, `Get`, `List`, `Archive`) + `Registry.Environments()`.
+- [x] `postgres/environment.go`: `environmentRepo` implementing the
+      interface. `Upsert` looks up by key first (insert if absent, update
+      every field but `Key`/`Archived` if present); `Archive` is
+      archived→archived idempotent no-op, matching `SetAppStatus`'s shape.
+      Normalizes a nil `AllowedPrincipals` to `[]string{}` before insert —
+      pgx encodes Go `nil` slices as SQL `NULL`, which the `NOT NULL` column
+      rejects; caught by the integration test, see report.
+- [x] `fake/fake.go`: `environmentFake` (a distinct type wrapping
+      `*Registry`, NOT methods directly on `Registry`) implementing the same
+      interface over `state.Environments`. Required because
+      `EnvironmentRepository.Get`/`List` collide by name with
+      `IdempotencyRepository.Get`/other methods already on `Registry` — Go
+      has no overloading. `WithTx` snapshotting covers it automatically
+      since it's still `r.state` underneath.
+- [x] `server/handlers/environment.go`: all four `EnvironmentRegistry` RPCs
+      implemented against `repository.Registry`. `UpsertEnvironment`/
+      `ArchiveEnvironment` → `auth.RoleAdmin`; `GetEnvironment`/
+      `ListEnvironments` → `auth.RequireAuthenticated`. Neither write RPC
+      carries an `idempotency_key` in the proto (confirmed against
+      `api_messages_environment.proto`), so neither routes through
+      `runIdempotent` — same shape as `AppRegistry.SetAppStatus`, the other
+      admin-only write.
+- [x] `server/handlers/convert.go`: `environmentToPB`/`environmentsToPB`.
+- [x] `server/main.go`: `NewEnvironmentServer(repo)` now takes the real
+      repository; doc comments updated to say EnvironmentRegistry is real.
+- [x] `server/main_test.go`: `TestRegisterServices_AllFourServicesReachable`'s
+      `EnvironmentRegistry` subtest now asserts a real empty-but-successful
+      `ListEnvironments`, matching the App/Artifact subtests, plus a new
+      `ArchiveEnvironment` NotFound check. `PromotionRegistry` stays the only
+      genuinely-`Unimplemented` subtest.
+- [x] Tests: `server/handlers/environment_test.go` (create/update, rank
+      ordering, `include_archived`, archive idempotency, not-found paths)
+      and the AR-3a authorization triple for `UpsertEnvironment`/
+      `ArchiveEnvironment` in `authz_test.go` (admin allowed, builder →
+      `PermissionDenied`, no claims → `Unauthenticated`) plus a
+      `RequireAuthenticated`-only pair for the two reads.
+- [x] `server/repository/postgres/postgres_integration_test.go`: added
+      `TestMigration002SeedsDevStageProd` (proves 002 applies on 001 and the
+      seed data lands), `TestEnvironment_KeyUniqueConstraint` (raw INSERT
+      proving the real `UNIQUE (key)` index rejects a duplicate, not app
+      logic), and `TestEnvironmentRepo_UpsertCreateThenUpdate` (repository
+      layer round-trip including `TEXT[]` `allowed_principals`).
+- [x] BUILD.bazel: added `environment.go`/`environment_test.go` to the
+      relevant `go_library`/`go_test` srcs; added `@com_github_jackc_pgx_v5//pgconn`
+      to the hand-written `postgres_integration_test` target's deps (gazelle
+      skips this target — `# keep` marker, see its own comment).
+      `bazel run //:gazelle` was run once; every out-of-scope file it
+      reformatted was reverted, keeping only the `app_registry` deps it
+      added (none, in the end — no new import needed gazelle's help).
+
+## Seeding decision
+
+**Migration, not server startup.** `INSERT ... ON CONFLICT (key) DO NOTHING`
+inside `002_environment_registry.up.sql`:
+
+- It is a one-shot schema-migration operation like every other seed in this
+  repo (`domain_adoption` has no seed rows, but the *pattern* of "DDL +
+  bootstrap data in the same migration" is standard golang-migrate practice
+  here).
+- `ON CONFLICT DO NOTHING` makes it idempotent and non-destructive: if `dev`
+  already has admin-edited `allowed_principals` by the time this runs (e.g.
+  an operator called `UpsertEnvironment` by hand before upgrading, or the
+  migration is retried after a partial failure), the seed is skipped
+  entirely rather than clobbering that edit.
+- Server-startup seeding would need its own idempotency/locking story (what
+  if two API replicas start concurrently?) that migrations already solve for
+  free via `golang-migrate`'s advisory lock — reinventing that in Go for no
+  benefit.
+- This is exactly the same trade PLAN.md already made for `domain_adoption`
+  in migration `001`: ship the row so no consumer is ever missing one, at
+  migration time, without a redundant application-layer bootstrap path.
+
+This matters here because, per PLAN.md, the registry may already be deployed
+to `dev` by the time this migration ships — the ON CONFLICT clause is what
+makes that safe.
+
+## Verification
+
+```
+bazel test //tools/app_registry/...                                                              # 4/4 pass
+bazel test //tools/app_registry/server/repository/postgres:postgres_integration_test --test_output=all  # pass (Docker)
+bazel build //tools/...                                                                          # green
+```
+
+Migration round-trip verified against a real Postgres container (not just
+`bazel test`): `up` 0→2, `down -steps=1` 2→1 (environment table dropped,
+`app`/`chart` intact), `up` again 1→2 (seed rows reappear). See phase report
+for exact command transcript.
+
+Deliberate-break verification (per AR-2d's lesson): removed `UNIQUE (key)`
+from the migration → every integration test failed at migration-apply time
+("no unique or exclusion constraint matching ON CONFLICT specification");
+changed the seeded `stage` rank from 10 to 15 → `TestMigration002SeedsDevStageProd`
+failed with an exact mismatch message; reverted `updated.DisplayName`'s
+assignment in the fake to a constant → `TestUpsertEnvironment_CreateThenUpdate`
+failed. All three reverted and reconfirmed green. See phase report for
+transcripts.
+
+## Explicitly not done (AR-3c/3d)
+
+- `PromotionRegistry` — still `Unimplemented`. SCD2 `promotion` table,
+  `promotion_event`, `v_current_promotion`, promotability enforcement,
+  `allow_override`/drift reporting all land in AR-3c's own migration `003`.
+- No CLI (`app-registry environments ...`) or workflow changes — AR-3d.
+- `environment.requires_approval` is stored and returned but not honored by
+  anything yet (no promotion path exists to honor it) — unchanged from
+  ARCHITECTURE.md's "Future: approval gate".

--- a/tools/app_registry/migrate/README.md
+++ b/tools/app_registry/migrate/README.md
@@ -30,11 +30,16 @@ ArgoCD sync waves. See `friendly_computing_machine/docs/argocd-integration.md`.
 | File | Contents |
 |---|---|
 | `001_initial_schema` | `app`, `chart`, `chart_app`, `build`, `artifact`, `artifact_link`, `idempotency_key`, `domain_adoption` |
-| `002_environments_promotions` | `environment`, `promotion` (SCD2), `promotion_event`, `v_current_promotion` |
-| `003_writeback_outbox` | `writeback_outbox` |
+| `002_environment_registry` | `environment`, seeded with `dev`/`stage`/`prod` |
+| `003_promotion` (planned, AR-3c) | `promotion` (SCD2), `promotion_event`, `v_current_promotion` |
+| `004_writeback_outbox` (planned, AR-4) | `writeback_outbox` |
 
-Split this way so AR-2 needs only `001`, AR-3 adds `002`, and AR-4 adds `003` —
-each phase ships an independently applicable migration.
+Split this way so AR-2 needs only `001`, AR-3b adds `002`, AR-3c adds `003`,
+and AR-4 adds `004` — each phase ships an independently applicable
+migration. `002` was originally planned to also carry `promotion`, but
+AR-3b's scope is environments only (no promotion logic), so that table moved
+out to its own migration in AR-3c, which needs `environment.environment_id`
+to already exist as an FK target.
 
 ## Required indexes
 

--- a/tools/app_registry/migrate/schema/migrations/002_environment_registry.down.sql
+++ b/tools/app_registry/migrate/schema/migrations/002_environment_registry.down.sql
@@ -1,0 +1,3 @@
+-- Rollback App Registry Environment Registry
+
+DROP TABLE IF EXISTS environment;

--- a/tools/app_registry/migrate/schema/migrations/002_environment_registry.up.sql
+++ b/tools/app_registry/migrate/schema/migrations/002_environment_registry.up.sql
@@ -1,0 +1,51 @@
+-- App Registry — Environment Registry (AR-3b)
+--
+-- Adds the `environment` table described in ARCHITECTURE.md's "Data model":
+-- environments are managed rows, not a compiled-in enum, so an ephemeral or
+-- regional environment is an insert, not a release. `promotion`,
+-- `promotion_event`, and `v_current_promotion` are deliberately NOT here —
+-- they land in AR-3c's migration, which needs `environment_id` to exist
+-- first. See migrate/README.md "Planned migrations".
+
+CREATE TABLE environment (
+    environment_id      UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    key                  TEXT NOT NULL,
+    display_name         TEXT NOT NULL DEFAULT '',
+    -- Orders promotion legality (e.g. "must be in stage before prod"). Not
+    -- enforced until AR-3c. Left as plain INTEGER, not UNIQUE — nothing in
+    -- ARCHITECTURE.md requires ranks to be distinct, and a shared rank
+    -- (e.g. two parallel prod-like environments) is a legitimate shape.
+    rank                  INTEGER NOT NULL DEFAULT 0,
+    -- Honored once the approval gate ships (see ARCHITECTURE.md "Future:
+    -- approval gate"). Not enforced by anything in AR-3b.
+    requires_approval    BOOLEAN NOT NULL DEFAULT false,
+    gitops_path          TEXT NOT NULL DEFAULT '',
+    -- Principals permitted to promote here, checked against the caller's
+    -- OIDC claims once AR-3c enforces it.
+    allowed_principals   TEXT[] NOT NULL DEFAULT '{}',
+    archived             BOOLEAN NOT NULL DEFAULT false,
+    created_at           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (key)
+);
+
+CREATE INDEX environment_rank_idx ON environment (rank);
+
+-- Seed the three environments every domain promotes through. Ranks leave
+-- gaps (0/10/20) so a future environment (e.g. "stage-eu") can be inserted
+-- between existing ones without renumbering. requires_approval is left
+-- false for all three here — the approval gate is unimplemented (see
+-- ARCHITECTURE.md), so defaulting prod to true would be inert metadata a
+-- future migration would need to reason about; enabling it is an explicit
+-- admin action via UpsertEnvironment once the gate exists.
+--
+-- ON CONFLICT (key) DO NOTHING makes this safe to apply to a database that
+-- already has these rows (e.g. a partially-applied migration retried, or an
+-- operator who pre-seeded via UpsertEnvironment before this migration ran)
+-- — it will never overwrite live admin edits. See the AR-3b phase report
+-- for why seeding lives in the migration rather than server startup.
+INSERT INTO environment (key, display_name, rank, requires_approval, gitops_path)
+VALUES
+    ('dev', 'Development', 0, false, 'environments/dev'),
+    ('stage', 'Staging', 10, false, 'environments/stage'),
+    ('prod', 'Production', 20, false, 'environments/prod')
+ON CONFLICT (key) DO NOTHING;

--- a/tools/app_registry/server/handlers/BUILD.bazel
+++ b/tools/app_registry/server/handlers/BUILD.bazel
@@ -30,6 +30,7 @@ go_test(
         "app_test.go",
         "artifact_test.go",
         "authz_test.go",
+        "environment_test.go",
     ],
     embed = [":handlers"],
     deps = [

--- a/tools/app_registry/server/handlers/authz_test.go
+++ b/tools/app_registry/server/handlers/authz_test.go
@@ -277,3 +277,98 @@ func TestArtifactReads_RequireAuthenticationOnly(t *testing.T) {
 
 	_ = build
 }
+
+// TestUpsertEnvironment_Authorization and TestArchiveEnvironment_Authorization
+// cover EnvironmentRegistry's write RPCs, which require RoleAdmin per
+// ARCHITECTURE.md's Authorization table -- unlike every other service,
+// EnvironmentRegistry has no builder/promoter carve-out at all, so a
+// builder credential (real power over AppRegistry/ArtifactRegistry) must
+// not be able to touch it either.
+func TestUpsertEnvironment_Authorization(t *testing.T) {
+	req := &pb.UpsertEnvironmentRequest{Key: "dev", DisplayName: "Development"}
+
+	t.Run("correct role allowed", func(t *testing.T) {
+		srv := NewEnvironmentServer(fake.New())
+		_, err := srv.UpsertEnvironment(ctxWithRoles(auth.RoleAdmin), req)
+		if err != nil {
+			t.Fatalf("expected admin to be allowed, got %v", err)
+		}
+	})
+
+	t.Run("wrong role is PermissionDenied", func(t *testing.T) {
+		srv := NewEnvironmentServer(fake.New())
+		_, err := srv.UpsertEnvironment(ctxWithRoles(auth.RoleBuilder), req)
+		requireCode(t, err, codes.PermissionDenied, "UpsertEnvironment")
+	})
+
+	t.Run("no claims is Unauthenticated", func(t *testing.T) {
+		srv := NewEnvironmentServer(fake.New())
+		_, err := srv.UpsertEnvironment(context.Background(), req)
+		requireCode(t, err, codes.Unauthenticated, "UpsertEnvironment")
+	})
+}
+
+func TestArchiveEnvironment_Authorization(t *testing.T) {
+	newSrvWithEnv := func(t *testing.T) *EnvironmentServer {
+		t.Helper()
+		srv := NewEnvironmentServer(fake.New())
+		if _, err := srv.UpsertEnvironment(ctxWithRoles(auth.RoleAdmin), &pb.UpsertEnvironmentRequest{Key: "dev"}); err != nil {
+			t.Fatalf("seed environment: %v", err)
+		}
+		return srv
+	}
+	req := &pb.ArchiveEnvironmentRequest{Key: "dev", Reason: "decommissioned"}
+
+	t.Run("correct role allowed", func(t *testing.T) {
+		srv := newSrvWithEnv(t)
+		_, err := srv.ArchiveEnvironment(ctxWithRoles(auth.RoleAdmin), req)
+		if err != nil {
+			t.Fatalf("expected admin to be allowed, got %v", err)
+		}
+	})
+
+	t.Run("wrong role is PermissionDenied", func(t *testing.T) {
+		srv := newSrvWithEnv(t)
+		// A builder credential -- real power over AppRegistry/ArtifactRegistry,
+		// none over EnvironmentRegistry.
+		_, err := srv.ArchiveEnvironment(ctxWithRoles(auth.RoleBuilder), req)
+		requireCode(t, err, codes.PermissionDenied, "ArchiveEnvironment")
+	})
+
+	t.Run("no claims is Unauthenticated", func(t *testing.T) {
+		srv := newSrvWithEnv(t)
+		_, err := srv.ArchiveEnvironment(context.Background(), req)
+		requireCode(t, err, codes.Unauthenticated, "ArchiveEnvironment")
+	})
+}
+
+// TestEnvironmentReads_RequireAuthenticationOnly covers GetEnvironment and
+// ListEnvironments: any authenticated principal, no specific role -- not
+// even RoleAdmin, matching every other service's read RPCs.
+func TestEnvironmentReads_RequireAuthenticationOnly(t *testing.T) {
+	srv := NewEnvironmentServer(fake.New())
+	if _, err := srv.UpsertEnvironment(ctxWithRoles(auth.RoleAdmin), &pb.UpsertEnvironmentRequest{Key: "dev"}); err != nil {
+		t.Fatalf("seed environment: %v", err)
+	}
+
+	// A principal with an unrelated single role still passes.
+	readerCtx := ctxWithRoles(auth.RoleBuilder)
+
+	t.Run("GetEnvironment", func(t *testing.T) {
+		if _, err := srv.GetEnvironment(readerCtx, &pb.GetEnvironmentRequest{Key: "dev"}); err != nil {
+			t.Fatalf("expected any authenticated principal to get an environment, got %v", err)
+		}
+		if _, err := srv.GetEnvironment(context.Background(), &pb.GetEnvironmentRequest{Key: "dev"}); status.Code(err) != codes.Unauthenticated {
+			t.Fatalf("expected Unauthenticated with no claims, got %v", err)
+		}
+	})
+
+	t.Run("ListEnvironments", func(t *testing.T) {
+		if _, err := srv.ListEnvironments(readerCtx, &pb.ListEnvironmentsRequest{}); err != nil {
+			t.Fatalf("expected any authenticated principal to list environments, got %v", err)
+		}
+		if _, err := srv.ListEnvironments(context.Background(), &pb.ListEnvironmentsRequest{}); status.Code(err) != codes.Unauthenticated {
+			t.Fatalf("expected Unauthenticated with no claims, got %v", err)
+		}
+	})
+}

--- a/tools/app_registry/server/handlers/convert.go
+++ b/tools/app_registry/server/handlers/convert.go
@@ -207,6 +207,28 @@ func appStatusesFromPB(statuses []pb.AppStatus) []repository.Status {
 	return out
 }
 
+func environmentToPB(e repository.Environment) *pb.Environment {
+	return &pb.Environment{
+		EnvironmentId:     e.EnvironmentID,
+		Key:               e.Key,
+		DisplayName:       e.DisplayName,
+		Rank:              e.Rank,
+		RequiresApproval:  e.RequiresApproval,
+		GitopsPath:        e.GitopsPath,
+		AllowedPrincipals: e.AllowedPrincipals,
+		Archived:          e.Archived,
+		CreatedAt:         timeToUnix(e.CreatedAt),
+	}
+}
+
+func environmentsToPB(envs []repository.Environment) []*pb.Environment {
+	out := make([]*pb.Environment, 0, len(envs))
+	for _, e := range envs {
+		out = append(out, environmentToPB(e))
+	}
+	return out
+}
+
 func containedImagesFromPB(images []*pb.ContainedImage) []repository.ContainedImageInput {
 	out := make([]repository.ContainedImageInput, 0, len(images))
 	for _, ci := range images {

--- a/tools/app_registry/server/handlers/environment.go
+++ b/tools/app_registry/server/handlers/environment.go
@@ -4,34 +4,102 @@ import (
 	"context"
 
 	pb "github.com/whale-net/everything/tools/app_registry/protos"
+	"github.com/whale-net/everything/tools/app_registry/server/auth"
+	"github.com/whale-net/everything/tools/app_registry/server/repository"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
-// EnvironmentServer implements pb.EnvironmentRegistryServer. Role: admin
-// only, per ARCHITECTURE.md "Authorization". The `environment` table doesn't
-// exist until migration 002 (AR-3), so every RPC here is Unimplemented.
+// EnvironmentServer implements pb.EnvironmentRegistryServer, backed by
+// repository.Registry. Role: admin for every RPC's write path, per
+// ARCHITECTURE.md "Authorization" -- EnvironmentRegistry has no
+// builder/promoter carve-out, unlike AppRegistry/ArtifactRegistry. Reads
+// require only that the caller is authenticated, same as every other
+// service's reads. PromotionRegistry (AR-3c) is the only other planned
+// consumer of the environment table and stays Unimplemented until then.
 type EnvironmentServer struct {
 	pb.UnimplementedEnvironmentRegistryServer
+	repo repository.Registry
 }
 
-// NewEnvironmentServer constructs an EnvironmentServer.
-func NewEnvironmentServer() *EnvironmentServer {
-	return &EnvironmentServer{}
+// NewEnvironmentServer constructs an EnvironmentServer over repo.
+func NewEnvironmentServer(repo repository.Registry) *EnvironmentServer {
+	return &EnvironmentServer{repo: repo}
 }
 
+// UpsertEnvironment creates or updates an environment by its immutable key.
+// Neither this nor ArchiveEnvironment take an idempotency_key (see
+// api_messages_environment.proto) -- same shape as AppRegistry.SetAppStatus,
+// the other admin-only write in this codebase, so there is no runIdempotent
+// path here.
 func (s *EnvironmentServer) UpsertEnvironment(ctx context.Context, req *pb.UpsertEnvironmentRequest) (*pb.UpsertEnvironmentResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "UpsertEnvironment not implemented")
+	if err := auth.Require(ctx, auth.RoleAdmin); err != nil {
+		return nil, err
+	}
+	if req.Key == "" {
+		return nil, status.Error(codes.InvalidArgument, "key is required")
+	}
+
+	env, created, err := s.repo.Environments().Upsert(ctx, repository.Environment{
+		Key:               req.Key,
+		DisplayName:       req.DisplayName,
+		Rank:              req.Rank,
+		RequiresApproval:  req.RequiresApproval,
+		GitopsPath:        req.GitopsPath,
+		AllowedPrincipals: req.AllowedPrincipals,
+	})
+	if err != nil {
+		return nil, mapRepoErr(err)
+	}
+	return &pb.UpsertEnvironmentResponse{Environment: environmentToPB(*env), Created: created}, nil
 }
 
 func (s *EnvironmentServer) GetEnvironment(ctx context.Context, req *pb.GetEnvironmentRequest) (*pb.GetEnvironmentResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "GetEnvironment not implemented")
+	if err := auth.RequireAuthenticated(ctx); err != nil {
+		return nil, err
+	}
+	if req.Key == "" {
+		return nil, status.Error(codes.InvalidArgument, "key is required")
+	}
+
+	env, err := s.repo.Environments().Get(ctx, req.Key)
+	if err != nil {
+		return nil, mapRepoErr(err)
+	}
+	return &pb.GetEnvironmentResponse{Environment: environmentToPB(*env)}, nil
 }
 
+// ListEnvironments returns environments ordered by rank ascending, per
+// ListEnvironmentsResponse's doc comment.
 func (s *EnvironmentServer) ListEnvironments(ctx context.Context, req *pb.ListEnvironmentsRequest) (*pb.ListEnvironmentsResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "ListEnvironments not implemented")
+	if err := auth.RequireAuthenticated(ctx); err != nil {
+		return nil, err
+	}
+
+	envs, err := s.repo.Environments().List(ctx, req.IncludeArchived)
+	if err != nil {
+		return nil, mapRepoErr(err)
+	}
+	return &pb.ListEnvironmentsResponse{Environments: environmentsToPB(envs)}, nil
 }
 
+// ArchiveEnvironment is the only lifecycle transition on an environment row.
+// Unlike App/Chart, there is no automatic un-archive path -- if this proves
+// wrong in practice, UpsertEnvironment can be extended to accept it later.
 func (s *EnvironmentServer) ArchiveEnvironment(ctx context.Context, req *pb.ArchiveEnvironmentRequest) (*pb.ArchiveEnvironmentResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "ArchiveEnvironment not implemented")
+	if err := auth.Require(ctx, auth.RoleAdmin); err != nil {
+		return nil, err
+	}
+	if req.Key == "" {
+		return nil, status.Error(codes.InvalidArgument, "key is required")
+	}
+	if req.Reason == "" {
+		return nil, status.Error(codes.InvalidArgument, "reason is required")
+	}
+
+	env, err := s.repo.Environments().Archive(ctx, req.Key, req.Reason)
+	if err != nil {
+		return nil, mapRepoErr(err)
+	}
+	return &pb.ArchiveEnvironmentResponse{Environment: environmentToPB(*env)}, nil
 }

--- a/tools/app_registry/server/handlers/environment_test.go
+++ b/tools/app_registry/server/handlers/environment_test.go
@@ -1,0 +1,188 @@
+package handlers
+
+import (
+	"testing"
+
+	pb "github.com/whale-net/everything/tools/app_registry/protos"
+	"github.com/whale-net/everything/tools/app_registry/server/repository/fake"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func upsertReq(key string) *pb.UpsertEnvironmentRequest {
+	return &pb.UpsertEnvironmentRequest{
+		Key: key, DisplayName: "Development", Rank: 0, GitopsPath: "environments/" + key,
+	}
+}
+
+// TestUpsertEnvironment_CreateThenUpdate covers the two Upsert branches: a
+// fresh key creates (created=true), a repeated key updates every field but
+// Key, per repository.EnvironmentRepository.Upsert's doc comment.
+func TestUpsertEnvironment_CreateThenUpdate(t *testing.T) {
+	ctx := authedCtx()
+	srv := NewEnvironmentServer(fake.New())
+
+	created, err := srv.UpsertEnvironment(ctx, upsertReq("dev"))
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if !created.Created || created.Environment.Key != "dev" || created.Environment.DisplayName != "Development" {
+		t.Fatalf("expected a newly created dev environment, got %+v", created)
+	}
+	envID := created.Environment.EnvironmentId
+
+	req := upsertReq("dev")
+	req.DisplayName = "Dev (renamed)"
+	req.Rank = 5
+	req.RequiresApproval = true
+	req.AllowedPrincipals = []string{"alice@example.com"}
+	updated, err := srv.UpsertEnvironment(ctx, req)
+	if err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if updated.Created {
+		t.Fatalf("expected created=false on the second upsert of the same key, got %+v", updated)
+	}
+	if updated.Environment.EnvironmentId != envID {
+		t.Fatalf("expected the same environment_id across upserts, got %s vs %s", updated.Environment.EnvironmentId, envID)
+	}
+	if updated.Environment.DisplayName != "Dev (renamed)" || updated.Environment.Rank != 5 || !updated.Environment.RequiresApproval {
+		t.Fatalf("expected fields updated in place, got %+v", updated.Environment)
+	}
+	if len(updated.Environment.AllowedPrincipals) != 1 || updated.Environment.AllowedPrincipals[0] != "alice@example.com" {
+		t.Fatalf("expected allowed_principals updated, got %+v", updated.Environment.AllowedPrincipals)
+	}
+}
+
+func TestUpsertEnvironment_RequiresKey(t *testing.T) {
+	ctx := authedCtx()
+	srv := NewEnvironmentServer(fake.New())
+	_, err := srv.UpsertEnvironment(ctx, &pb.UpsertEnvironmentRequest{DisplayName: "no key"})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("expected InvalidArgument when key is missing, got %v", err)
+	}
+}
+
+// TestListEnvironments_OrderedByRank covers ListEnvironmentsResponse's doc
+// comment: "Ordered by rank ascending."
+func TestListEnvironments_OrderedByRank(t *testing.T) {
+	ctx := authedCtx()
+	srv := NewEnvironmentServer(fake.New())
+
+	for _, e := range []struct {
+		key  string
+		rank int32
+	}{
+		{"prod", 20},
+		{"dev", 0},
+		{"stage", 10},
+	} {
+		req := upsertReq(e.key)
+		req.Rank = e.rank
+		if _, err := srv.UpsertEnvironment(ctx, req); err != nil {
+			t.Fatalf("upsert %s: %v", e.key, err)
+		}
+	}
+
+	resp, err := srv.ListEnvironments(ctx, &pb.ListEnvironmentsRequest{})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(resp.Environments) != 3 {
+		t.Fatalf("expected 3 environments, got %d", len(resp.Environments))
+	}
+	gotKeys := []string{resp.Environments[0].Key, resp.Environments[1].Key, resp.Environments[2].Key}
+	want := []string{"dev", "stage", "prod"}
+	for i := range want {
+		if gotKeys[i] != want[i] {
+			t.Fatalf("expected rank-ascending order %v, got %v", want, gotKeys)
+		}
+	}
+}
+
+// TestListEnvironments_IncludeArchived covers the include_archived filter:
+// archived environments are hidden by default and returned only when asked.
+func TestListEnvironments_IncludeArchived(t *testing.T) {
+	ctx := authedCtx()
+	srv := NewEnvironmentServer(fake.New())
+
+	if _, err := srv.UpsertEnvironment(ctx, upsertReq("dev")); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	if _, err := srv.ArchiveEnvironment(ctx, &pb.ArchiveEnvironmentRequest{Key: "dev", Reason: "decommissioned"}); err != nil {
+		t.Fatalf("archive: %v", err)
+	}
+
+	resp, err := srv.ListEnvironments(ctx, &pb.ListEnvironmentsRequest{})
+	if err != nil {
+		t.Fatalf("list default: %v", err)
+	}
+	if len(resp.Environments) != 0 {
+		t.Fatalf("expected archived environment hidden by default, got %+v", resp.Environments)
+	}
+
+	respAll, err := srv.ListEnvironments(ctx, &pb.ListEnvironmentsRequest{IncludeArchived: true})
+	if err != nil {
+		t.Fatalf("list include_archived: %v", err)
+	}
+	if len(respAll.Environments) != 1 || !respAll.Environments[0].Archived {
+		t.Fatalf("expected 1 archived environment when include_archived=true, got %+v", respAll.Environments)
+	}
+}
+
+// TestArchiveEnvironment_IdempotentNoOp mirrors SetAppStatus's archived ->
+// archived no-op success, so a retried archive call is safe.
+func TestArchiveEnvironment_IdempotentNoOp(t *testing.T) {
+	ctx := authedCtx()
+	srv := NewEnvironmentServer(fake.New())
+
+	if _, err := srv.UpsertEnvironment(ctx, upsertReq("dev")); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	first, err := srv.ArchiveEnvironment(ctx, &pb.ArchiveEnvironmentRequest{Key: "dev", Reason: "gone"})
+	if err != nil {
+		t.Fatalf("first archive: %v", err)
+	}
+	if !first.Environment.Archived {
+		t.Fatalf("expected archived=true, got %+v", first.Environment)
+	}
+
+	second, err := srv.ArchiveEnvironment(ctx, &pb.ArchiveEnvironmentRequest{Key: "dev", Reason: "gone again"})
+	if err != nil {
+		t.Fatalf("re-archive should be a no-op success, got error: %v", err)
+	}
+	if !second.Environment.Archived {
+		t.Fatalf("expected archived=true, got %+v", second.Environment)
+	}
+}
+
+func TestArchiveEnvironment_NotFound(t *testing.T) {
+	ctx := authedCtx()
+	srv := NewEnvironmentServer(fake.New())
+	_, err := srv.ArchiveEnvironment(ctx, &pb.ArchiveEnvironmentRequest{Key: "nonexistent", Reason: "gone"})
+	if status.Code(err) != codes.NotFound {
+		t.Fatalf("expected NotFound, got %v", err)
+	}
+}
+
+func TestArchiveEnvironment_RequiresReason(t *testing.T) {
+	ctx := authedCtx()
+	srv := NewEnvironmentServer(fake.New())
+	if _, err := srv.UpsertEnvironment(ctx, upsertReq("dev")); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	_, err := srv.ArchiveEnvironment(ctx, &pb.ArchiveEnvironmentRequest{Key: "dev"})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("expected InvalidArgument when reason is missing, got %v", err)
+	}
+}
+
+func TestGetEnvironment_NotFound(t *testing.T) {
+	ctx := authedCtx()
+	srv := NewEnvironmentServer(fake.New())
+	_, err := srv.GetEnvironment(ctx, &pb.GetEnvironmentRequest{Key: "nonexistent"})
+	if status.Code(err) != codes.NotFound {
+		t.Fatalf("expected NotFound, got %v", err)
+	}
+}

--- a/tools/app_registry/server/main.go
+++ b/tools/app_registry/server/main.go
@@ -1,6 +1,6 @@
 // Command app-registry-api is the App Registry's gRPC server. AppRegistry and
-// ArtifactRegistry are real as of AR-2a; PromotionRegistry and
-// EnvironmentRegistry still return codes.Unimplemented until AR-3/AR-4. See
+// ArtifactRegistry are real as of AR-2a; EnvironmentRegistry is real as of
+// AR-3b. PromotionRegistry still returns codes.Unimplemented until AR-3c. See
 // ../ARCHITECTURE.md and ../README.md.
 package main
 
@@ -128,13 +128,13 @@ func run() error {
 // a fake repository.Registry.
 func registerServices(grpcServer *grpc.Server, repo repository.Registry) *health.Server {
 	// AppRegistry and ArtifactRegistry are real as of AR-2a (AllocateVersion
-	// stays Unimplemented — that's AR-5). PromotionRegistry and
-	// EnvironmentRegistry stay Unimplemented until AR-3/AR-4 — see
-	// handlers/promotion.go, handlers/environment.go.
+	// stays Unimplemented — that's AR-5). EnvironmentRegistry is real as of
+	// AR-3b. PromotionRegistry stays Unimplemented until AR-3c — see
+	// handlers/promotion.go.
 	pb.RegisterAppRegistryServer(grpcServer, handlers.NewAppServer(repo))
 	pb.RegisterArtifactRegistryServer(grpcServer, handlers.NewArtifactServer(repo))
 	pb.RegisterPromotionRegistryServer(grpcServer, handlers.NewPromotionServer())
-	pb.RegisterEnvironmentRegistryServer(grpcServer, handlers.NewEnvironmentServer())
+	pb.RegisterEnvironmentRegistryServer(grpcServer, handlers.NewEnvironmentServer(repo))
 
 	// Health check — reports SERVING once the process is up. AR-1 has no
 	// downstream dependency to gate on beyond the DB pool, which is already

--- a/tools/app_registry/server/main_test.go
+++ b/tools/app_registry/server/main_test.go
@@ -109,12 +109,12 @@ func assertUnimplementedFromHandler(t *testing.T, rpc, wantMsg string, err error
 // the message text for exactly that reason. A dropped pb.RegisterXxxServer
 // call in main.go fails this test.
 //
-// AppRegistry and ArtifactRegistry are real as of AR-2a, so those two
-// subtests assert a real (empty-but-successful) response against the fake
-// repository instead of Unimplemented — a dropped Register call would now
-// surface as codes.Unavailable/Unimplemented-with-"unknown service" instead,
-// still caught below. PromotionRegistry and EnvironmentRegistry are still
-// Unimplemented until AR-3/AR-4.
+// AppRegistry, ArtifactRegistry, and EnvironmentRegistry are real (as of
+// AR-2a and AR-3b respectively), so those subtests assert a real
+// (empty-but-successful) response against the fake repository instead of
+// Unimplemented — a dropped Register call would now surface as
+// codes.Unavailable/Unimplemented-with-"unknown service" instead, still
+// caught below. PromotionRegistry is still Unimplemented until AR-3c.
 func TestRegisterServices_AllFourServicesReachable(t *testing.T) {
 	conn := startTestServer(t)
 	ctx := context.Background()
@@ -155,8 +155,21 @@ func TestRegisterServices_AllFourServicesReachable(t *testing.T) {
 
 	t.Run("EnvironmentRegistry", func(t *testing.T) {
 		client := pb.NewEnvironmentRegistryClient(conn)
-		_, err := client.ListEnvironments(ctx, &pb.ListEnvironmentsRequest{})
-		assertUnimplementedFromHandler(t, "EnvironmentRegistry.ListEnvironments", "ListEnvironments not implemented", err)
+		resp, err := client.ListEnvironments(ctx, &pb.ListEnvironmentsRequest{})
+		if err != nil {
+			t.Fatalf("EnvironmentRegistry.ListEnvironments: expected success against the fake repository, got %v", err)
+		}
+		if len(resp.Environments) != 0 {
+			t.Fatalf("EnvironmentRegistry.ListEnvironments: expected no environments in a fresh fake registry, got %d", len(resp.Environments))
+		}
+	})
+
+	t.Run("EnvironmentRegistry_ArchiveEnvironment_StillReachable", func(t *testing.T) {
+		client := pb.NewEnvironmentRegistryClient(conn)
+		_, err := client.ArchiveEnvironment(ctx, &pb.ArchiveEnvironmentRequest{Key: "nonexistent", Reason: "test"})
+		if status.Code(err) != codes.NotFound {
+			t.Fatalf("EnvironmentRegistry.ArchiveEnvironment: expected codes.NotFound against a fresh fake registry, got %v", err)
+		}
 	})
 }
 

--- a/tools/app_registry/server/repository/fake/fake.go
+++ b/tools/app_registry/server/repository/fake/fake.go
@@ -35,20 +35,22 @@ type idemEntry struct {
 // (rather than fields directly on Registry) so it round-trips through JSON
 // cleanly for a cheap deep copy.
 type state struct {
-	Apps        map[string]repository.App
-	Charts      map[string]repository.Chart
-	Builds      map[string]repository.Build
-	Artifacts   map[string]repository.Artifact
-	Idempotency map[string]idemEntry
+	Apps         map[string]repository.App
+	Charts       map[string]repository.Chart
+	Builds       map[string]repository.Build
+	Artifacts    map[string]repository.Artifact
+	Idempotency  map[string]idemEntry
+	Environments map[string]repository.Environment // keyed by environment_id
 }
 
 func newState() *state {
 	return &state{
-		Apps:        map[string]repository.App{},
-		Charts:      map[string]repository.Chart{},
-		Builds:      map[string]repository.Build{},
-		Artifacts:   map[string]repository.Artifact{},
-		Idempotency: map[string]idemEntry{},
+		Apps:         map[string]repository.App{},
+		Charts:       map[string]repository.Chart{},
+		Builds:       map[string]repository.Build{},
+		Artifacts:    map[string]repository.Artifact{},
+		Idempotency:  map[string]idemEntry{},
+		Environments: map[string]repository.Environment{},
 	}
 }
 
@@ -81,6 +83,13 @@ func (r *Registry) Apps() repository.AppRepository                { return r }
 func (r *Registry) Builds() repository.BuildRepository            { return r }
 func (r *Registry) Artifacts() repository.ArtifactRepository      { return r }
 func (r *Registry) Idempotency() repository.IdempotencyRepository { return r }
+
+// Environments returns a distinct type, not Registry itself, because
+// EnvironmentRepository.Get/List collide by name with IdempotencyRepository's
+// Get and AppRepository's List-shaped methods if implemented directly on
+// Registry -- Go has no method overloading. Every method still reads/writes
+// r.state, the same map WithTx snapshots.
+func (r *Registry) Environments() repository.EnvironmentRepository { return environmentFake{r} }
 
 // WithTx snapshots state, runs fn against a Registry sharing that snapshot,
 // and commits the snapshot back only if fn succeeds — giving the fake the
@@ -455,6 +464,85 @@ func (r *Registry) Get(ctx context.Context, key string) ([]byte, bool, error) {
 func (r *Registry) Put(ctx context.Context, key, method string, response []byte) error {
 	r.state.Idempotency[key] = idemEntry{Method: method, Response: response}
 	return nil
+}
+
+// ============================================================================
+// EnvironmentRepository
+// ============================================================================
+
+// environmentFake implements repository.EnvironmentRepository over the same
+// *Registry.state every other repository reads/writes -- see Environments's
+// doc comment for why this can't be a set of methods directly on Registry.
+type environmentFake struct{ r *Registry }
+
+// Upsert mirrors postgres's environmentRepo.Upsert: creates by Key, or
+// updates every field but Key (the immutable identity) and Archived (only
+// Archive changes that) if a row already exists.
+func (f environmentFake) Upsert(ctx context.Context, e repository.Environment) (*repository.Environment, bool, error) {
+	if existing, ok := f.findByKey(e.Key); ok {
+		updated := existing
+		updated.DisplayName = e.DisplayName
+		updated.Rank = e.Rank
+		updated.RequiresApproval = e.RequiresApproval
+		updated.GitopsPath = e.GitopsPath
+		updated.AllowedPrincipals = e.AllowedPrincipals
+		f.r.state.Environments[updated.EnvironmentID] = updated
+		return &updated, false, nil
+	}
+
+	e.EnvironmentID = uuid.NewString()
+	e.Archived = false
+	f.r.state.Environments[e.EnvironmentID] = e
+	return &e, true, nil
+}
+
+func (f environmentFake) Get(ctx context.Context, key string) (*repository.Environment, error) {
+	if e, ok := f.findByKey(key); ok {
+		return &e, nil
+	}
+	return nil, repository.ErrNotFound
+}
+
+func (f environmentFake) List(ctx context.Context, includeArchived bool) ([]repository.Environment, error) {
+	var out []repository.Environment
+	for _, e := range f.r.state.Environments {
+		if !includeArchived && e.Archived {
+			continue
+		}
+		out = append(out, e)
+	}
+	sortEnvironments(out)
+	return out, nil
+}
+
+// Archive mirrors postgres's environmentRepo.Archive: archived -> archived
+// is a no-op success so a retried archive call is safe. reason is accepted
+// (and required at the handler layer) but not persisted, same as
+// SetAppStatus's reason today.
+func (f environmentFake) Archive(ctx context.Context, key, reason string) (*repository.Environment, error) {
+	e, ok := f.findByKey(key)
+	if !ok {
+		return nil, repository.ErrNotFound
+	}
+	if e.Archived {
+		return &e, nil
+	}
+	e.Archived = true
+	f.r.state.Environments[e.EnvironmentID] = e
+	return &e, nil
+}
+
+func (f environmentFake) findByKey(key string) (repository.Environment, bool) {
+	for _, e := range f.r.state.Environments {
+		if e.Key == key {
+			return e, true
+		}
+	}
+	return repository.Environment{}, false
+}
+
+func sortEnvironments(envs []repository.Environment) {
+	sort.Slice(envs, func(i, j int) bool { return envs[i].Rank < envs[j].Rank })
 }
 
 // ============================================================================

--- a/tools/app_registry/server/repository/models.go
+++ b/tools/app_registry/server/repository/models.go
@@ -160,3 +160,19 @@ type ArtifactLookup struct {
 	Kind          ArtifactKind
 	Version       string
 }
+
+// Environment is a promotion target, e.g. "dev"/"stage"/"prod". A row, not
+// an enum, so ephemeral/regional environments are an insert, not a release
+// — see ARCHITECTURE.md "Data model". Key is the immutable identity;
+// Upsert may change every other field but never Key itself.
+type Environment struct {
+	EnvironmentID     string
+	Key               string
+	DisplayName       string
+	Rank              int32
+	RequiresApproval  bool
+	GitopsPath        string
+	AllowedPrincipals []string
+	Archived          bool
+	CreatedAt         time.Time
+}

--- a/tools/app_registry/server/repository/postgres/BUILD.bazel
+++ b/tools/app_registry/server/repository/postgres/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "app.go",
         "artifact.go",
+        "environment.go",
         "errors.go",
         "idempotency.go",
         "repository.go",
@@ -68,6 +69,7 @@ go_test(
         "//tools/app_registry/server/auth",
         "//tools/app_registry/server/handlers",
         "//tools/app_registry/server/repository",
+        "@com_github_jackc_pgx_v5//pgconn",
         "@com_github_jackc_pgx_v5//pgxpool",
         "@com_github_jackc_pgx_v5//stdlib",
     ],

--- a/tools/app_registry/server/repository/postgres/environment.go
+++ b/tools/app_registry/server/repository/postgres/environment.go
@@ -1,0 +1,136 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/whale-net/everything/tools/app_registry/server/repository"
+)
+
+type environmentRepo struct{ ex dbtx }
+
+const environmentColumns = `environment_id, key, display_name, rank, requires_approval, gitops_path, allowed_principals, archived, created_at`
+
+func scanEnvironment(row pgx.Row) (repository.Environment, error) {
+	var e repository.Environment
+	if err := row.Scan(&e.EnvironmentID, &e.Key, &e.DisplayName, &e.Rank, &e.RequiresApproval, &e.GitopsPath, &e.AllowedPrincipals, &e.Archived, &e.CreatedAt); err != nil {
+		return repository.Environment{}, err
+	}
+	return e, nil
+}
+
+func (r *environmentRepo) getByKey(ctx context.Context, key string) (*repository.Environment, error) {
+	row := r.ex.QueryRow(ctx, `SELECT `+environmentColumns+` FROM environment WHERE key = $1`, key)
+	e, err := scanEnvironment(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, repository.ErrNotFound
+		}
+		return nil, err
+	}
+	return &e, nil
+}
+
+// Upsert creates an environment keyed by e.Key, or updates every field but
+// Key (the immutable identity) if one already exists. Archived is never
+// touched here -- only Archive changes it, mirroring
+// AppRepository.SetAppStatus's separation of "reconcile writes identity
+// fields" from "a dedicated call changes lifecycle state".
+func (r *environmentRepo) Upsert(ctx context.Context, e repository.Environment) (*repository.Environment, bool, error) {
+	// allowed_principals is NOT NULL; pgx encodes a nil []string as SQL NULL
+	// rather than an empty array, so a caller passing nil (the Go zero value
+	// for "no principals set") must be normalized before it reaches the
+	// driver.
+	if e.AllowedPrincipals == nil {
+		e.AllowedPrincipals = []string{}
+	}
+
+	existing, err := r.getByKey(ctx, e.Key)
+	if err != nil && !errors.Is(err, repository.ErrNotFound) {
+		return nil, false, fmt.Errorf("upsert environment %s: look up: %w", e.Key, err)
+	}
+
+	if existing == nil {
+		id := uuid.NewString()
+		now := time.Now().UTC()
+		if _, err := r.ex.Exec(ctx, `
+			INSERT INTO environment (environment_id, key, display_name, rank, requires_approval, gitops_path, allowed_principals, archived, created_at)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, false, $8)`,
+			id, e.Key, e.DisplayName, e.Rank, e.RequiresApproval, e.GitopsPath, e.AllowedPrincipals, now); err != nil {
+			if de, ok := translatePgError(err, fmt.Sprintf("environment %q already recorded", e.Key)); ok {
+				return nil, false, de
+			}
+			return nil, false, fmt.Errorf("upsert environment %s: insert: %w", e.Key, err)
+		}
+		e.EnvironmentID = id
+		e.Archived = false
+		e.CreatedAt = now
+		return &e, true, nil
+	}
+
+	if _, err := r.ex.Exec(ctx, `
+		UPDATE environment SET display_name = $2, rank = $3, requires_approval = $4, gitops_path = $5, allowed_principals = $6
+		WHERE key = $1`,
+		e.Key, e.DisplayName, e.Rank, e.RequiresApproval, e.GitopsPath, e.AllowedPrincipals); err != nil {
+		return nil, false, fmt.Errorf("upsert environment %s: update: %w", e.Key, err)
+	}
+
+	updated := *existing
+	updated.DisplayName = e.DisplayName
+	updated.Rank = e.Rank
+	updated.RequiresApproval = e.RequiresApproval
+	updated.GitopsPath = e.GitopsPath
+	updated.AllowedPrincipals = e.AllowedPrincipals
+	return &updated, false, nil
+}
+
+func (r *environmentRepo) Get(ctx context.Context, key string) (*repository.Environment, error) {
+	return r.getByKey(ctx, key)
+}
+
+func (r *environmentRepo) List(ctx context.Context, includeArchived bool) ([]repository.Environment, error) {
+	query := `SELECT ` + environmentColumns + ` FROM environment`
+	if !includeArchived {
+		query += ` WHERE archived = false`
+	}
+	query += ` ORDER BY rank ASC`
+
+	rows, err := r.ex.Query(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []repository.Environment
+	for rows.Next() {
+		e, err := scanEnvironment(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, e)
+	}
+	return out, rows.Err()
+}
+
+// Archive marks an environment archived. archived -> archived is a no-op
+// success so a retried archive call is safe, mirroring
+// AppRepository.SetAppStatus's archive path. reason is accepted (and
+// required at the handler layer) but not persisted -- there is no
+// environment audit log yet, same as SetAppStatus's reason today.
+func (r *environmentRepo) Archive(ctx context.Context, key, reason string) (*repository.Environment, error) {
+	existing, err := r.getByKey(ctx, key)
+	if err != nil {
+		return nil, err
+	}
+	if existing.Archived {
+		return existing, nil
+	}
+	if _, err := r.ex.Exec(ctx, `UPDATE environment SET archived = true WHERE key = $1`, key); err != nil {
+		return nil, fmt.Errorf("archive environment %s: %w", key, err)
+	}
+	existing.Archived = true
+	return existing, nil
+}

--- a/tools/app_registry/server/repository/postgres/postgres_integration_test.go
+++ b/tools/app_registry/server/repository/postgres/postgres_integration_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/jackc/pgx/v5/pgconn"
 	_ "github.com/jackc/pgx/v5/stdlib" // database/sql driver for the migration runner
 	"github.com/jackc/pgx/v5/pgxpool"
 
@@ -337,5 +338,119 @@ func TestResolveArtifact_ChartToImageJoin(t *testing.T) {
 	}
 	if len(builds) != 1 || builds[0].BuildID != buildID {
 		t.Fatalf("expected the pinned image's build %s, got %+v", buildID, builds)
+	}
+}
+
+// --- 5. migration 002 / environment table (AR-3b) --------------------------
+
+// TestMigration002SeedsDevStageProd proves migration 002 applies cleanly on
+// top of 001 (newTestRegistry already ran both) and that its seed data
+// landed: dev/stage/prod, ordered by rank ascending, none archived. This is
+// the one seed assertion that can only be proven against a real migration
+// run -- server/repository/fake has no migrations to apply.
+func TestMigration002SeedsDevStageProd(t *testing.T) {
+	_, pool := newTestRegistry(t)
+
+	rows, err := pool.Query(context.Background(), `SELECT key, rank, archived FROM environment ORDER BY rank ASC`)
+	if err != nil {
+		t.Fatalf("query environment: %v", err)
+	}
+	defer rows.Close()
+
+	type seeded struct {
+		key      string
+		rank     int32
+		archived bool
+	}
+	var got []seeded
+	for rows.Next() {
+		var s seeded
+		if err := rows.Scan(&s.key, &s.rank, &s.archived); err != nil {
+			t.Fatalf("scan environment row: %v", err)
+		}
+		got = append(got, s)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate environment rows: %v", err)
+	}
+
+	want := []seeded{{"dev", 0, false}, {"stage", 10, false}, {"prod", 20, false}}
+	if len(got) != len(want) {
+		t.Fatalf("expected migration 002 to seed exactly %v, got %v", want, got)
+	}
+	for i, w := range want {
+		if got[i] != w {
+			t.Fatalf("expected seeded environment %+v at rank position %d, got %+v", w, i, got[i])
+		}
+	}
+}
+
+// TestEnvironment_KeyUniqueConstraint proves the real UNIQUE (key)
+// constraint on the environment table -- not application logic -- rejects a
+// second row for a key that already exists. The repository layer's Upsert
+// never reaches this path on its own (it looks up by key before deciding
+// whether to insert or update), so this issues the raw INSERT directly to
+// exercise the constraint itself.
+func TestEnvironment_KeyUniqueConstraint(t *testing.T) {
+	_, pool := newTestRegistry(t)
+
+	// "dev" already exists from migration 002's seed data.
+	_, err := pool.Exec(context.Background(), `
+		INSERT INTO environment (key, display_name, rank) VALUES ('dev', 'Duplicate Dev', 99)`)
+	if err == nil {
+		t.Fatalf("expected a duplicate key insert to be rejected by the UNIQUE (key) constraint, got nil error")
+	}
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) {
+		t.Fatalf("expected a *pgconn.PgError, got: %v (%T)", err, err)
+	}
+	if pgErr.Code != sqlStateUniqueViolation {
+		t.Fatalf("expected SQLSTATE %s (unique_violation), got %s: %v", sqlStateUniqueViolation, pgErr.Code, err)
+	}
+
+	var count int
+	if err := pool.QueryRow(context.Background(), `SELECT count(*) FROM environment WHERE key = 'dev'`).Scan(&count); err != nil {
+		t.Fatalf("count dev rows: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected exactly 1 'dev' row after the rejected duplicate insert, found %d", count)
+	}
+}
+
+// TestEnvironmentRepo_UpsertCreateThenUpdate exercises the repository layer
+// (not raw SQL) end to end against real Postgres: a fresh key creates a row,
+// a repeated key updates every field but Key and Archived.
+func TestEnvironmentRepo_UpsertCreateThenUpdate(t *testing.T) {
+	reg, _ := newTestRegistry(t)
+	ctx := context.Background()
+
+	created, wasCreated, err := reg.Environments().Upsert(ctx, repository.Environment{
+		Key: "canary", DisplayName: "Canary", Rank: 5, GitopsPath: "environments/canary",
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if !wasCreated || created.EnvironmentID == "" {
+		t.Fatalf("expected a newly created environment, got %+v (created=%v)", created, wasCreated)
+	}
+
+	updated, wasCreated, err := reg.Environments().Upsert(ctx, repository.Environment{
+		Key: "canary", DisplayName: "Canary (renamed)", Rank: 6, RequiresApproval: true,
+		AllowedPrincipals: []string{"alice@example.com", "bob@example.com"},
+	})
+	if err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if wasCreated {
+		t.Fatalf("expected created=false on the second upsert of the same key")
+	}
+	if updated.EnvironmentID != created.EnvironmentID {
+		t.Fatalf("expected the same environment_id across upserts, got %s vs %s", updated.EnvironmentID, created.EnvironmentID)
+	}
+	if updated.DisplayName != "Canary (renamed)" || updated.Rank != 6 || !updated.RequiresApproval {
+		t.Fatalf("expected fields updated in place, got %+v", updated)
+	}
+	if len(updated.AllowedPrincipals) != 2 {
+		t.Fatalf("expected allowed_principals persisted as a real TEXT[] round-trip, got %+v", updated.AllowedPrincipals)
 	}
 }

--- a/tools/app_registry/server/repository/postgres/repository.go
+++ b/tools/app_registry/server/repository/postgres/repository.go
@@ -46,6 +46,9 @@ func (r *Registry) Apps() repository.AppRepository                { return &appR
 func (r *Registry) Builds() repository.BuildRepository            { return &buildRepo{ex: r.ex} }
 func (r *Registry) Artifacts() repository.ArtifactRepository      { return &artifactRepo{ex: r.ex} }
 func (r *Registry) Idempotency() repository.IdempotencyRepository { return &idempotencyRepo{ex: r.ex} }
+func (r *Registry) Environments() repository.EnvironmentRepository {
+	return &environmentRepo{ex: r.ex}
+}
 
 // WithTx runs fn inside a single Postgres transaction, committing iff fn
 // returns nil and rolling back otherwise. This is the atomicity boundary

--- a/tools/app_registry/server/repository/repository.go
+++ b/tools/app_registry/server/repository/repository.go
@@ -101,6 +101,32 @@ type IdempotencyRepository interface {
 	Put(ctx context.Context, key, method string, response []byte) error
 }
 
+// EnvironmentRepository covers the `environment` table (AR-3b). Writes
+// require auth.RoleAdmin at the handler layer -- ARCHITECTURE.md's
+// Authorization table gives EnvironmentRegistry no builder/promoter
+// carve-out. UpsertEnvironmentRequest and ArchiveEnvironmentRequest carry no
+// idempotency_key (unlike ReconcileApps/RecordBuild/RecordArtifact), so
+// these methods are not routed through runIdempotent -- same as
+// AppRepository.SetAppStatus, the other admin-only write in this package.
+type EnvironmentRepository interface {
+	// Upsert creates an environment keyed by e.Key, or updates every field
+	// but Key (the immutable identity) if one already exists. created
+	// reports which happened. Does not change Archived -- only Archive does.
+	Upsert(ctx context.Context, e Environment) (env *Environment, created bool, err error)
+
+	Get(ctx context.Context, key string) (*Environment, error)
+
+	// List returns environments ordered by rank ascending. includeArchived
+	// controls whether archived rows are included, matching
+	// ListEnvironmentsRequest.include_archived.
+	List(ctx context.Context, includeArchived bool) ([]Environment, error)
+
+	// Archive marks an environment archived. archived -> archived is a
+	// no-op success, so a retried archive call is safe -- same idempotent
+	// shape as AppRepository.SetAppStatus's archive path.
+	Archive(ctx context.Context, key, reason string) (*Environment, error)
+}
+
 // Registry aggregates the per-entity repositories and provides a
 // unit-of-work boundary. Handlers call WithTx to make a business operation
 // (reconcile, idempotency check-and-store, etc.) atomic: fn receives a
@@ -110,6 +136,7 @@ type Registry interface {
 	Builds() BuildRepository
 	Artifacts() ArtifactRepository
 	Idempotency() IdempotencyRepository
+	Environments() EnvironmentRepository
 
 	WithTx(ctx context.Context, fn func(ctx context.Context, r Registry) error) error
 }


### PR DESCRIPTION
Third layer of AR-3. **Environments only — no promotion logic**; `PromotionRegistry` stays `Unimplemented` until AR-3c. Branches off `main` (#503/#504 merged).

## Schema — migration `002_environment_registry`

`environment` table per ARCHITECTURE.md: `key` UNIQUE, `rank`, `requires_approval`, `gitops_path`, `allowed_principals TEXT[]`, `archived`.

Deliberate choices, all commented in the SQL:

- **`rank` is not UNIQUE.** Nothing in ARCHITECTURE.md requires distinct ranks, and two parallel prod-like environments sharing one is a legitimate shape.
- **Seeded ranks leave gaps (0/10/20)** so a future environment can be inserted between existing ones without renumbering.
- **`requires_approval` is `false` for all three, including prod.** The approval gate is unimplemented, so defaulting prod to `true` would be inert metadata a later migration has to reason about. Enabling it is an explicit admin action once the gate exists.
- **No `promotion` table** — that needs `environment_id` to exist first, so it lands in AR-3c's migration `003`. `migrate/README.md`'s planned-migrations table updated to reflect the split.

## Seeding lives in the migration

Via `INSERT ... ON CONFLICT (key) DO NOTHING`. This matters because **the registry is being deployed to a dev environment right now**, so the migration must be safe against a live database: `DO NOTHING` never overwrites rows an operator or a partial retry already created, and golang-migrate's own locking handles the concurrent-replica startup race for free. Doing it at server startup instead would need its own idempotency story for no benefit.

Verified against a real Postgres container, not just `bazel test`: up (0→2), down `-steps=1` (2→1, `environment` dropped, 001's tables intact), and re-up (seed rows reappear). Transcripts in `TODO-AR-3b.md`.

## Shape AR-3c builds on

`repository.EnvironmentRepository` (`Upsert`/`Get`/`List`/`Archive`) on `Registry.Environments()`, with postgres and fake implementations. Handlers: writes require `auth.RoleAdmin`, reads `auth.RequireAuthenticated`. Neither write RPC carries an `idempotency_key` in the proto, so neither routes through `runIdempotent`.

One wrinkle for future fake work: `EnvironmentRepository.Get`/`List` collide by name with existing methods on the fake's `Registry` struct, so it is implemented via a distinct `environmentFake{r}` wrapper — Go has no overloading.

**No proto changes were needed.**

## Bug caught by the real-Postgres tests

pgx encodes a nil Go `[]string` as SQL `NULL`, which the `NOT NULL allowed_principals` column rejects. Normalized to `[]string{}` before insert. The in-memory fake could not have caught this — the same reason AR-2d exists.

## Verification

- `bazel test //tools/app_registry/...` → 4/4 pass
- `bazel test //tools/app_registry/server/repository/postgres:postgres_integration_test` → pass
- `bazel build //tools/...` → green

Each new assertion verified by deliberately breaking it, then reverting:

| Break | Failure |
|---|---|
| `UNIQUE (key)` removed | every integration test failed at migration-apply: `no unique or exclusion constraint matching ON CONFLICT specification` |
| seeded `stage` rank 10→15 | `expected seeded environment {key:stage rank:10} at rank position 1, got {rank:15}` |
| fake `Upsert` hardcoded `DisplayName` | `TestUpsertEnvironment_CreateThenUpdate` failed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)