### PR TITLE
AR-3c: PromotionRegistry — SCD2 promote/rollback, drift reporting

### DIFF
--- a/tools/app_registry/ENV.md
+++ b/tools/app_registry/ENV.md
@@ -44,10 +44,10 @@ to configure the Keycloak side. In short: `AppRegistry.ReconcileApps`,
 `ArtifactRegistry.RecordBuild`/`RecordArtifact` require
 `app-registry-builder`; `AppRegistry.SetAppStatus` and every
 `EnvironmentRegistry` write (`UpsertEnvironment`/`ArchiveEnvironment`)
-require `app-registry-admin`; all read RPCs require only that the caller is
-authenticated (any role). `PromotionRegistry` stays `Unimplemented` until
-AR-3c, but `server/auth.RequirePromoter` already exists for it to call
-unmodified.
+require `app-registry-admin`; `PromotionRegistry.Promote`/`Rollback`
+require the environment-scoped `app-registry-promoter-<environment_key>`
+via `server/auth.RequirePromoter` (AR-3c); all read RPCs require only that
+the caller is authenticated (any role).
 
 **`GRPC_AUTH_MODE=none` and local/CI dev claims:** `libs/go/grpcauth`'s
 dev-mode claims default to `Roles: ["admin"]`, which satisfies none of this

--- a/tools/app_registry/PLAN.md
+++ b/tools/app_registry/PLAN.md
@@ -26,8 +26,9 @@ The registry is being deployed to `dev` by the repo owner. `app-registry-api`
 and `app-registry-migration` images publish from `apps=all`.
 `APP_REGISTRY_CICD_OPT_IN` is still unset, so CI makes no registry calls.
 
-**Next up:** AR-3c (`PromotionRegistry`). AR-2d, AR-3a, and AR-3b are done
-and stacked on top of `main`.
+**Next up:** AR-3d (CLI `promote`/`rollback`/`status`/`history`/`diff` +
+`promote.yml`). AR-2d, AR-3a, AR-3b, and AR-3c are done and stacked on top
+of `main`.
 
 ### AR-2c — merged
 
@@ -312,6 +313,64 @@ criterion is testable from the moment promotion exists:
   `[]string` as SQL `NULL`, which the `NOT NULL allowed_principals` column
   rejected — fixed by normalizing to `[]string{}` before insert.
 - See [TODO-AR-3b.md](TODO-AR-3b.md) for full execution detail and the
+  deliberate-break verification transcripts.
+
+### AR-3c — `PromotionRegistry` — done
+
+- Migration `003_promotion` (up/down): `promotion` (SCD2 — `valid_from`/
+  `valid_to`, partial unique index `promotion_current_idx ON promotion
+  (environment_id, target_key) WHERE valid_to IS NULL`, plus
+  `promotion_window_idx` for historical/`--at` reads), `promotion_event`
+  (append-only, NOT SCD2 per AGENTS.md), and `v_current_promotion` (pre-joins
+  promotion → artifact → environment for the current-state read path).
+  `target_key` is `"<kind>:<owner_full_name>"`, denormalized so the partial
+  unique index doesn't need a nullable two-column target; everything else
+  about the promoted artifact is read via a join to `artifact` rather than
+  copied onto `promotion`, so there is exactly one place it can drift from.
+- `repository.PromotionRepository` (`Promote`/`GetCurrent`/`GetPrevious`/
+  `StateAt`/`ListPromotions`/`RecordEvent`/`ListEvents`) + postgres and fake
+  implementations. `Promote` performs the SCD2 close-and-open write
+  described in AGENTS.md as three statements (read current, close it, open
+  the new row) that the caller MUST run inside `Registry.WithTx` — none of
+  the repository methods open their own transaction, matching every other
+  repository in this package.
+- All five `PromotionRegistry` RPCs implemented in
+  `server/handlers/promotion.go`. `Promote`/`Rollback` require
+  `auth.RequirePromoter(ctx, environment_key)` (environment-scoped, not a
+  flat role); the read RPCs require `auth.RequireAuthenticated`.
+- Business rules, all enforced in the handler (repository stays free of
+  gRPC/proto concerns, matching the rest of this package):
+  - **Promotability.** `NOT_PROMOTABLE` is rejected outright. `VIA_CHART`
+    requires `allow_override`; when set, the promotion is stored with
+    `is_override = true`.
+  - **Drift reporting.** `GetEnvironmentState` cross-references every
+    `is_override` image promotion against the pinned digest of any chart
+    promotion covering the same app in the same state snapshot, and reports
+    a mismatch as a `DriftEntry` on the chart's `EnvironmentStateEntry`.
+  - **`reason` required above rank 0**, checked against the resolved
+    `Environment.Rank` (dev is rank 0 by convention) — applies to both
+    `Promote` and `Rollback`.
+  - **`already_promoted` short-circuit.** Re-promoting the artifact that is
+    already current is detected before the SCD2 write and returns the
+    existing row instead of creating a redundant history entry — not a
+    correctness requirement from ARCHITECTURE.md, but avoids inflating audit
+    history with no-op repeats. A deliberate design call; the CLI can be
+    made to skip this check if it should be a hard error instead.
+- `Rollback` is `GetPrevious` + `Promote`: it re-promotes whatever
+  `GetPrevious` reports as the most recently superseded row for the target,
+  recording `PROMOTION_ACTION_ROLLBACK`.
+- Postgres integration coverage added, all verified against real Postgres
+  (see `postgres_integration_test.go`): the partial unique index
+  `promotion_current_idx` rejecting two concurrent current rows for the same
+  target (the test AR-2d's carry-over note flagged as deferred until this
+  table existed), promote→promote leaving exactly one current row with the
+  prior row's `valid_to` set, `StateAt` returning the correct historical row
+  for a timestamp strictly between two promotions, `GetPrevious` + `Promote`
+  round-tripping a rollback, and a transaction-abort test proving the
+  close-half of close-and-open does not survive when the open-half's INSERT
+  fails (verified to actually catch the bug by temporarily bypassing
+  `WithTx` in the test and observing the row count drop to zero).
+- See [TODO-AR-3c.md](TODO-AR-3c.md) for full execution detail and the
   deliberate-break verification transcripts.
 
 ### Credential model (decided)

--- a/tools/app_registry/TOC.md
+++ b/tools/app_registry/TOC.md
@@ -9,8 +9,10 @@ and the chart image lockfile are implemented and verified against real
 Postgres. The release workflow calls the CLI's write path after image/chart
 pushes, gated behind `APP_REGISTRY_CICD_OPT_IN`. The registry is being
 deployed to `dev`. AR-3 is split into a 4-PR stack (auth, environments,
-promotions, CLI). Auth (AR-3a) and `EnvironmentRegistry` (AR-3b) are done;
-`PromotionRegistry` stays `Unimplemented` until AR-3c lands.
+promotions, CLI). Auth (AR-3a), `EnvironmentRegistry` (AR-3b), and
+`PromotionRegistry` (AR-3c) are done, all verified against real Postgres;
+the CLI's `promote`/`rollback`/`status`/`history`/`diff` commands and the
+human-triggered `promote.yml` workflow (AR-3d) are next.
 
 **See [PLAN.md](PLAN.md) → "Current status" for the branch/PR map,
 what is next, and the carry-over items** — start there when picking this up.

--- a/tools/app_registry/TODO-AR-3c.md
+++ b/tools/app_registry/TODO-AR-3c.md
@@ -1,0 +1,127 @@
+# TODO-AR-3c — PromotionRegistry
+
+Execution tracking for AR-3c (see [PLAN.md](PLAN.md) → "AR-3 — Promotion").
+Scope: `PromotionRegistry` (`Promote`, `Rollback`, `GetEnvironmentState`,
+`ListPromotions`, `ListPromotionEvents`) — SCD2 close-and-open, event log,
+promotability enforcement, `allow_override` + drift reporting.
+
+## Done
+
+- [x] Migration `003_promotion` (up/down) in `migrate/schema/migrations/`:
+      `promotion` (SCD2 — `valid_from`/`valid_to`, partial unique index
+      `promotion_current_idx ON promotion (environment_id, target_key)
+      WHERE valid_to IS NULL`, plus `promotion_window_idx` for
+      historical/`--at` reads), `promotion_event` (append-only, NOT SCD2 per
+      AGENTS.md), `v_current_promotion` (pre-joins promotion → artifact →
+      environment). FK to `environment(environment_id)` from AR-3b.
+      `target_key` is `"<kind>:<owner_full_name>"`, denormalized so the
+      partial unique index doesn't need a nullable two-column target.
+- [x] `repository.Promotion` / `PromotionEvent` / `PromotionState` /
+      `PromotionAction` models + `PromotionRepository` interface + `TargetKey`
+      helper in `server/repository/models.go` and `repository.go`.
+- [x] `postgres/promotion.go`: `promotionRepo`. `Promote` does the SCD2
+      close-and-open as three statements (select current, close it, insert
+      the new row); callers MUST wrap it in `Registry.WithTx` — verified by
+      deliberately bypassing `WithTx` in a test and observing a partial
+      write (see "Verification" below). Historical reads (`GetPrevious`,
+      `StateAt(at != nil)`, `ListPromotions(include_history=true)`) query
+      base tables joined the same way as `v_current_promotion`; pure current
+      reads (`GetCurrent`, `StateAt(at == nil)`) query the view directly.
+- [x] `fake/fake.go`: `promotionFake` (distinct type wrapping `*Registry`,
+      matching `environmentFake`'s pattern) over `state.Promotions`/
+      `state.PromotionEvents`.
+- [x] `server/handlers/promotion.go`: all five RPCs implemented.
+      `Promote`/`Rollback` require `auth.RequirePromoter(ctx,
+      environment_key)`; the read RPCs require `auth.RequireAuthenticated`.
+      Business rules enforced here (repository stays free of gRPC/proto
+      concerns):
+      - Promotability: `NOT_PROMOTABLE` rejected outright; `VIA_CHART`
+        requires `allow_override`, and when set the promotion is stored
+        with `is_override = true`.
+      - Drift: `GetEnvironmentState` cross-references every `is_override`
+        image promotion against the pinned digest of any chart promotion
+        covering the same app, reporting a mismatch as a `DriftEntry` on
+        the chart's `EnvironmentStateEntry`.
+      - `reason` required when the target environment's `rank > 0`, for
+        both `Promote` and `Rollback`.
+      - `already_promoted` short-circuit: re-promoting the artifact that's
+        already current returns the existing row instead of writing a
+        redundant SCD2 row.
+      - `Rollback` = `GetPrevious` + `Promote`, recording
+        `PROMOTION_ACTION_ROLLBACK`.
+- [x] `server/handlers/convert.go`: `promotionToPB`/`promotionEventToPB` +
+      state/action enum conversions.
+- [x] `server/main.go`: `NewPromotionServer(repo)` wired in (was a no-arg
+      stub); doc comments updated.
+- [x] Unit tests against the fake (`server/handlers/promotion_test.go`):
+      promotability enforcement (all three DeployUnit rows),
+      `allow_override` + `is_override` round-trip, reason-required-above-
+      rank-0, promote→promote→exactly-one-current-row via `ListPromotions`,
+      `already_promoted` short-circuit, `dry_run` writes nothing, rollback
+      round-trip, rollback-with-no-history rejected, `GetEnvironmentState`
+      drift reporting.
+- [x] Authorization tests (`server/handlers/authz_test.go`): `Promote`/
+      `Rollback` require the environment-scoped promoter role (not a flat
+      one) — promoter-dev may promote to dev but not prod; builder cannot
+      promote at all; reads require only authentication.
+- [x] Postgres integration tests
+      (`server/repository/postgres/postgres_integration_test.go`), all
+      verified against a real Postgres container via `bazel test
+      //tools/app_registry/server/repository/postgres:postgres_integration_test
+      --nocache_test_results`:
+      - `TestPromotion_CurrentIdxRejectsConcurrentCurrentRows` — the
+        partial unique index itself (raw SQL, not the repository) rejects
+        two concurrent current rows. This is the test PLAN.md/AR-2d's
+        carry-over note flagged as deferred until the `promotion` table
+        existed.
+      - `TestPromotionRepo_PromoteTwice_ExactlyOneCurrentRow`.
+      - `TestPromotionRepo_StateAt_HistoricalWindow` — a timestamp strictly
+        between two promotions returns the first, not the second; seeded
+        via direct SQL (not wall-clock `time.Now()`) since
+        `Promotion.valid_from`/`valid_to` are Unix-second proto fields and a
+        real-time test would be flaky by construction.
+      - `TestPromotionRepo_Rollback_RoundTrips`.
+      - `TestPromotionRepo_Promote_TransactionAbortLeavesNoPartialWrite`.
+- [x] `bazel run //:gazelle` run; only `tools/app_registry/server/handlers`
+      and `.../repository/postgres`'s `BUILD.bazel` needed new deps/srcs.
+      (Gazelle also wanted to touch `cli/BUILD.bazel` and
+      `protos/BUILD.bazel` for unrelated pre-existing attribute-ordering
+      drift on this branch; reverted both — out of this change's scope.)
+- [x] Docs: `migrate/README.md`'s "Planned migrations" row for `003`
+      un-marked as planned; `TOC.md` and `PLAN.md` status lines updated;
+      this file.
+
+## Verification transcripts (deliberate-break passes)
+
+- **Auth guard.** Removed the `auth.RequirePromoter` call from `Promote`;
+  `TestPromote_Authorization`'s "wrong environment" / "builder" / "no
+  claims" subtests all failed as expected (`expected PermissionDenied, got
+  ... NotFound` / `Unauthenticated ... NotFound`). Reverted; suite green
+  again.
+- **Partial unique index.** Commented out `CREATE UNIQUE INDEX
+  promotion_current_idx ...` in the migration;
+  `TestPromotion_CurrentIdxRejectsConcurrentCurrentRows` failed (`expected a
+  second concurrent 'current' row ... to be rejected, got nil error`).
+  Reverted; full integration suite green again.
+- **Transaction wrapping.** Changed the integration test's `promoteTx`
+  helper to call `Promotions().Promote` directly against the pool instead
+  of through `Registry.WithTx` (simulating the AR-2a-style "forgot to wrap
+  in a transaction" bug).
+  `TestPromotionRepo_Promote_TransactionAbortLeavesNoPartialWrite` failed
+  (`found 0 current rows` — the UPDATE that closed the first promotion
+  committed on its own before the second statement's FK violation, leaving
+  the target with zero current rows). Reverted; full integration suite
+  green again.
+
+## Deferred / out of scope
+
+- `PENDING_APPROVAL`/`APPROVE`/`REJECT` — schema and enum values exist
+  (`environment.requires_approval`, `PromotionState`/`PromotionAction`) but
+  are never written; see ARCHITECTURE.md "Future: approval gate".
+- `writeback_outbox` and the Temporal writeback workflow — AR-4.
+- CLI commands (`promote`/`rollback`/`status`/`history`/`diff`) and
+  `promote.yml` — AR-3d.
+- `ListPromotions`/`ListPromotionEvents` do not implement real
+  `PageRequest.page_token` pagination (they return everything matching the
+  filter, `Page.TotalSize` only) — matches every other `List*` RPC in this
+  package (`ListArtifacts`, `ListApps`, ...), none of which paginate either.

--- a/tools/app_registry/migrate/README.md
+++ b/tools/app_registry/migrate/README.md
@@ -31,7 +31,7 @@ ArgoCD sync waves. See `friendly_computing_machine/docs/argocd-integration.md`.
 |---|---|
 | `001_initial_schema` | `app`, `chart`, `chart_app`, `build`, `artifact`, `artifact_link`, `idempotency_key`, `domain_adoption` |
 | `002_environment_registry` | `environment`, seeded with `dev`/`stage`/`prod` |
-| `003_promotion` (planned, AR-3c) | `promotion` (SCD2), `promotion_event`, `v_current_promotion` |
+| `003_promotion` (AR-3c) | `promotion` (SCD2), `promotion_event`, `v_current_promotion` |
 | `004_writeback_outbox` (planned, AR-4) | `writeback_outbox` |
 
 Split this way so AR-2 needs only `001`, AR-3b adds `002`, AR-3c adds `003`,

--- a/tools/app_registry/migrate/schema/migrations/003_promotion.down.sql
+++ b/tools/app_registry/migrate/schema/migrations/003_promotion.down.sql
@@ -1,0 +1,3 @@
+DROP VIEW IF EXISTS v_current_promotion;
+DROP TABLE IF EXISTS promotion_event;
+DROP TABLE IF EXISTS promotion;

--- a/tools/app_registry/migrate/schema/migrations/003_promotion.up.sql
+++ b/tools/app_registry/migrate/schema/migrations/003_promotion.up.sql
@@ -1,0 +1,106 @@
+-- App Registry — Promotion (AR-3c)
+--
+-- Adds the `promotion`/`promotion_event` tables described in
+-- ARCHITECTURE.md's "Data model" and "SCD2 on promotion". `promotion` is
+-- SCD2 history following the repo-wide valid_from/valid_to convention in
+-- AGENTS.md; `promotion_event` is a separate append-only audit log — per
+-- AGENTS.md, SCD2 does not apply to event logs.
+--
+-- Deliberately kept out of 001/002 (see migrate/README.md "Planned
+-- migrations"): this needs environment.environment_id (002) and
+-- artifact.artifact_id (001) as FK targets.
+
+-- promotion: what is deployed where, right now and historically. Rows are
+-- never updated in place except to close them (valid_to); a new promotion
+-- is always a new row. `target_key` is "<kind>:<owner_full_name>" — the
+-- promoted thing's identity, denormalized so the partial unique index below
+-- is expressible without a nullable two-column target (app_id is NULL for
+-- chart artifacts and vice versa, and a unique index cannot treat two NULLs
+-- as equal). Everything else about the promoted artifact (repository,
+-- version, digest, kind, owner) is read via the artifact join rather than
+-- copied here — see promotionSelectBase in
+-- server/repository/postgres/promotion.go — so there is exactly one place
+-- that data can drift from.
+CREATE TABLE promotion (
+    promotion_id    UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    environment_id  UUID NOT NULL REFERENCES environment (environment_id),
+    target_key      TEXT NOT NULL,
+    artifact_id     UUID NOT NULL REFERENCES artifact (artifact_id),
+    -- PromotionState in messages.proto. pending_approval/failed are reserved
+    -- for the approval gate described in ARCHITECTURE.md "Future: approval
+    -- gate" — AR-3c only ever writes 'active', and a row that has been
+    -- closed (valid_to set) is implicitly "superseded" without needing its
+    -- own state value change (the SCD2 window already encodes that).
+    state           TEXT NOT NULL DEFAULT 'active' CHECK (state IN ('pending_approval', 'active', 'superseded', 'failed')),
+    -- True when an image belonging to a DEPLOY_UNIT_CHART app was promoted
+    -- directly, bypassing its chart -- see ARCHITECTURE.md "Promotability".
+    is_override     BOOLEAN NOT NULL DEFAULT false,
+    valid_from      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    valid_to        TIMESTAMPTZ
+);
+
+-- Load-bearing, not an optimization (see migrate/README.md "Required
+-- indexes"): makes double-promotion of the same target in the same
+-- environment structurally impossible, and backs the hot "current state"
+-- read.
+CREATE UNIQUE INDEX promotion_current_idx
+    ON promotion (environment_id, target_key)
+    WHERE valid_to IS NULL;
+
+-- Backs GetEnvironmentState's "state at time T" query and
+-- ListPromotions(include_history = true): walking a target's history newest
+-- first.
+CREATE INDEX promotion_window_idx
+    ON promotion (environment_id, target_key, valid_from DESC);
+
+CREATE INDEX promotion_artifact_id_idx ON promotion (artifact_id);
+
+-- promotion_event: append-only audit log. One Promote/Rollback call writes
+-- exactly one event; the approval gate (unbuilt) would add APPROVE/REJECT
+-- events against the same promotion_id. NOT SCD2 — see AGENTS.md, event
+-- logs get their own shape, not valid_from/valid_to.
+CREATE TABLE promotion_event (
+    event_id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    promotion_id          UUID NOT NULL REFERENCES promotion (promotion_id),
+    action                TEXT NOT NULL CHECK (action IN ('promote', 'rollback', 'override', 'retire', 'approve', 'reject')),
+    actor                 TEXT NOT NULL DEFAULT '',
+    -- Free text. Required by the handler (not this schema) when the target
+    -- environment's rank > 0 -- see ARCHITECTURE.md "Authorization".
+    reason                TEXT NOT NULL DEFAULT '',
+    -- Set once the writeback worker (AR-4) picks this up, so an operator can
+    -- jump from an audit row to the workflow history. Empty string until then.
+    temporal_workflow_id  TEXT NOT NULL DEFAULT '',
+    temporal_run_id       TEXT NOT NULL DEFAULT '',
+    occurred_at           TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX promotion_event_promotion_id_idx ON promotion_event (promotion_id);
+CREATE INDEX promotion_event_occurred_at_idx ON promotion_event (occurred_at);
+
+-- v_current_promotion: pre-joins promotion (valid_to IS NULL) -> artifact ->
+-- environment so the CLI, the writeback worker, and any future UI never
+-- re-derive this join -- see AGENTS.md "Views". Column order matches
+-- server/repository/postgres/promotion.go's scanPromotion so the same Go
+-- code can scan either this view or the equivalent base-table query used
+-- for historical (non-current) reads.
+CREATE VIEW v_current_promotion AS
+SELECT
+    p.promotion_id,
+    p.environment_id,
+    e.key AS environment_key,
+    a.kind,
+    a.app_id,
+    a.chart_id,
+    p.artifact_id,
+    a.repository,
+    a.version,
+    a.digest,
+    p.state,
+    p.is_override,
+    p.valid_from,
+    p.valid_to,
+    p.target_key
+FROM promotion p
+JOIN environment e ON e.environment_id = p.environment_id
+JOIN artifact a ON a.artifact_id = p.artifact_id
+WHERE p.valid_to IS NULL;

--- a/tools/app_registry/server/handlers/BUILD.bazel
+++ b/tools/app_registry/server/handlers/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     importpath = "github.com/whale-net/everything/tools/app_registry/server/handlers",
     visibility = ["//visibility:public"],
     deps = [
+        "//libs/go/grpcauth",
         "//tools/app_registry/protos:appregistrypb",
         "//tools/app_registry/server/auth",
         "//tools/app_registry/server/repository",
@@ -31,6 +32,7 @@ go_test(
         "artifact_test.go",
         "authz_test.go",
         "environment_test.go",
+        "promotion_test.go",
     ],
     embed = [":handlers"],
     deps = [

--- a/tools/app_registry/server/handlers/authz_test.go
+++ b/tools/app_registry/server/handlers/authz_test.go
@@ -372,3 +372,120 @@ func TestEnvironmentReads_RequireAuthenticationOnly(t *testing.T) {
 		}
 	})
 }
+
+// TestPromote_Authorization and TestRollback_Authorization cover
+// PromotionRegistry's write RPCs, which require
+// auth.RequirePromoter(ctx, environment_key) -- an ENVIRONMENT-SCOPED role,
+// not a flat one. This is the credential-model boundary KEYCLOAK.md and
+// ARCHITECTURE.md's Authorization table both describe: a promoter-dev
+// credential must not be able to promote to prod, and a builder credential
+// (real power over AppRegistry/ArtifactRegistry) must not be able to
+// promote anywhere.
+func TestPromote_Authorization(t *testing.T) {
+	newSrv := func(t *testing.T) *PromotionServer {
+		t.Helper()
+		repo := fake.New()
+		envSrv := NewEnvironmentServer(repo)
+		if _, err := envSrv.UpsertEnvironment(ctxWithRoles(auth.RoleAdmin), &pb.UpsertEnvironmentRequest{Key: "dev"}); err != nil {
+			t.Fatalf("seed dev environment: %v", err)
+		}
+		if _, err := envSrv.UpsertEnvironment(ctxWithRoles(auth.RoleAdmin), &pb.UpsertEnvironmentRequest{Key: "prod", Rank: 20}); err != nil {
+			t.Fatalf("seed prod environment: %v", err)
+		}
+		return NewPromotionServer(repo)
+	}
+	req := func(env string) *pb.PromoteRequest {
+		return &pb.PromoteRequest{EnvironmentKey: env, ArtifactId: "nonexistent", Reason: "test", IdempotencyKey: "authz-promote"}
+	}
+
+	t.Run("matching environment role allowed through to business logic", func(t *testing.T) {
+		srv := newSrv(t)
+		// promoter-dev may call Promote against dev -- the request fails
+		// downstream (unknown artifact), which is exactly how we know auth
+		// let it through instead of stopping it.
+		_, err := srv.Promote(ctxWithRoles(auth.RolePromoterDev), req("dev"))
+		if status.Code(err) == codes.Unauthenticated || status.Code(err) == codes.PermissionDenied {
+			t.Fatalf("expected promoter-dev to pass authorization for dev, got %v", err)
+		}
+	})
+
+	t.Run("wrong environment's promoter role is PermissionDenied", func(t *testing.T) {
+		srv := newSrv(t)
+		// promoter-dev holds real power over dev, none over prod -- the
+		// exact per-environment isolation ARCHITECTURE.md depends on.
+		_, err := srv.Promote(ctxWithRoles(auth.RolePromoterDev), req("prod"))
+		requireCode(t, err, codes.PermissionDenied, "Promote(prod) as promoter-dev")
+	})
+
+	t.Run("builder credential cannot promote", func(t *testing.T) {
+		srv := newSrv(t)
+		_, err := srv.Promote(ctxWithRoles(auth.RoleBuilder), req("dev"))
+		requireCode(t, err, codes.PermissionDenied, "Promote as builder")
+	})
+
+	t.Run("no claims is Unauthenticated", func(t *testing.T) {
+		srv := newSrv(t)
+		_, err := srv.Promote(context.Background(), req("dev"))
+		requireCode(t, err, codes.Unauthenticated, "Promote")
+	})
+}
+
+func TestRollback_Authorization(t *testing.T) {
+	repo := fake.New()
+	envSrv := NewEnvironmentServer(repo)
+	if _, err := envSrv.UpsertEnvironment(ctxWithRoles(auth.RoleAdmin), &pb.UpsertEnvironmentRequest{Key: "prod", Rank: 20}); err != nil {
+		t.Fatalf("seed prod environment: %v", err)
+	}
+	srv := NewPromotionServer(repo)
+	req := &pb.RollbackRequest{EnvironmentKey: "prod", OwnerFullName: "demo-svc", Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE, Reason: "test", IdempotencyKey: "authz-rollback"}
+
+	t.Run("wrong environment's promoter role is PermissionDenied", func(t *testing.T) {
+		_, err := srv.Rollback(ctxWithRoles(auth.RolePromoterDev), req)
+		requireCode(t, err, codes.PermissionDenied, "Rollback(prod) as promoter-dev")
+	})
+
+	t.Run("no claims is Unauthenticated", func(t *testing.T) {
+		_, err := srv.Rollback(context.Background(), req)
+		requireCode(t, err, codes.Unauthenticated, "Rollback")
+	})
+}
+
+// TestPromotionReads_RequireAuthenticationOnly covers GetEnvironmentState,
+// ListPromotions, and ListPromotionEvents: any authenticated principal, no
+// specific (let alone environment-scoped) role.
+func TestPromotionReads_RequireAuthenticationOnly(t *testing.T) {
+	repo := fake.New()
+	envSrv := NewEnvironmentServer(repo)
+	if _, err := envSrv.UpsertEnvironment(ctxWithRoles(auth.RoleAdmin), &pb.UpsertEnvironmentRequest{Key: "dev"}); err != nil {
+		t.Fatalf("seed dev environment: %v", err)
+	}
+	srv := NewPromotionServer(repo)
+	readerCtx := ctxWithRoles(auth.RoleBuilder)
+
+	t.Run("GetEnvironmentState", func(t *testing.T) {
+		if _, err := srv.GetEnvironmentState(readerCtx, &pb.GetEnvironmentStateRequest{EnvironmentKey: "dev"}); err != nil {
+			t.Fatalf("expected any authenticated principal to read environment state, got %v", err)
+		}
+		if _, err := srv.GetEnvironmentState(context.Background(), &pb.GetEnvironmentStateRequest{EnvironmentKey: "dev"}); status.Code(err) != codes.Unauthenticated {
+			t.Fatalf("expected Unauthenticated with no claims, got %v", err)
+		}
+	})
+
+	t.Run("ListPromotions", func(t *testing.T) {
+		if _, err := srv.ListPromotions(readerCtx, &pb.ListPromotionsRequest{}); err != nil {
+			t.Fatalf("expected any authenticated principal to list promotions, got %v", err)
+		}
+		if _, err := srv.ListPromotions(context.Background(), &pb.ListPromotionsRequest{}); status.Code(err) != codes.Unauthenticated {
+			t.Fatalf("expected Unauthenticated with no claims, got %v", err)
+		}
+	})
+
+	t.Run("ListPromotionEvents", func(t *testing.T) {
+		if _, err := srv.ListPromotionEvents(readerCtx, &pb.ListPromotionEventsRequest{}); err != nil {
+			t.Fatalf("expected any authenticated principal to list promotion events, got %v", err)
+		}
+		if _, err := srv.ListPromotionEvents(context.Background(), &pb.ListPromotionEventsRequest{}); status.Code(err) != codes.Unauthenticated {
+			t.Fatalf("expected Unauthenticated with no claims, got %v", err)
+		}
+	})
+}

--- a/tools/app_registry/server/handlers/convert.go
+++ b/tools/app_registry/server/handlers/convert.go
@@ -229,6 +229,93 @@ func environmentsToPB(envs []repository.Environment) []*pb.Environment {
 	return out
 }
 
+func promotionStateToPB(s repository.PromotionState) pb.PromotionState {
+	switch s {
+	case repository.PromotionStatePendingApproval:
+		return pb.PromotionState_PROMOTION_STATE_PENDING_APPROVAL
+	case repository.PromotionStateActive:
+		return pb.PromotionState_PROMOTION_STATE_ACTIVE
+	case repository.PromotionStateSuperseded:
+		return pb.PromotionState_PROMOTION_STATE_SUPERSEDED
+	case repository.PromotionStateFailed:
+		return pb.PromotionState_PROMOTION_STATE_FAILED
+	default:
+		return pb.PromotionState_PROMOTION_STATE_UNSPECIFIED
+	}
+}
+
+func promotionActionToPB(a repository.PromotionAction) pb.PromotionAction {
+	switch a {
+	case repository.PromotionActionPromote:
+		return pb.PromotionAction_PROMOTION_ACTION_PROMOTE
+	case repository.PromotionActionRollback:
+		return pb.PromotionAction_PROMOTION_ACTION_ROLLBACK
+	case repository.PromotionActionOverride:
+		return pb.PromotionAction_PROMOTION_ACTION_OVERRIDE
+	case repository.PromotionActionRetire:
+		return pb.PromotionAction_PROMOTION_ACTION_RETIRE
+	case repository.PromotionActionApprove:
+		return pb.PromotionAction_PROMOTION_ACTION_APPROVE
+	case repository.PromotionActionReject:
+		return pb.PromotionAction_PROMOTION_ACTION_REJECT
+	default:
+		return pb.PromotionAction_PROMOTION_ACTION_UNSPECIFIED
+	}
+}
+
+func promotionToPB(p repository.Promotion) *pb.Promotion {
+	out := &pb.Promotion{
+		PromotionId:    p.PromotionID,
+		EnvironmentId:  p.EnvironmentID,
+		EnvironmentKey: p.EnvironmentKey,
+		ArtifactId:     p.ArtifactID,
+		Repository:     p.Repository,
+		Version:        p.Version,
+		Digest:         p.Digest,
+		State:          promotionStateToPB(p.State),
+		IsOverride:     p.IsOverride,
+		ValidFrom:      timeToUnix(p.ValidFrom),
+	}
+	if p.Kind == repository.ArtifactKindImage {
+		out.AppId = p.AppID
+	} else {
+		out.ChartId = p.ChartID
+	}
+	if p.ValidTo != nil {
+		out.ValidTo = timeToUnix(*p.ValidTo)
+	}
+	return out
+}
+
+func promotionsToPB(promotions []repository.Promotion) []*pb.Promotion {
+	out := make([]*pb.Promotion, 0, len(promotions))
+	for _, p := range promotions {
+		out = append(out, promotionToPB(p))
+	}
+	return out
+}
+
+func promotionEventToPB(e repository.PromotionEvent) *pb.PromotionEvent {
+	return &pb.PromotionEvent{
+		EventId:            e.EventID,
+		PromotionId:        e.PromotionID,
+		Action:             promotionActionToPB(e.Action),
+		Actor:              e.Actor,
+		Reason:             e.Reason,
+		TemporalWorkflowId: e.TemporalWorkflowID,
+		TemporalRunId:      e.TemporalRunID,
+		OccurredAt:         timeToUnix(e.OccurredAt),
+	}
+}
+
+func promotionEventsToPB(events []repository.PromotionEvent) []*pb.PromotionEvent {
+	out := make([]*pb.PromotionEvent, 0, len(events))
+	for _, e := range events {
+		out = append(out, promotionEventToPB(e))
+	}
+	return out
+}
+
 func containedImagesFromPB(images []*pb.ContainedImage) []repository.ContainedImageInput {
 	out := make([]repository.ContainedImageInput, 0, len(images))
 	for _, ci := range images {

--- a/tools/app_registry/server/handlers/promotion.go
+++ b/tools/app_registry/server/handlers/promotion.go
@@ -2,40 +2,467 @@ package handlers
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"sort"
+	"time"
 
+	"github.com/whale-net/everything/libs/go/grpcauth"
 	pb "github.com/whale-net/everything/tools/app_registry/protos"
+	"github.com/whale-net/everything/tools/app_registry/server/auth"
+	"github.com/whale-net/everything/tools/app_registry/server/repository"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 )
 
-// PromotionServer implements pb.PromotionRegistryServer. Real writes land in
-// AR-3; the underlying `promotion`/`promotion_event` tables don't exist until
-// migration 002, so every RPC here is a hard Unimplemented in AR-1.
+// PromotionServer implements pb.PromotionRegistryServer, backed by
+// repository.Registry. See ARCHITECTURE.md "Promotability" and
+// "Authorization" for the rules enforced here: Promote/Rollback require
+// auth.RequirePromoter for the target environment; the read RPCs require
+// only auth.RequireAuthenticated.
 type PromotionServer struct {
 	pb.UnimplementedPromotionRegistryServer
+	repo repository.Registry
 }
 
-// NewPromotionServer constructs a PromotionServer.
-func NewPromotionServer() *PromotionServer {
-	return &PromotionServer{}
+// NewPromotionServer constructs a PromotionServer over repo.
+func NewPromotionServer(repo repository.Registry) *PromotionServer {
+	return &PromotionServer{repo: repo}
 }
 
+// Promote resolves the target artifact, enforces promotability (rejecting
+// NOT_PROMOTABLE outright, requiring allow_override for VIA_CHART), then
+// performs the SCD2 close-and-open write inside one transaction alongside
+// the promotion_event row -- see repository.PromotionRepository.Promote and
+// AGENTS.md "SCD2".
 func (s *PromotionServer) Promote(ctx context.Context, req *pb.PromoteRequest) (*pb.PromoteResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "Promote not implemented")
+	if req.EnvironmentKey == "" {
+		return nil, status.Error(codes.InvalidArgument, "environment_key is required")
+	}
+	if err := auth.RequirePromoter(ctx, req.EnvironmentKey); err != nil {
+		return nil, err
+	}
+
+	env, err := s.repo.Environments().Get(ctx, req.EnvironmentKey)
+	if err != nil {
+		return nil, mapRepoErr(err)
+	}
+	if env.Archived {
+		return nil, status.Errorf(codes.FailedPrecondition, "environment %q is archived", env.Key)
+	}
+	// ARCHITECTURE.md "Authorization": "reason is required on promotions to
+	// any environment above rank 0" (dev is rank 0 by convention).
+	if req.Reason == "" && env.Rank > 0 {
+		return nil, status.Errorf(codes.InvalidArgument, "reason is required to promote to %q (rank %d)", env.Key, env.Rank)
+	}
+
+	lookup, err := promoteArtifactLookup(req)
+	if err != nil {
+		return nil, err
+	}
+	artifact, err := s.repo.Artifacts().GetArtifact(ctx, lookup)
+	if err != nil {
+		return nil, mapRepoErr(err)
+	}
+
+	candidate, err := s.buildCandidatePromotion(ctx, *env, *artifact, req.AllowOverride)
+	if err != nil {
+		return nil, err
+	}
+
+	if req.DryRun {
+		resp := &pb.PromoteResponse{DryRun: true, Promotion: promotionToPB(candidate)}
+		if current, cerr := s.repo.Promotions().GetCurrent(ctx, env.EnvironmentID, candidate.TargetKey); cerr == nil {
+			resp.Superseded = promotionToPB(*current)
+			resp.AlreadyPromoted = current.ArtifactID == artifact.ArtifactID && current.IsOverride == candidate.IsOverride
+		} else if !errors.Is(cerr, repository.ErrNotFound) {
+			return nil, mapRepoErr(cerr)
+		}
+		return resp, nil
+	}
+
+	if req.IdempotencyKey == "" {
+		return nil, status.Error(codes.InvalidArgument, "idempotency_key is required")
+	}
+
+	resp, _, err := runIdempotent(ctx, s.repo, req.IdempotencyKey, "Promote",
+		func() proto.Message { return &pb.PromoteResponse{} },
+		func(ctx context.Context, r repository.Registry) (proto.Message, error) {
+			// Short-circuit an already-current artifact rather than writing
+			// an identical, redundant SCD2 row -- the whole point of a
+			// distinct AlreadyPromoted flag on the response.
+			if existing, gerr := r.Promotions().GetCurrent(ctx, env.EnvironmentID, candidate.TargetKey); gerr == nil {
+				if existing.ArtifactID == artifact.ArtifactID && existing.IsOverride == candidate.IsOverride {
+					return &pb.PromoteResponse{Promotion: promotionToPB(*existing), AlreadyPromoted: true}, nil
+				}
+			} else if !errors.Is(gerr, repository.ErrNotFound) {
+				return nil, gerr
+			}
+
+			current, superseded, perr := r.Promotions().Promote(ctx, candidate)
+			if perr != nil {
+				return nil, perr
+			}
+			action := repository.PromotionActionPromote
+			if candidate.IsOverride {
+				action = repository.PromotionActionOverride
+			}
+			event, eerr := r.Promotions().RecordEvent(ctx, repository.PromotionEvent{
+				PromotionID: current.PromotionID,
+				Action:      action,
+				Actor:       actorFromCtx(ctx),
+				Reason:      req.Reason,
+			})
+			if eerr != nil {
+				return nil, eerr
+			}
+			out := &pb.PromoteResponse{Promotion: promotionToPB(*current), Event: promotionEventToPB(*event)}
+			if superseded != nil {
+				out.Superseded = promotionToPB(*superseded)
+			}
+			return out, nil
+		},
+	)
+	if err != nil {
+		return nil, mapRepoErr(err)
+	}
+	return resp.(*pb.PromoteResponse), nil
 }
 
+// buildCandidatePromotion resolves artifact's promotability against
+// ARCHITECTURE.md "Promotability" and, if legal, builds the (not yet
+// written) repository.Promotion the caller is requesting. Every field is
+// populated here -- not left for a later join -- so both dry_run responses
+// and the fake repository (which does no SQL joins) see a complete row.
+func (s *PromotionServer) buildCandidatePromotion(ctx context.Context, env repository.Environment, artifact repository.Artifact, allowOverride bool) (repository.Promotion, error) {
+	isOverride := false
+	switch artifact.Promotability {
+	case repository.PromotabilityNotPromotable:
+		return repository.Promotion{}, status.Errorf(codes.FailedPrecondition, "artifact %s is not promotable", artifact.ArtifactID)
+	case repository.PromotabilityViaChart:
+		if !allowOverride {
+			return repository.Promotion{}, status.Errorf(codes.FailedPrecondition,
+				"artifact %s belongs to a chart-deployed app; promoting it directly bypasses the chart -- pass allow_override to acknowledge", artifact.ArtifactID)
+		}
+		isOverride = true
+	case repository.PromotabilityPromotable:
+		// Legal regardless of allow_override.
+	default:
+		return repository.Promotion{}, status.Errorf(codes.FailedPrecondition, "artifact %s has unknown promotability", artifact.ArtifactID)
+	}
+
+	ownerFullName, err := s.ownerFullName(ctx, artifact)
+	if err != nil {
+		return repository.Promotion{}, mapRepoErr(err)
+	}
+
+	return repository.Promotion{
+		EnvironmentID:  env.EnvironmentID,
+		EnvironmentKey: env.Key,
+		TargetKey:      repository.TargetKey(artifact.Kind, ownerFullName),
+		Kind:           artifact.Kind,
+		AppID:          artifact.AppID,
+		ChartID:        artifact.ChartID,
+		ArtifactID:     artifact.ArtifactID,
+		Repository:     artifact.Repository,
+		Version:        artifact.Version,
+		Digest:         artifact.Digest,
+		State:          repository.PromotionStateActive,
+		IsOverride:     isOverride,
+		ValidFrom:      time.Now().UTC(),
+	}, nil
+}
+
+func (s *PromotionServer) ownerFullName(ctx context.Context, a repository.Artifact) (string, error) {
+	if a.Kind == repository.ArtifactKindImage {
+		app, err := s.repo.Apps().GetAppByID(ctx, a.AppID)
+		if err != nil {
+			return "", err
+		}
+		return app.FullName(), nil
+	}
+	chart, err := s.repo.Apps().GetChartByID(ctx, a.ChartID)
+	if err != nil {
+		return "", err
+	}
+	return chart.FullName(), nil
+}
+
+func promoteArtifactLookup(req *pb.PromoteRequest) (repository.ArtifactLookup, error) {
+	switch {
+	case req.ArtifactId != "":
+		return repository.ArtifactLookup{ArtifactID: req.ArtifactId}, nil
+	case req.Digest != "":
+		return repository.ArtifactLookup{Digest: req.Digest}, nil
+	case req.OwnerFullName != "":
+		kind := artifactKindFromPB(req.Kind)
+		if kind == "" {
+			return repository.ArtifactLookup{}, status.Error(codes.InvalidArgument, "kind is required when identifying by owner_full_name")
+		}
+		if req.Version == "" {
+			return repository.ArtifactLookup{}, status.Error(codes.InvalidArgument, "version is required when identifying by owner_full_name")
+		}
+		return repository.ArtifactLookup{OwnerFullName: req.OwnerFullName, Kind: kind, Version: req.Version}, nil
+	default:
+		return repository.ArtifactLookup{}, status.Error(codes.InvalidArgument, "artifact_id, digest, or owner_full_name+kind+version is required")
+	}
+}
+
+// Rollback is sugar over Promote: it re-promotes whatever GetPrevious
+// reports as the most recently superseded row for this target -- see
+// api_messages_promotion.proto's doc comment on RollbackRequest.
 func (s *PromotionServer) Rollback(ctx context.Context, req *pb.RollbackRequest) (*pb.RollbackResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "Rollback not implemented")
+	if req.EnvironmentKey == "" {
+		return nil, status.Error(codes.InvalidArgument, "environment_key is required")
+	}
+	if err := auth.RequirePromoter(ctx, req.EnvironmentKey); err != nil {
+		return nil, err
+	}
+	kind := artifactKindFromPB(req.Kind)
+	if kind == "" {
+		return nil, status.Error(codes.InvalidArgument, "kind is required")
+	}
+	if req.OwnerFullName == "" {
+		return nil, status.Error(codes.InvalidArgument, "owner_full_name is required")
+	}
+
+	env, err := s.repo.Environments().Get(ctx, req.EnvironmentKey)
+	if err != nil {
+		return nil, mapRepoErr(err)
+	}
+	if req.Reason == "" && env.Rank > 0 {
+		return nil, status.Errorf(codes.InvalidArgument, "reason is required to roll back %q (rank %d)", env.Key, env.Rank)
+	}
+
+	targetKey := repository.TargetKey(kind, req.OwnerFullName)
+	previous, err := s.repo.Promotions().GetPrevious(ctx, env.EnvironmentID, targetKey)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, status.Errorf(codes.FailedPrecondition, "no prior promotion of %s in %q to roll back to", req.OwnerFullName, env.Key)
+		}
+		return nil, mapRepoErr(err)
+	}
+
+	candidate := *previous
+	candidate.PromotionID = ""
+	candidate.State = repository.PromotionStateActive
+	candidate.ValidFrom = time.Now().UTC()
+	candidate.ValidTo = nil
+
+	if req.DryRun {
+		resp := &pb.RollbackResponse{DryRun: true, Promotion: promotionToPB(candidate)}
+		if current, cerr := s.repo.Promotions().GetCurrent(ctx, env.EnvironmentID, targetKey); cerr == nil {
+			resp.Superseded = promotionToPB(*current)
+		} else if !errors.Is(cerr, repository.ErrNotFound) {
+			return nil, mapRepoErr(cerr)
+		}
+		return resp, nil
+	}
+
+	if req.IdempotencyKey == "" {
+		return nil, status.Error(codes.InvalidArgument, "idempotency_key is required")
+	}
+
+	resp, _, err := runIdempotent(ctx, s.repo, req.IdempotencyKey, "Rollback",
+		func() proto.Message { return &pb.RollbackResponse{} },
+		func(ctx context.Context, r repository.Registry) (proto.Message, error) {
+			current, superseded, perr := r.Promotions().Promote(ctx, candidate)
+			if perr != nil {
+				return nil, perr
+			}
+			event, eerr := r.Promotions().RecordEvent(ctx, repository.PromotionEvent{
+				PromotionID: current.PromotionID,
+				Action:      repository.PromotionActionRollback,
+				Actor:       actorFromCtx(ctx),
+				Reason:      req.Reason,
+			})
+			if eerr != nil {
+				return nil, eerr
+			}
+			out := &pb.RollbackResponse{Promotion: promotionToPB(*current), Event: promotionEventToPB(*event)}
+			if superseded != nil {
+				out.Superseded = promotionToPB(*superseded)
+			}
+			return out, nil
+		},
+	)
+	if err != nil {
+		return nil, mapRepoErr(err)
+	}
+	return resp.(*pb.RollbackResponse), nil
 }
 
+// GetEnvironmentState is the deploy-tooling read path: current state, or
+// state at a past instant via the SCD2 window (StateAt). For chart
+// promotions it also reports drift -- an image belonging to the chart that
+// was separately promoted with allow_override, so the chart's pin no longer
+// matches what's actually live. See ARCHITECTURE.md "Promotability".
 func (s *PromotionServer) GetEnvironmentState(ctx context.Context, req *pb.GetEnvironmentStateRequest) (*pb.GetEnvironmentStateResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "GetEnvironmentState not implemented")
+	if err := auth.RequireAuthenticated(ctx); err != nil {
+		return nil, err
+	}
+	if req.EnvironmentKey == "" {
+		return nil, status.Error(codes.InvalidArgument, "environment_key is required")
+	}
+
+	env, err := s.repo.Environments().Get(ctx, req.EnvironmentKey)
+	if err != nil {
+		return nil, mapRepoErr(err)
+	}
+
+	var at *time.Time
+	if req.At != 0 {
+		t := unixToTime(req.At)
+		at = &t
+	}
+
+	promotions, err := s.repo.Promotions().StateAt(ctx, env.EnvironmentID, at)
+	if err != nil {
+		return nil, mapRepoErr(err)
+	}
+
+	entries := make([]*pb.EnvironmentStateEntry, 0, len(promotions))
+	type chartPin struct {
+		digest string
+		entry  *pb.EnvironmentStateEntry
+	}
+	chartPinByAppID := map[string]chartPin{}
+
+	for _, p := range promotions {
+		if req.Domain != "" {
+			domain, derr := s.ownerDomain(ctx, p)
+			if derr != nil || domain != req.Domain {
+				continue
+			}
+		}
+		artifact, aerr := s.repo.Artifacts().GetArtifact(ctx, repository.ArtifactLookup{ArtifactID: p.ArtifactID})
+		if aerr != nil {
+			return nil, mapRepoErr(aerr)
+		}
+		entry := &pb.EnvironmentStateEntry{Promotion: promotionToPB(p), Artifact: artifactToPB(*artifact)}
+		if p.Kind == repository.ArtifactKindChart {
+			for _, link := range artifact.Contains {
+				entry.Images = append(entry.Images, artifactLinkToPB(link))
+				chartPinByAppID[link.AppID] = chartPin{digest: link.Digest, entry: entry}
+			}
+		}
+		entries = append(entries, entry)
+	}
+
+	for _, p := range promotions {
+		if p.Kind != repository.ArtifactKindImage || !p.IsOverride {
+			continue
+		}
+		pin, ok := chartPinByAppID[p.AppID]
+		if !ok || pin.digest == p.Digest {
+			continue
+		}
+		appFullName := ""
+		if app, aerr := s.repo.Apps().GetAppByID(ctx, p.AppID); aerr == nil {
+			appFullName = app.FullName()
+		}
+		pin.entry.Drift = append(pin.entry.Drift, &pb.DriftEntry{
+			AppId:             p.AppID,
+			AppFullName:       appFullName,
+			ChartPinnedDigest: pin.digest,
+			PromotedDigest:    p.Digest,
+			PromotionId:       p.PromotionID,
+		})
+	}
+
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Promotion.PromotionId < entries[j].Promotion.PromotionId })
+
+	asOf := req.At
+	if asOf == 0 {
+		asOf = time.Now().Unix()
+	}
+
+	return &pb.GetEnvironmentStateResponse{
+		Environment: environmentToPB(*env),
+		Entries:     entries,
+		AsOf:        asOf,
+		StateHash:   stateHash(entries),
+	}, nil
+}
+
+func (s *PromotionServer) ownerDomain(ctx context.Context, p repository.Promotion) (string, error) {
+	if p.Kind == repository.ArtifactKindImage {
+		app, err := s.repo.Apps().GetAppByID(ctx, p.AppID)
+		if err != nil {
+			return "", err
+		}
+		return app.Domain, nil
+	}
+	chart, err := s.repo.Apps().GetChartByID(ctx, p.ChartID)
+	if err != nil {
+		return "", err
+	}
+	return chart.Domain, nil
+}
+
+// stateHash is a stable content hash of entries, used by the writeback
+// worker (AR-4) to skip no-op gitops commits -- see
+// GetEnvironmentStateResponse's doc comment. entries must already be
+// sorted deterministically by the caller.
+func stateHash(entries []*pb.EnvironmentStateEntry) string {
+	h := sha256.New()
+	for _, e := range entries {
+		fmt.Fprintf(h, "%s|%s|%s|%v\n", e.Promotion.PromotionId, e.Artifact.Digest, e.Promotion.State, e.Promotion.IsOverride)
+	}
+	return hex.EncodeToString(h.Sum(nil))
 }
 
 func (s *PromotionServer) ListPromotions(ctx context.Context, req *pb.ListPromotionsRequest) (*pb.ListPromotionsResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "ListPromotions not implemented")
+	if err := auth.RequireAuthenticated(ctx); err != nil {
+		return nil, err
+	}
+	promotions, err := s.repo.Promotions().ListPromotions(ctx, repository.PromotionListFilter{
+		EnvironmentKey: req.EnvironmentKey,
+		OwnerFullName:  req.OwnerFullName,
+		IncludeHistory: req.IncludeHistory,
+	})
+	if err != nil {
+		return nil, mapRepoErr(err)
+	}
+	return &pb.ListPromotionsResponse{
+		Promotions: promotionsToPB(promotions),
+		Page:       &pb.PageResponse{TotalSize: int32(len(promotions))},
+	}, nil
 }
 
 func (s *PromotionServer) ListPromotionEvents(ctx context.Context, req *pb.ListPromotionEventsRequest) (*pb.ListPromotionEventsResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "ListPromotionEvents not implemented")
+	if err := auth.RequireAuthenticated(ctx); err != nil {
+		return nil, err
+	}
+	var since time.Time
+	if req.Since != 0 {
+		since = unixToTime(req.Since)
+	}
+	events, err := s.repo.Promotions().ListEvents(ctx, repository.PromotionEventListFilter{
+		PromotionID:    req.PromotionId,
+		EnvironmentKey: req.EnvironmentKey,
+		OwnerFullName:  req.OwnerFullName,
+		Actor:          req.Actor,
+		Since:          since,
+	})
+	if err != nil {
+		return nil, mapRepoErr(err)
+	}
+	return &pb.ListPromotionEventsResponse{
+		Events: promotionEventsToPB(events),
+		Page:   &pb.PageResponse{TotalSize: int32(len(events))},
+	}, nil
+}
+
+// actorFromCtx reads the authenticated principal recorded on
+// promotion_event.actor. Claims are guaranteed present here -- every caller
+// of this helper runs after auth.RequirePromoter has already succeeded.
+func actorFromCtx(ctx context.Context) string {
+	if claims, ok := grpcauth.ClaimsFromContext(ctx); ok {
+		return claims.Subject
+	}
+	return ""
 }

--- a/tools/app_registry/server/handlers/promotion_test.go
+++ b/tools/app_registry/server/handlers/promotion_test.go
@@ -1,0 +1,419 @@
+package handlers
+
+import (
+	"testing"
+
+	pb "github.com/whale-net/everything/tools/app_registry/protos"
+	"github.com/whale-net/everything/tools/app_registry/server/repository/fake"
+	appmetapb "github.com/whale-net/everything/tools/appmeta/proto"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// promotionFixture wires one shared fake registry through all four servers,
+// with one app per DeployUnit (mirroring artifact_test.go's setup) plus a
+// chart pinning the chart-deployed app's image, and dev(rank 0)/stage(rank
+// 10) environments -- everything ARCHITECTURE.md's "Promotability" and
+// "Authorization" sections need to be exercised.
+type promotionFixture struct {
+	app   *AppServer
+	art   *ArtifactServer
+	env   *EnvironmentServer
+	promo *PromotionServer
+
+	chartImageDigest string // the digest the chart pins for chart-app
+}
+
+func newPromotionFixture(t *testing.T) *promotionFixture {
+	t.Helper()
+	repo := fake.New()
+	appSrv := NewAppServer(repo)
+	artSrv := NewArtifactServer(repo)
+	envSrv := NewEnvironmentServer(repo)
+	promoSrv := NewPromotionServer(repo)
+	ctx := authedCtx()
+
+	if _, err := appSrv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
+		Manifests: manifestSet([]*appmetapb.AppManifest{
+			{Domain: "demo", Name: "chart-app", DeployUnit: appmetapb.DeployUnit_DEPLOY_UNIT_CHART},
+			{Domain: "demo", Name: "image-app", DeployUnit: appmetapb.DeployUnit_DEPLOY_UNIT_IMAGE},
+			{Domain: "demo", Name: "none-app", DeployUnit: appmetapb.DeployUnit_DEPLOY_UNIT_NONE},
+		}, []*appmetapb.ChartManifest{
+			{Domain: "demo", Name: "achart", Apps: []string{"chart-app"}},
+		}),
+		IdempotencyKey: "fixture-reconcile",
+	}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	build, err := artSrv.RecordBuild(ctx, &pb.RecordBuildRequest{GitSha: "abc123", WorkflowRunId: "run-1", IdempotencyKey: "fixture-build"})
+	if err != nil {
+		t.Fatalf("record build: %v", err)
+	}
+
+	mustRecordArtifact(t, artSrv, &pb.RecordArtifactRequest{
+		BuildId: build.Build.BuildId, Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE,
+		OwnerFullName: "demo-chart-app", Digest: "sha256:chartapp-v1", Version: "v1.0.0",
+		IdempotencyKey: "fixture-artifact-chartapp-image",
+	})
+	mustRecordArtifact(t, artSrv, &pb.RecordArtifactRequest{
+		BuildId: build.Build.BuildId, Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE,
+		OwnerFullName: "demo-image-app", Digest: "sha256:imageapp-v1", Version: "v1.0.0",
+		IdempotencyKey: "fixture-artifact-imageapp",
+	})
+	mustRecordArtifact(t, artSrv, &pb.RecordArtifactRequest{
+		BuildId: build.Build.BuildId, Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE,
+		OwnerFullName: "demo-none-app", Digest: "sha256:noneapp-v1", Version: "v1.0.0",
+		IdempotencyKey: "fixture-artifact-noneapp",
+	})
+	mustRecordArtifact(t, artSrv, &pb.RecordArtifactRequest{
+		BuildId: build.Build.BuildId, Kind: pb.ArtifactKind_ARTIFACT_KIND_CHART,
+		OwnerFullName: "demo-achart", Digest: "sha256:achart-v1", Version: "v1.0.0",
+		Contains: []*pb.ContainedImage{
+			{AppFullName: "demo-chart-app", Repository: "ghcr.io/demo/chart-app", Version: "v1.0.0", Digest: "sha256:chartapp-v1"},
+		},
+		IdempotencyKey: "fixture-artifact-achart",
+	})
+
+	for _, e := range []struct {
+		key  string
+		rank int32
+	}{{"dev", 0}, {"stage", 10}} {
+		if _, err := envSrv.UpsertEnvironment(ctx, &pb.UpsertEnvironmentRequest{Key: e.key, Rank: e.rank}); err != nil {
+			t.Fatalf("upsert environment %s: %v", e.key, err)
+		}
+	}
+
+	return &promotionFixture{app: appSrv, art: artSrv, env: envSrv, promo: promoSrv, chartImageDigest: "sha256:chartapp-v1"}
+}
+
+func mustRecordArtifact(t *testing.T, srv *ArtifactServer, req *pb.RecordArtifactRequest) *pb.Artifact {
+	t.Helper()
+	resp, err := srv.RecordArtifact(authedCtx(), req)
+	if err != nil {
+		t.Fatalf("RecordArtifact %s: %v", req.OwnerFullName, err)
+	}
+	return resp.Artifact
+}
+
+func promoteReq(env, ownerFullName string, kind pb.ArtifactKind, key string, opts ...func(*pb.PromoteRequest)) *pb.PromoteRequest {
+	req := &pb.PromoteRequest{
+		EnvironmentKey: env, OwnerFullName: ownerFullName, Kind: kind, Version: "v1.0.0", IdempotencyKey: key,
+	}
+	for _, o := range opts {
+		o(req)
+	}
+	return req
+}
+
+func withReason(reason string) func(*pb.PromoteRequest) {
+	return func(r *pb.PromoteRequest) { r.Reason = reason }
+}
+func withOverride() func(*pb.PromoteRequest) {
+	return func(r *pb.PromoteRequest) { r.AllowOverride = true }
+}
+
+// TestPromote_NotPromotable_Rejected covers ARCHITECTURE.md's promotability
+// table: a DEPLOY_UNIT_NONE app's image is never a legal promotion target.
+func TestPromote_NotPromotable_Rejected(t *testing.T) {
+	f := newPromotionFixture(t)
+	req := promoteReq("dev", "demo-none-app", pb.ArtifactKind_ARTIFACT_KIND_IMAGE, "promo-none")
+	_, err := f.promo.Promote(authedCtx(), req)
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("expected FailedPrecondition for a not-promotable artifact, got %v", err)
+	}
+}
+
+// TestPromote_ViaChartImage_RequiresAllowOverride covers the override rule:
+// promoting a VIA_CHART image directly is rejected unless allow_override is
+// set, and when set the promotion is stored with is_override=true.
+func TestPromote_ViaChartImage_RequiresAllowOverride(t *testing.T) {
+	f := newPromotionFixture(t)
+
+	req := promoteReq("dev", "demo-chart-app", pb.ArtifactKind_ARTIFACT_KIND_IMAGE, "promo-viachart-1")
+	_, err := f.promo.Promote(authedCtx(), req)
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("expected FailedPrecondition without allow_override, got %v", err)
+	}
+
+	req2 := promoteReq("dev", "demo-chart-app", pb.ArtifactKind_ARTIFACT_KIND_IMAGE, "promo-viachart-2", withOverride())
+	resp, err := f.promo.Promote(authedCtx(), req2)
+	if err != nil {
+		t.Fatalf("expected allow_override to succeed, got %v", err)
+	}
+	if !resp.Promotion.IsOverride {
+		t.Fatalf("expected is_override=true when allow_override was used, got %+v", resp.Promotion)
+	}
+}
+
+// TestPromote_Promotable_Succeeds covers the direct-promotion path for a
+// DEPLOY_UNIT_IMAGE app -- legal with or without allow_override.
+func TestPromote_Promotable_Succeeds(t *testing.T) {
+	f := newPromotionFixture(t)
+	resp, err := f.promo.Promote(authedCtx(), promoteReq("dev", "demo-image-app", pb.ArtifactKind_ARTIFACT_KIND_IMAGE, "promo-image"))
+	if err != nil {
+		t.Fatalf("expected a promotable image to succeed, got %v", err)
+	}
+	if resp.Promotion.IsOverride {
+		t.Fatalf("expected is_override=false for a directly-promotable artifact, got %+v", resp.Promotion)
+	}
+	if resp.Promotion.ValidTo != 0 {
+		t.Fatalf("expected the new promotion to be current (valid_to == 0), got %+v", resp.Promotion)
+	}
+}
+
+// TestPromote_ReasonRequiredAboveRankZero covers ARCHITECTURE.md
+// "Authorization": "reason is required on promotions to any environment
+// above rank 0." dev is rank 0 and needs no reason; stage is rank 10.
+func TestPromote_ReasonRequiredAboveRankZero(t *testing.T) {
+	f := newPromotionFixture(t)
+
+	// dev (rank 0): no reason needed.
+	if _, err := f.promo.Promote(authedCtx(), promoteReq("dev", "demo-image-app", pb.ArtifactKind_ARTIFACT_KIND_IMAGE, "promo-dev-noreason")); err != nil {
+		t.Fatalf("expected dev promotion without reason to succeed, got %v", err)
+	}
+
+	// stage (rank 10): reason required.
+	_, err := f.promo.Promote(authedCtx(), promoteReq("stage", "demo-image-app", pb.ArtifactKind_ARTIFACT_KIND_IMAGE, "promo-stage-noreason"))
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("expected InvalidArgument when promoting to stage without a reason, got %v", err)
+	}
+
+	if _, err := f.promo.Promote(authedCtx(), promoteReq("stage", "demo-image-app", pb.ArtifactKind_ARTIFACT_KIND_IMAGE, "promo-stage-reason", withReason("shipping"))); err != nil {
+		t.Fatalf("expected stage promotion with a reason to succeed, got %v", err)
+	}
+}
+
+// TestPromote_PromoteAgain_ExactlyOneCurrentRow proves the SCD2
+// close-and-open behaviour end to end through the handler: promoting a
+// second version supersedes the first, and ListPromotions(include_history)
+// shows exactly one current row plus the closed one.
+func TestPromote_PromoteAgain_ExactlyOneCurrentRow(t *testing.T) {
+	f := newPromotionFixture(t)
+	ctx := authedCtx()
+
+	first, err := f.promo.Promote(ctx, promoteReq("dev", "demo-image-app", pb.ArtifactKind_ARTIFACT_KIND_IMAGE, "promo-first"))
+	if err != nil {
+		t.Fatalf("first promote: %v", err)
+	}
+	if first.Superseded != nil {
+		t.Fatalf("expected no superseded row on the first-ever promotion, got %+v", first.Superseded)
+	}
+
+	mustRecordArtifact(t, f.art, &pb.RecordArtifactRequest{
+		BuildId: mustRecordBuild(t, f.art, "run-2").BuildId, Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE,
+		OwnerFullName: "demo-image-app", Digest: "sha256:imageapp-v2", Version: "v2.0.0",
+		IdempotencyKey: "fixture-artifact-imageapp-v2",
+	})
+
+	req := promoteReq("dev", "demo-image-app", pb.ArtifactKind_ARTIFACT_KIND_IMAGE, "promo-second")
+	req.Version = "v2.0.0"
+	second, err := f.promo.Promote(ctx, req)
+	if err != nil {
+		t.Fatalf("second promote: %v", err)
+	}
+	if second.Superseded == nil || second.Superseded.PromotionId != first.Promotion.PromotionId {
+		t.Fatalf("expected the second promote to supersede the first, got %+v", second.Superseded)
+	}
+	if second.Superseded.ValidTo == 0 {
+		t.Fatalf("expected superseded.valid_to to be set, got %+v", second.Superseded)
+	}
+	if second.Promotion.ValidTo != 0 {
+		t.Fatalf("expected the new promotion to be current, got %+v", second.Promotion)
+	}
+
+	hist, err := f.promo.ListPromotions(ctx, &pb.ListPromotionsRequest{EnvironmentKey: "dev", OwnerFullName: "demo-image-app", IncludeHistory: true})
+	if err != nil {
+		t.Fatalf("list history: %v", err)
+	}
+	if len(hist.Promotions) != 2 {
+		t.Fatalf("expected 2 rows (1 current + 1 superseded) with include_history, got %d: %+v", len(hist.Promotions), hist.Promotions)
+	}
+
+	current, err := f.promo.ListPromotions(ctx, &pb.ListPromotionsRequest{EnvironmentKey: "dev", OwnerFullName: "demo-image-app"})
+	if err != nil {
+		t.Fatalf("list current: %v", err)
+	}
+	if len(current.Promotions) != 1 || current.Promotions[0].PromotionId != second.Promotion.PromotionId {
+		t.Fatalf("expected exactly 1 current row (the second promotion), got %+v", current.Promotions)
+	}
+}
+
+func mustRecordBuild(t *testing.T, srv *ArtifactServer, runID string) *pb.Build {
+	t.Helper()
+	resp, err := srv.RecordBuild(authedCtx(), &pb.RecordBuildRequest{GitSha: "abc123", WorkflowRunId: runID, IdempotencyKey: runID + "-build"})
+	if err != nil {
+		t.Fatalf("record build %s: %v", runID, err)
+	}
+	return resp.Build
+}
+
+// TestPromote_AlreadyPromoted_ShortCircuits covers the AlreadyPromoted flag:
+// promoting the same artifact twice does not create a second SCD2 row.
+func TestPromote_AlreadyPromoted_ShortCircuits(t *testing.T) {
+	f := newPromotionFixture(t)
+	ctx := authedCtx()
+
+	first, err := f.promo.Promote(ctx, promoteReq("dev", "demo-image-app", pb.ArtifactKind_ARTIFACT_KIND_IMAGE, "promo-again-1"))
+	if err != nil {
+		t.Fatalf("first promote: %v", err)
+	}
+
+	second, err := f.promo.Promote(ctx, promoteReq("dev", "demo-image-app", pb.ArtifactKind_ARTIFACT_KIND_IMAGE, "promo-again-2"))
+	if err != nil {
+		t.Fatalf("second promote of the same artifact: %v", err)
+	}
+	if !second.AlreadyPromoted {
+		t.Fatalf("expected already_promoted=true, got %+v", second)
+	}
+	if second.Promotion.PromotionId != first.Promotion.PromotionId {
+		t.Fatalf("expected re-promoting the same artifact to be a no-op (same promotion_id), got %s vs %s", second.Promotion.PromotionId, first.Promotion.PromotionId)
+	}
+
+	hist, err := f.promo.ListPromotions(ctx, &pb.ListPromotionsRequest{EnvironmentKey: "dev", OwnerFullName: "demo-image-app", IncludeHistory: true})
+	if err != nil {
+		t.Fatalf("list history: %v", err)
+	}
+	if len(hist.Promotions) != 1 {
+		t.Fatalf("expected no new row from the already-promoted call, got %d: %+v", len(hist.Promotions), hist.Promotions)
+	}
+}
+
+// TestPromote_DryRun_DoesNotWrite proves dry_run computes the transition
+// without touching state.
+func TestPromote_DryRun_DoesNotWrite(t *testing.T) {
+	f := newPromotionFixture(t)
+	ctx := authedCtx()
+
+	req := promoteReq("dev", "demo-image-app", pb.ArtifactKind_ARTIFACT_KIND_IMAGE, "promo-dryrun")
+	req.DryRun = true
+	resp, err := f.promo.Promote(ctx, req)
+	if err != nil {
+		t.Fatalf("dry run: %v", err)
+	}
+	if !resp.DryRun || resp.Promotion == nil {
+		t.Fatalf("expected a dry_run response describing the candidate promotion, got %+v", resp)
+	}
+
+	list, err := f.promo.ListPromotions(ctx, &pb.ListPromotionsRequest{EnvironmentKey: "dev", OwnerFullName: "demo-image-app", IncludeHistory: true})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(list.Promotions) != 0 {
+		t.Fatalf("expected dry_run to write nothing, found %d promotion(s)", len(list.Promotions))
+	}
+}
+
+// TestRollback_RoundTrips covers RollbackRequest's doc comment: it
+// re-promotes whatever was previously current.
+func TestRollback_RoundTrips(t *testing.T) {
+	f := newPromotionFixture(t)
+	ctx := authedCtx()
+
+	v1, err := f.promo.Promote(ctx, promoteReq("dev", "demo-image-app", pb.ArtifactKind_ARTIFACT_KIND_IMAGE, "rollback-promo-1"))
+	if err != nil {
+		t.Fatalf("promote v1: %v", err)
+	}
+
+	mustRecordArtifact(t, f.art, &pb.RecordArtifactRequest{
+		BuildId: mustRecordBuild(t, f.art, "run-rollback-2").BuildId, Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE,
+		OwnerFullName: "demo-image-app", Digest: "sha256:imageapp-rb-v2", Version: "v2.0.0",
+		IdempotencyKey: "fixture-artifact-imageapp-rb-v2",
+	})
+	req := promoteReq("dev", "demo-image-app", pb.ArtifactKind_ARTIFACT_KIND_IMAGE, "rollback-promo-2")
+	req.Version = "v2.0.0"
+	v2, err := f.promo.Promote(ctx, req)
+	if err != nil {
+		t.Fatalf("promote v2: %v", err)
+	}
+
+	rollback, err := f.promo.Rollback(ctx, &pb.RollbackRequest{
+		EnvironmentKey: "dev", OwnerFullName: "demo-image-app", Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE, IdempotencyKey: "rollback-1",
+	})
+	if err != nil {
+		t.Fatalf("rollback: %v", err)
+	}
+	if rollback.Promotion.ArtifactId != v1.Promotion.ArtifactId {
+		t.Fatalf("expected rollback to re-promote v1's artifact %s, got %s", v1.Promotion.ArtifactId, rollback.Promotion.ArtifactId)
+	}
+	if rollback.Superseded == nil || rollback.Superseded.PromotionId != v2.Promotion.PromotionId {
+		t.Fatalf("expected rollback to supersede v2's promotion, got %+v", rollback.Superseded)
+	}
+}
+
+// TestRollback_NoPriorPromotion_FailedPrecondition covers the "nothing to
+// roll back to" case: a target promoted exactly once (or never) has no
+// GetPrevious row.
+func TestRollback_NoPriorPromotion_FailedPrecondition(t *testing.T) {
+	f := newPromotionFixture(t)
+	ctx := authedCtx()
+
+	if _, err := f.promo.Promote(ctx, promoteReq("dev", "demo-image-app", pb.ArtifactKind_ARTIFACT_KIND_IMAGE, "rb-none-1")); err != nil {
+		t.Fatalf("promote: %v", err)
+	}
+
+	_, err := f.promo.Rollback(ctx, &pb.RollbackRequest{
+		EnvironmentKey: "dev", OwnerFullName: "demo-image-app", Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE, IdempotencyKey: "rb-none-2",
+	})
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("expected FailedPrecondition when there is no prior promotion, got %v", err)
+	}
+}
+
+// TestGetEnvironmentState_ReportsDrift covers ARCHITECTURE.md's override
+// drift reporting: promoting the chart, then separately promoting a
+// different digest of the image it pins with allow_override, must surface
+// as a DriftEntry on the chart's EnvironmentStateEntry.
+func TestGetEnvironmentState_ReportsDrift(t *testing.T) {
+	f := newPromotionFixture(t)
+	ctx := authedCtx()
+
+	if _, err := f.promo.Promote(ctx, promoteReq("dev", "demo-achart", pb.ArtifactKind_ARTIFACT_KIND_CHART, "drift-chart")); err != nil {
+		t.Fatalf("promote chart: %v", err)
+	}
+
+	mustRecordArtifact(t, f.art, &pb.RecordArtifactRequest{
+		BuildId: mustRecordBuild(t, f.art, "run-drift-hotfix").BuildId, Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE,
+		OwnerFullName: "demo-chart-app", Digest: "sha256:chartapp-hotfix", Version: "v1.0.1",
+		IdempotencyKey: "fixture-artifact-chartapp-hotfix",
+	})
+	req := promoteReq("dev", "demo-chart-app", pb.ArtifactKind_ARTIFACT_KIND_IMAGE, "drift-override", withOverride())
+	req.Version = "v1.0.1"
+	if _, err := f.promo.Promote(ctx, req); err != nil {
+		t.Fatalf("promote override image: %v", err)
+	}
+
+	state, err := f.promo.GetEnvironmentState(ctx, &pb.GetEnvironmentStateRequest{EnvironmentKey: "dev"})
+	if err != nil {
+		t.Fatalf("get state: %v", err)
+	}
+
+	var chartEntry *pb.EnvironmentStateEntry
+	for _, e := range state.Entries {
+		if e.Artifact.Kind == pb.ArtifactKind_ARTIFACT_KIND_CHART {
+			chartEntry = e
+		}
+	}
+	if chartEntry == nil {
+		t.Fatalf("expected a chart entry in the environment state, got %+v", state.Entries)
+	}
+	if len(chartEntry.Drift) != 1 {
+		t.Fatalf("expected exactly 1 drift entry on the chart, got %+v", chartEntry.Drift)
+	}
+	d := chartEntry.Drift[0]
+	if d.ChartPinnedDigest != f.chartImageDigest || d.PromotedDigest != "sha256:chartapp-hotfix" {
+		t.Fatalf("unexpected drift entry: %+v", d)
+	}
+	if state.StateHash == "" {
+		t.Fatalf("expected a non-empty state_hash")
+	}
+}
+
+// The "GetEnvironmentState --at <T> returns correct historical state"
+// exit criterion is deliberately proven at the repository layer against
+// real Postgres (see postgres_integration_test.go's
+// TestPromotionRepo_StateAt_HistoricalWindow), not here: wall-clock time at
+// second resolution (Promotion.valid_from/valid_to are Unix seconds) makes
+// a handler-level "promote twice, query between them" test flaky by
+// construction -- two Promote calls a few microseconds apart routinely land
+// in the same second.

--- a/tools/app_registry/server/main.go
+++ b/tools/app_registry/server/main.go
@@ -1,7 +1,7 @@
 // Command app-registry-api is the App Registry's gRPC server. AppRegistry and
 // ArtifactRegistry are real as of AR-2a; EnvironmentRegistry is real as of
-// AR-3b. PromotionRegistry still returns codes.Unimplemented until AR-3c. See
-// ../ARCHITECTURE.md and ../README.md.
+// AR-3b; PromotionRegistry is real as of AR-3c. See ../ARCHITECTURE.md and
+// ../README.md.
 package main
 
 import (
@@ -129,11 +129,10 @@ func run() error {
 func registerServices(grpcServer *grpc.Server, repo repository.Registry) *health.Server {
 	// AppRegistry and ArtifactRegistry are real as of AR-2a (AllocateVersion
 	// stays Unimplemented — that's AR-5). EnvironmentRegistry is real as of
-	// AR-3b. PromotionRegistry stays Unimplemented until AR-3c — see
-	// handlers/promotion.go.
+	// AR-3b. PromotionRegistry is real as of AR-3c.
 	pb.RegisterAppRegistryServer(grpcServer, handlers.NewAppServer(repo))
 	pb.RegisterArtifactRegistryServer(grpcServer, handlers.NewArtifactServer(repo))
-	pb.RegisterPromotionRegistryServer(grpcServer, handlers.NewPromotionServer())
+	pb.RegisterPromotionRegistryServer(grpcServer, handlers.NewPromotionServer(repo))
 	pb.RegisterEnvironmentRegistryServer(grpcServer, handlers.NewEnvironmentServer(repo))
 
 	// Health check — reports SERVING once the process is up. AR-1 has no

--- a/tools/app_registry/server/main_test.go
+++ b/tools/app_registry/server/main_test.go
@@ -109,12 +109,12 @@ func assertUnimplementedFromHandler(t *testing.T, rpc, wantMsg string, err error
 // the message text for exactly that reason. A dropped pb.RegisterXxxServer
 // call in main.go fails this test.
 //
-// AppRegistry, ArtifactRegistry, and EnvironmentRegistry are real (as of
-// AR-2a and AR-3b respectively), so those subtests assert a real
-// (empty-but-successful) response against the fake repository instead of
-// Unimplemented — a dropped Register call would now surface as
+// AppRegistry, ArtifactRegistry, EnvironmentRegistry, and PromotionRegistry
+// are all real now (AR-2a, AR-3b, AR-3c respectively), so those subtests
+// assert a real (empty-but-successful) response against the fake repository
+// instead of Unimplemented — a dropped Register call would now surface as
 // codes.Unavailable/Unimplemented-with-"unknown service" instead, still
-// caught below. PromotionRegistry is still Unimplemented until AR-3c.
+// caught below.
 func TestRegisterServices_AllFourServicesReachable(t *testing.T) {
 	conn := startTestServer(t)
 	ctx := context.Background()
@@ -149,8 +149,26 @@ func TestRegisterServices_AllFourServicesReachable(t *testing.T) {
 
 	t.Run("PromotionRegistry", func(t *testing.T) {
 		client := pb.NewPromotionRegistryClient(conn)
-		_, err := client.ListPromotions(ctx, &pb.ListPromotionsRequest{})
-		assertUnimplementedFromHandler(t, "PromotionRegistry.ListPromotions", "ListPromotions not implemented", err)
+		resp, err := client.ListPromotions(ctx, &pb.ListPromotionsRequest{})
+		if err != nil {
+			t.Fatalf("PromotionRegistry.ListPromotions: expected success against the fake repository, got %v", err)
+		}
+		if len(resp.Promotions) != 0 {
+			t.Fatalf("PromotionRegistry.ListPromotions: expected no promotions in a fresh fake registry, got %d", len(resp.Promotions))
+		}
+	})
+
+	t.Run("PromotionRegistry_Promote_StillReachable", func(t *testing.T) {
+		client := pb.NewPromotionRegistryClient(conn)
+		// "dev" matches DevRoles' app-registry-promoter-dev grant; a
+		// PermissionDenied here would mean auth never ran, and a "not
+		// registered" error would surface as Unimplemented/Unavailable —
+		// NotFound (unknown environment, since the fake repo is empty) is
+		// the only outcome proving the RPC actually reached the handler.
+		_, err := client.Promote(ctx, &pb.PromoteRequest{EnvironmentKey: "dev", ArtifactId: "nonexistent", IdempotencyKey: "test"})
+		if status.Code(err) != codes.NotFound {
+			t.Fatalf("PromotionRegistry.Promote: expected NotFound (unknown environment) against the fake repository, got %v", err)
+		}
 	})
 
 	t.Run("EnvironmentRegistry", func(t *testing.T) {

--- a/tools/app_registry/server/repository/fake/fake.go
+++ b/tools/app_registry/server/repository/fake/fake.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"sort"
 	"sync"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/whale-net/everything/tools/app_registry/server/repository"
@@ -35,22 +36,26 @@ type idemEntry struct {
 // (rather than fields directly on Registry) so it round-trips through JSON
 // cleanly for a cheap deep copy.
 type state struct {
-	Apps         map[string]repository.App
-	Charts       map[string]repository.Chart
-	Builds       map[string]repository.Build
-	Artifacts    map[string]repository.Artifact
-	Idempotency  map[string]idemEntry
-	Environments map[string]repository.Environment // keyed by environment_id
+	Apps            map[string]repository.App
+	Charts          map[string]repository.Chart
+	Builds          map[string]repository.Build
+	Artifacts       map[string]repository.Artifact
+	Idempotency     map[string]idemEntry
+	Environments    map[string]repository.Environment    // keyed by environment_id
+	Promotions      map[string]repository.Promotion      // keyed by promotion_id
+	PromotionEvents map[string]repository.PromotionEvent // keyed by event_id
 }
 
 func newState() *state {
 	return &state{
-		Apps:         map[string]repository.App{},
-		Charts:       map[string]repository.Chart{},
-		Builds:       map[string]repository.Build{},
-		Artifacts:    map[string]repository.Artifact{},
-		Idempotency:  map[string]idemEntry{},
-		Environments: map[string]repository.Environment{},
+		Apps:            map[string]repository.App{},
+		Charts:          map[string]repository.Chart{},
+		Builds:          map[string]repository.Build{},
+		Artifacts:       map[string]repository.Artifact{},
+		Idempotency:     map[string]idemEntry{},
+		Environments:    map[string]repository.Environment{},
+		Promotions:      map[string]repository.Promotion{},
+		PromotionEvents: map[string]repository.PromotionEvent{},
 	}
 }
 
@@ -90,6 +95,9 @@ func (r *Registry) Idempotency() repository.IdempotencyRepository { return r }
 // Registry -- Go has no method overloading. Every method still reads/writes
 // r.state, the same map WithTx snapshots.
 func (r *Registry) Environments() repository.EnvironmentRepository { return environmentFake{r} }
+
+// Promotions returns a distinct type for the same reason Environments does.
+func (r *Registry) Promotions() repository.PromotionRepository { return promotionFake{r} }
 
 // WithTx snapshots state, runs fn against a Registry sharing that snapshot,
 // and commits the snapshot back only if fn succeeds — giving the fake the
@@ -544,6 +552,170 @@ func (f environmentFake) findByKey(key string) (repository.Environment, bool) {
 func sortEnvironments(envs []repository.Environment) {
 	sort.Slice(envs, func(i, j int) bool { return envs[i].Rank < envs[j].Rank })
 }
+
+// ============================================================================
+// PromotionRepository
+// ============================================================================
+
+// promotionFake implements repository.PromotionRepository over the same
+// *Registry.state every other repository reads/writes -- see Environments's
+// doc comment for why this can't be methods directly on Registry.
+type promotionFake struct{ r *Registry }
+
+// Promote mirrors postgres's promotionRepo.Promote: close whatever is
+// currently valid_to == nil for (p.EnvironmentID, p.TargetKey), then insert
+// p as the new current row.
+func (f promotionFake) Promote(ctx context.Context, p repository.Promotion) (*repository.Promotion, *repository.Promotion, error) {
+	var superseded *repository.Promotion
+	if existing, ok := f.findCurrent(p.EnvironmentID, p.TargetKey); ok {
+		now := timeNow()
+		existing.ValidTo = &now
+		f.r.state.Promotions[existing.PromotionID] = existing
+		superseded = &existing
+	}
+
+	p.PromotionID = uuid.NewString()
+	p.ValidFrom = timeNow()
+	p.ValidTo = nil
+	if p.State == "" {
+		p.State = repository.PromotionStateActive
+	}
+	f.r.state.Promotions[p.PromotionID] = p
+
+	current := p
+	return &current, superseded, nil
+}
+
+func (f promotionFake) GetCurrent(ctx context.Context, environmentID, targetKey string) (*repository.Promotion, error) {
+	if p, ok := f.findCurrent(environmentID, targetKey); ok {
+		return &p, nil
+	}
+	return nil, repository.ErrNotFound
+}
+
+func (f promotionFake) GetPrevious(ctx context.Context, environmentID, targetKey string) (*repository.Promotion, error) {
+	var best *repository.Promotion
+	for _, p := range f.r.state.Promotions {
+		if p.EnvironmentID != environmentID || p.TargetKey != targetKey || p.ValidTo == nil {
+			continue
+		}
+		if best == nil || p.ValidFrom.After(best.ValidFrom) {
+			cp := p
+			best = &cp
+		}
+	}
+	if best == nil {
+		return nil, repository.ErrNotFound
+	}
+	return best, nil
+}
+
+func (f promotionFake) StateAt(ctx context.Context, environmentID string, at *time.Time) ([]repository.Promotion, error) {
+	var out []repository.Promotion
+	for _, p := range f.r.state.Promotions {
+		if p.EnvironmentID != environmentID {
+			continue
+		}
+		if at == nil {
+			if p.ValidTo == nil {
+				out = append(out, p)
+			}
+			continue
+		}
+		if !p.ValidFrom.After(*at) && (p.ValidTo == nil || p.ValidTo.After(*at)) {
+			out = append(out, p)
+		}
+	}
+	sortPromotions(out)
+	return out, nil
+}
+
+func (f promotionFake) ListPromotions(ctx context.Context, filter repository.PromotionListFilter) ([]repository.Promotion, error) {
+	var out []repository.Promotion
+	for _, p := range f.r.state.Promotions {
+		if filter.EnvironmentKey != "" && p.EnvironmentKey != filter.EnvironmentKey {
+			continue
+		}
+		if filter.OwnerFullName != "" && f.ownerFullName(p) != filter.OwnerFullName {
+			continue
+		}
+		if !filter.IncludeHistory && p.ValidTo != nil {
+			continue
+		}
+		out = append(out, p)
+	}
+	sortPromotions(out)
+	return out, nil
+}
+
+func (f promotionFake) RecordEvent(ctx context.Context, e repository.PromotionEvent) (*repository.PromotionEvent, error) {
+	e.EventID = uuid.NewString()
+	if e.OccurredAt.IsZero() {
+		e.OccurredAt = timeNow()
+	}
+	f.r.state.PromotionEvents[e.EventID] = e
+	return &e, nil
+}
+
+func (f promotionFake) ListEvents(ctx context.Context, filter repository.PromotionEventListFilter) ([]repository.PromotionEvent, error) {
+	var out []repository.PromotionEvent
+	for _, e := range f.r.state.PromotionEvents {
+		if filter.PromotionID != "" && e.PromotionID != filter.PromotionID {
+			continue
+		}
+		if filter.Actor != "" && e.Actor != filter.Actor {
+			continue
+		}
+		if !filter.Since.IsZero() && e.OccurredAt.Before(filter.Since) {
+			continue
+		}
+		if filter.EnvironmentKey != "" || filter.OwnerFullName != "" {
+			p, ok := f.r.state.Promotions[e.PromotionID]
+			if !ok {
+				continue
+			}
+			if filter.EnvironmentKey != "" && p.EnvironmentKey != filter.EnvironmentKey {
+				continue
+			}
+			if filter.OwnerFullName != "" && f.ownerFullName(p) != filter.OwnerFullName {
+				continue
+			}
+		}
+		out = append(out, e)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].OccurredAt.After(out[j].OccurredAt) })
+	return out, nil
+}
+
+func (f promotionFake) findCurrent(environmentID, targetKey string) (repository.Promotion, bool) {
+	for _, p := range f.r.state.Promotions {
+		if p.EnvironmentID == environmentID && p.TargetKey == targetKey && p.ValidTo == nil {
+			return p, true
+		}
+	}
+	return repository.Promotion{}, false
+}
+
+func (f promotionFake) ownerFullName(p repository.Promotion) string {
+	if p.Kind == repository.ArtifactKindImage {
+		if app, ok := f.r.state.Apps[p.AppID]; ok {
+			return app.FullName()
+		}
+	} else {
+		if c, ok := f.r.state.Charts[p.ChartID]; ok {
+			return c.FullName()
+		}
+	}
+	return ""
+}
+
+func sortPromotions(promotions []repository.Promotion) {
+	sort.Slice(promotions, func(i, j int) bool { return promotions[i].ValidFrom.After(promotions[j].ValidFrom) })
+}
+
+// timeNow is a thin indirection so a future test could freeze it; today it's
+// just time.Now().UTC(), matching every other fake's timestamp handling.
+func timeNow() time.Time { return time.Now().UTC() }
 
 // ============================================================================
 // helpers shared with reconcile.go

--- a/tools/app_registry/server/repository/models.go
+++ b/tools/app_registry/server/repository/models.go
@@ -176,3 +176,92 @@ type Environment struct {
 	Archived          bool
 	CreatedAt         time.Time
 }
+
+// PromotionState mirrors PromotionState in protos/messages.proto. AR-3c
+// only ever writes PromotionStateActive; the other values are reserved for
+// the approval gate described in ARCHITECTURE.md "Future: approval gate".
+type PromotionState string
+
+const (
+	PromotionStatePendingApproval PromotionState = "pending_approval"
+	PromotionStateActive          PromotionState = "active"
+	PromotionStateSuperseded      PromotionState = "superseded"
+	PromotionStateFailed          PromotionState = "failed"
+)
+
+// PromotionAction mirrors PromotionAction in protos/messages.proto — the
+// human-meaningful verb recorded on promotion_event.
+type PromotionAction string
+
+const (
+	PromotionActionPromote  PromotionAction = "promote"
+	PromotionActionRollback PromotionAction = "rollback"
+	PromotionActionOverride PromotionAction = "override"
+	PromotionActionRetire   PromotionAction = "retire"
+	PromotionActionApprove  PromotionAction = "approve"
+	PromotionActionReject   PromotionAction = "reject"
+)
+
+// TargetKey is the promoted thing's identity, denormalized onto the
+// promotion table so its partial unique index can be expressed without a
+// nullable two-column target (app_id is NULL for chart artifacts and vice
+// versa) — see ARCHITECTURE.md "SCD2 on promotion".
+func TargetKey(kind ArtifactKind, ownerFullName string) string {
+	return string(kind) + ":" + ownerFullName
+}
+
+// Promotion is SCD2 state: what is deployed to an environment right now, or
+// at any past instant. Follows the repo-wide valid_from/valid_to convention
+// — see AGENTS.md "SCD2". AppID/ChartID/Repository/Version/Digest are
+// populated by a join to the promoted artifact at read time — never stored
+// redundantly on the promotion row itself, so there is exactly one place
+// that data can drift from. ValidTo == nil means still current.
+type Promotion struct {
+	PromotionID    string
+	EnvironmentID  string
+	EnvironmentKey string // denormalized at read time, for readability
+	TargetKey      string
+
+	Kind       ArtifactKind
+	AppID      string // set when Kind == ArtifactKindImage
+	ChartID    string // set when Kind == ArtifactKindChart
+	ArtifactID string
+	Repository string
+	Version    string
+	Digest     string
+
+	State      PromotionState
+	IsOverride bool
+
+	ValidFrom time.Time
+	ValidTo   *time.Time
+}
+
+// PromotionEvent is the append-only audit log. NOT SCD2 — see AGENTS.md,
+// event logs get their own shape.
+type PromotionEvent struct {
+	EventID            string
+	PromotionID        string
+	Action             PromotionAction
+	Actor              string
+	Reason             string
+	TemporalWorkflowID string
+	TemporalRunID      string
+	OccurredAt         time.Time
+}
+
+// PromotionListFilter is ListPromotionsRequest's filter set.
+type PromotionListFilter struct {
+	EnvironmentKey string
+	OwnerFullName  string
+	IncludeHistory bool
+}
+
+// PromotionEventListFilter is ListPromotionEventsRequest's filter set.
+type PromotionEventListFilter struct {
+	PromotionID    string
+	EnvironmentKey string
+	OwnerFullName  string
+	Actor          string
+	Since          time.Time
+}

--- a/tools/app_registry/server/repository/postgres/BUILD.bazel
+++ b/tools/app_registry/server/repository/postgres/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
         "environment.go",
         "errors.go",
         "idempotency.go",
+        "promotion.go",
         "repository.go",
     ],
     importpath = "github.com/whale-net/everything/tools/app_registry/server/repository/postgres",

--- a/tools/app_registry/server/repository/postgres/postgres_integration_test.go
+++ b/tools/app_registry/server/repository/postgres/postgres_integration_test.go
@@ -20,10 +20,11 @@ import (
 	"database/sql"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgconn"
-	_ "github.com/jackc/pgx/v5/stdlib" // database/sql driver for the migration runner
 	"github.com/jackc/pgx/v5/pgxpool"
+	_ "github.com/jackc/pgx/v5/stdlib" // database/sql driver for the migration runner
 
 	"github.com/whale-net/everything/libs/go/dbtest"
 	"github.com/whale-net/everything/libs/go/grpcauth"
@@ -414,6 +415,301 @@ func TestEnvironment_KeyUniqueConstraint(t *testing.T) {
 	}
 	if count != 1 {
 		t.Fatalf("expected exactly 1 'dev' row after the rejected duplicate insert, found %d", count)
+	}
+}
+
+// --- 6. promotion (AR-3c) ---------------------------------------------
+
+// devEnvironmentID looks up the "dev" environment_id seeded by migration
+// 002, which newTestRegistry already applied.
+func devEnvironmentID(t *testing.T, reg *Registry) string {
+	t.Helper()
+	env, err := reg.Environments().Get(context.Background(), "dev")
+	if err != nil {
+		t.Fatalf("get dev environment: %v", err)
+	}
+	return env.EnvironmentID
+}
+
+// promoteTx runs Promotions().Promote inside a real WithTx transaction,
+// exactly as handlers.PromotionServer.Promote does in production.
+func promoteTx(t *testing.T, reg *Registry, p repository.Promotion) (*repository.Promotion, *repository.Promotion, error) {
+	t.Helper()
+	var current, superseded *repository.Promotion
+	err := reg.WithTx(context.Background(), func(ctx context.Context, r repository.Registry) error {
+		var ferr error
+		current, superseded, ferr = r.Promotions().Promote(ctx, p)
+		return ferr
+	})
+	return current, superseded, err
+}
+
+func currentPromotionCount(t *testing.T, pool *pgxpool.Pool, environmentID, targetKey string) int {
+	t.Helper()
+	var n int
+	if err := pool.QueryRow(context.Background(), `
+		SELECT count(*) FROM promotion WHERE environment_id = $1 AND target_key = $2 AND valid_to IS NULL`,
+		environmentID, targetKey).Scan(&n); err != nil {
+		t.Fatalf("count current promotions: %v", err)
+	}
+	return n
+}
+
+// TestPromotion_CurrentIdxRejectsConcurrentCurrentRows proves the real
+// partial unique index promotion_current_idx -- not application logic --
+// makes two "current" rows for the same (environment_id, target_key)
+// structurally impossible. PLAN.md's AR-2d carry-over note flags this
+// exact index as deliberately deferred until the promotion table existed;
+// this is that follow-up.
+func TestPromotion_CurrentIdxRejectsConcurrentCurrentRows(t *testing.T) {
+	reg, pool := newTestRegistry(t)
+	ctx := context.Background()
+
+	envID := devEnvironmentID(t, reg)
+	appID := seedApp(t, pool, "acme", "widget", "image")
+	buildID := seedBuild(t, pool, "run-promo-idx")
+	artifactID := seedArtifact(t, pool, appID, buildID, "sha256:promo-idx", "v1.0.0")
+
+	insert := func() error {
+		_, err := pool.Exec(ctx, `
+			INSERT INTO promotion (environment_id, target_key, artifact_id) VALUES ($1, $2, $3)`,
+			envID, "image:acme-widget", artifactID)
+		return err
+	}
+
+	if err := insert(); err != nil {
+		t.Fatalf("first insert (should succeed, nothing current yet): %v", err)
+	}
+	err := insert()
+	if err == nil {
+		t.Fatalf("expected a second concurrent 'current' row for the same target to be rejected, got nil error")
+	}
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) {
+		t.Fatalf("expected a *pgconn.PgError, got: %v (%T)", err, err)
+	}
+	if pgErr.Code != sqlStateUniqueViolation {
+		t.Fatalf("expected SQLSTATE %s (unique_violation) from promotion_current_idx, got %s: %v", sqlStateUniqueViolation, pgErr.Code, err)
+	}
+	if n := currentPromotionCount(t, pool, envID, "image:acme-widget"); n != 1 {
+		t.Fatalf("expected exactly 1 current row to survive, found %d", n)
+	}
+}
+
+// seedArtifact inserts a minimal image artifact row directly, for tests that
+// only need a valid artifact_id to hang a promotion off of.
+func seedArtifact(t *testing.T, pool *pgxpool.Pool, appID, buildID, digest, version string) string {
+	t.Helper()
+	var artifactID string
+	err := pool.QueryRow(context.Background(), `
+		INSERT INTO artifact (kind, app_id, repository, version, digest, build_id)
+		VALUES ('image', $1, 'ghcr.io/acme/widget', $2, $3, $4)
+		RETURNING artifact_id`, appID, version, digest, buildID).Scan(&artifactID)
+	if err != nil {
+		t.Fatalf("seed artifact %s: %v", digest, err)
+	}
+	return artifactID
+}
+
+// TestPromotionRepo_PromoteTwice_ExactlyOneCurrentRow proves the SCD2
+// close-and-open write end to end through the repository layer against real
+// Postgres: promoting a second artifact for the same target closes the
+// first row (valid_to set) and leaves exactly one row with valid_to IS
+// NULL.
+func TestPromotionRepo_PromoteTwice_ExactlyOneCurrentRow(t *testing.T) {
+	reg, pool := newTestRegistry(t)
+	ctx := context.Background()
+
+	envID := devEnvironmentID(t, reg)
+	appID := seedApp(t, pool, "acme", "widget", "image")
+	buildID := seedBuild(t, pool, "run-promo-twice")
+	art1 := seedArtifact(t, pool, appID, buildID, "sha256:promo-twice-1", "v1.0.0")
+	art2 := seedArtifact(t, pool, appID, buildID, "sha256:promo-twice-2", "v2.0.0")
+
+	targetKey := "image:acme-widget"
+	first, superseded1, err := promoteTx(t, reg, repository.Promotion{EnvironmentID: envID, TargetKey: targetKey, ArtifactID: art1})
+	if err != nil {
+		t.Fatalf("first promote: %v", err)
+	}
+	if superseded1 != nil {
+		t.Fatalf("expected no superseded row on the first-ever promotion, got %+v", superseded1)
+	}
+
+	second, superseded2, err := promoteTx(t, reg, repository.Promotion{EnvironmentID: envID, TargetKey: targetKey, ArtifactID: art2})
+	if err != nil {
+		t.Fatalf("second promote: %v", err)
+	}
+	if superseded2 == nil || superseded2.PromotionID != first.PromotionID {
+		t.Fatalf("expected the second promote to supersede the first, got %+v", superseded2)
+	}
+	if superseded2.ValidTo == nil {
+		t.Fatalf("expected the superseded row's valid_to to be set")
+	}
+	if second.ValidTo != nil {
+		t.Fatalf("expected the new current row's valid_to to be nil, got %v", second.ValidTo)
+	}
+
+	if n := currentPromotionCount(t, pool, envID, targetKey); n != 1 {
+		t.Fatalf("expected exactly 1 row with valid_to IS NULL after two promotions, found %d", n)
+	}
+	var closedCount int
+	if err := pool.QueryRow(ctx, `
+		SELECT count(*) FROM promotion WHERE environment_id = $1 AND target_key = $2 AND valid_to IS NOT NULL`,
+		envID, targetKey).Scan(&closedCount); err != nil {
+		t.Fatalf("count closed rows: %v", err)
+	}
+	if closedCount != 1 {
+		t.Fatalf("expected exactly 1 closed (superseded) row, found %d", closedCount)
+	}
+}
+
+// TestPromotionRepo_StateAt_HistoricalWindow proves the SCD2 "state at time
+// T" window query (StateAt) against real Postgres: a timestamp between two
+// promotions returns the first artifact, not the second -- the exact
+// property GetEnvironmentState --at <T> depends on. Unlike the
+// handler-level tests, this controls valid_from/valid_to directly via SQL
+// so it isn't subject to wall-clock/second-resolution flakiness.
+func TestPromotionRepo_StateAt_HistoricalWindow(t *testing.T) {
+	reg, pool := newTestRegistry(t)
+	ctx := context.Background()
+
+	envID := devEnvironmentID(t, reg)
+	appID := seedApp(t, pool, "acme", "widget", "image")
+	buildID := seedBuild(t, pool, "run-stateat")
+	art1 := seedArtifact(t, pool, appID, buildID, "sha256:stateat-1", "v1.0.0")
+	art2 := seedArtifact(t, pool, appID, buildID, "sha256:stateat-2", "v2.0.0")
+	targetKey := "image:acme-widget"
+
+	t0 := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	t1 := t0.Add(1 * time.Hour)         // v1 promoted
+	t2 := t0.Add(2 * time.Hour)         // v1 superseded by v2
+	between := t0.Add(90 * time.Minute) // strictly between t1 and t2
+
+	var promo1ID string
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO promotion (environment_id, target_key, artifact_id, valid_from, valid_to)
+		VALUES ($1, $2, $3, $4, $5) RETURNING promotion_id`,
+		envID, targetKey, art1, t1, t2).Scan(&promo1ID); err != nil {
+		t.Fatalf("seed historical promotion 1: %v", err)
+	}
+	var promo2ID string
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO promotion (environment_id, target_key, artifact_id, valid_from, valid_to)
+		VALUES ($1, $2, $3, $4, NULL) RETURNING promotion_id`,
+		envID, targetKey, art2, t2).Scan(&promo2ID); err != nil {
+		t.Fatalf("seed current promotion 2: %v", err)
+	}
+
+	state, err := reg.Promotions().StateAt(ctx, envID, &between)
+	if err != nil {
+		t.Fatalf("StateAt(between): %v", err)
+	}
+	if len(state) != 1 || state[0].PromotionID != promo1ID || state[0].Digest != "sha256:stateat-1" {
+		t.Fatalf("expected exactly promotion 1 (v1) live at %v, got %+v", between, state)
+	}
+
+	stateNow, err := reg.Promotions().StateAt(ctx, envID, nil)
+	if err != nil {
+		t.Fatalf("StateAt(now): %v", err)
+	}
+	if len(stateNow) != 1 || stateNow[0].PromotionID != promo2ID {
+		t.Fatalf("expected current state to be promotion 2 (v2), got %+v", stateNow)
+	}
+}
+
+// TestPromotionRepo_Rollback_RoundTrips proves GetPrevious + Promote --
+// exactly what handlers.PromotionServer.Rollback composes -- round-trips
+// correctly against real Postgres: rolling back after v1 -> v2 re-promotes
+// v1 and supersedes v2.
+func TestPromotionRepo_Rollback_RoundTrips(t *testing.T) {
+	reg, pool := newTestRegistry(t)
+	ctx := context.Background()
+
+	envID := devEnvironmentID(t, reg)
+	appID := seedApp(t, pool, "acme", "widget", "image")
+	buildID := seedBuild(t, pool, "run-rollback")
+	art1 := seedArtifact(t, pool, appID, buildID, "sha256:rollback-1", "v1.0.0")
+	art2 := seedArtifact(t, pool, appID, buildID, "sha256:rollback-2", "v2.0.0")
+	targetKey := "image:acme-widget"
+
+	v1, _, err := promoteTx(t, reg, repository.Promotion{EnvironmentID: envID, TargetKey: targetKey, ArtifactID: art1})
+	if err != nil {
+		t.Fatalf("promote v1: %v", err)
+	}
+	v2, _, err := promoteTx(t, reg, repository.Promotion{EnvironmentID: envID, TargetKey: targetKey, ArtifactID: art2})
+	if err != nil {
+		t.Fatalf("promote v2: %v", err)
+	}
+
+	previous, err := reg.Promotions().GetPrevious(ctx, envID, targetKey)
+	if err != nil {
+		t.Fatalf("GetPrevious: %v", err)
+	}
+	if previous.PromotionID != v1.PromotionID {
+		t.Fatalf("expected GetPrevious to return v1's promotion %s, got %s", v1.PromotionID, previous.PromotionID)
+	}
+
+	rollback, supersededByRollback, err := promoteTx(t, reg, repository.Promotion{
+		EnvironmentID: envID, TargetKey: targetKey, ArtifactID: previous.ArtifactID,
+	})
+	if err != nil {
+		t.Fatalf("rollback promote: %v", err)
+	}
+	if rollback.ArtifactID != art1 {
+		t.Fatalf("expected rollback to re-promote v1's artifact %s, got %s", art1, rollback.ArtifactID)
+	}
+	if supersededByRollback == nil || supersededByRollback.PromotionID != v2.PromotionID {
+		t.Fatalf("expected rollback to supersede v2's promotion %s, got %+v", v2.PromotionID, supersededByRollback)
+	}
+	if n := currentPromotionCount(t, pool, envID, targetKey); n != 1 {
+		t.Fatalf("expected exactly 1 current row after rollback, found %d", n)
+	}
+}
+
+// TestPromotionRepo_Promote_TransactionAbortLeavesNoPartialWrite covers the
+// hazard AGENTS.md and this phase's assignment both flag explicitly: a
+// failed statement aborts the whole transaction, so the close half of
+// close-and-open must not survive if the open half fails. Here the INSERT
+// is forced to fail by pointing ArtifactID at a nonexistent artifact_id
+// (violates the artifact_id FK) *after* a real prior promotion exists to
+// close -- proving the earlier UPDATE (the close) does not commit on its
+// own when the surrounding transaction as a whole rolls back.
+func TestPromotionRepo_Promote_TransactionAbortLeavesNoPartialWrite(t *testing.T) {
+	reg, pool := newTestRegistry(t)
+	ctx := context.Background()
+
+	envID := devEnvironmentID(t, reg)
+	appID := seedApp(t, pool, "acme", "widget", "image")
+	buildID := seedBuild(t, pool, "run-abort")
+	art1 := seedArtifact(t, pool, appID, buildID, "sha256:abort-1", "v1.0.0")
+	targetKey := "image:acme-widget"
+
+	first, _, err := promoteTx(t, reg, repository.Promotion{EnvironmentID: envID, TargetKey: targetKey, ArtifactID: art1})
+	if err != nil {
+		t.Fatalf("seed first promotion: %v", err)
+	}
+
+	_, _, err = promoteTx(t, reg, repository.Promotion{
+		EnvironmentID: envID, TargetKey: targetKey, ArtifactID: "00000000-0000-0000-0000-000000000000",
+	})
+	if err == nil {
+		t.Fatalf("expected the second promote (nonexistent artifact_id) to fail on the artifact_id FK, got nil error")
+	}
+
+	// The whole transaction -- both the UPDATE that closed `first` and the
+	// failed INSERT -- must have rolled back together. If it didn't, `first`
+	// would now show valid_to set with no new current row: a target
+	// promoted once that now has ZERO current rows, exactly the partial
+	// write PLAN.md and AGENTS.md warn about.
+	if n := currentPromotionCount(t, pool, envID, targetKey); n != 1 {
+		t.Fatalf("expected the original promotion to still be the sole current row after the aborted transaction, found %d current rows", n)
+	}
+	var validTo *time.Time
+	if err := pool.QueryRow(ctx, `SELECT valid_to FROM promotion WHERE promotion_id = $1`, first.PromotionID).Scan(&validTo); err != nil {
+		t.Fatalf("read back first promotion: %v", err)
+	}
+	if validTo != nil {
+		t.Fatalf("expected the original promotion's valid_to to remain NULL after the aborted transaction, got %v", *validTo)
 	}
 }
 

--- a/tools/app_registry/server/repository/postgres/promotion.go
+++ b/tools/app_registry/server/repository/postgres/promotion.go
@@ -1,0 +1,274 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/whale-net/everything/tools/app_registry/server/repository"
+)
+
+type promotionRepo struct{ ex dbtx }
+
+// promotionSelectBase joins promotion -> environment (for environment_key)
+// -> artifact (for kind/app_id/chart_id/repository/version/digest), so a
+// state dump is readable on its own without a second query per row — see
+// ARCHITECTURE.md "SCD2 on promotion". Column order matches
+// v_current_promotion exactly, so scanPromotion serves both this
+// base-table query (used for historical/window reads, which the view
+// cannot serve since it is current-only) and the view (used for pure
+// "current" reads).
+const promotionSelectBase = `
+	SELECT p.promotion_id, p.environment_id, e.key, a.kind, a.app_id, a.chart_id, p.artifact_id,
+	       a.repository, a.version, a.digest, p.state, p.is_override, p.valid_from, p.valid_to, p.target_key
+	FROM promotion p
+	JOIN environment e ON e.environment_id = p.environment_id
+	JOIN artifact a ON a.artifact_id = p.artifact_id`
+
+const promotionCurrentSelect = `
+	SELECT promotion_id, environment_id, environment_key, kind, app_id, chart_id, artifact_id,
+	       repository, version, digest, state, is_override, valid_from, valid_to, target_key
+	FROM v_current_promotion`
+
+func scanPromotion(row pgx.Row) (repository.Promotion, error) {
+	var p repository.Promotion
+	var kind string
+	var appID, chartID *string
+	var state string
+	if err := row.Scan(
+		&p.PromotionID, &p.EnvironmentID, &p.EnvironmentKey, &kind, &appID, &chartID, &p.ArtifactID,
+		&p.Repository, &p.Version, &p.Digest, &state, &p.IsOverride, &p.ValidFrom, &p.ValidTo, &p.TargetKey,
+	); err != nil {
+		return repository.Promotion{}, err
+	}
+	p.Kind = repository.ArtifactKind(kind)
+	p.State = repository.PromotionState(state)
+	if appID != nil {
+		p.AppID = *appID
+	}
+	if chartID != nil {
+		p.ChartID = *chartID
+	}
+	return p, nil
+}
+
+// Promote performs the SCD2 close-and-open write. Callers MUST invoke this
+// inside Registry.WithTx -- it issues three statements (select current,
+// close it, insert the new row) that must commit or roll back together, the
+// exact hazard AGENTS.md's SCD2 section and ARCHITECTURE.md's "Promotion
+// and the intent to write it back must commit atomically" call out.
+func (r *promotionRepo) Promote(ctx context.Context, p repository.Promotion) (*repository.Promotion, *repository.Promotion, error) {
+	// 1. Snapshot whatever is current before closing it, so we can return it
+	// as `superseded`. Read from the base tables (not the view) so this is
+	// consistent with the UPDATE below inside the same transaction.
+	row := r.ex.QueryRow(ctx, promotionSelectBase+`
+		WHERE p.environment_id = $1 AND p.target_key = $2 AND p.valid_to IS NULL`,
+		p.EnvironmentID, p.TargetKey)
+	var superseded *repository.Promotion
+	if existing, err := scanPromotion(row); err == nil {
+		superseded = &existing
+	} else if !errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil, fmt.Errorf("promote %s/%s: read current: %w", p.EnvironmentID, p.TargetKey, err)
+	}
+
+	// 2. Close it. If nothing was current, this affects zero rows -- fine,
+	// superseded stays nil.
+	if superseded != nil {
+		now := time.Now().UTC()
+		if _, err := r.ex.Exec(ctx, `
+			UPDATE promotion SET valid_to = $3
+			WHERE environment_id = $1 AND target_key = $2 AND valid_to IS NULL`,
+			p.EnvironmentID, p.TargetKey, now); err != nil {
+			return nil, nil, fmt.Errorf("promote %s/%s: close current: %w", p.EnvironmentID, p.TargetKey, err)
+		}
+		superseded.ValidTo = &now
+	}
+
+	// 3. Open the new row. If a concurrent transaction closed-and-opened
+	// between steps 1 and here, promotion_current_idx (the partial unique
+	// index on (environment_id, target_key) WHERE valid_to IS NULL) rejects
+	// this insert -- that is the "double-promotion structurally impossible"
+	// property, not a bug to work around.
+	id := uuid.NewString()
+	state := p.State
+	if state == "" {
+		state = repository.PromotionStateActive
+	}
+	if _, err := r.ex.Exec(ctx, `
+		INSERT INTO promotion (promotion_id, environment_id, target_key, artifact_id, state, is_override)
+		VALUES ($1, $2, $3, $4, $5, $6)`,
+		id, p.EnvironmentID, p.TargetKey, p.ArtifactID, string(state), p.IsOverride); err != nil {
+		msg := fmt.Sprintf("target %s already has a current promotion in environment %s", p.TargetKey, p.EnvironmentID)
+		if de, ok := translatePgError(err, msg); ok {
+			return nil, nil, de
+		}
+		return nil, nil, fmt.Errorf("promote %s/%s: insert: %w", p.EnvironmentID, p.TargetKey, err)
+	}
+
+	current, err := r.GetCurrent(ctx, p.EnvironmentID, p.TargetKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("promote %s/%s: read back: %w", p.EnvironmentID, p.TargetKey, err)
+	}
+	return current, superseded, nil
+}
+
+func (r *promotionRepo) GetCurrent(ctx context.Context, environmentID, targetKey string) (*repository.Promotion, error) {
+	row := r.ex.QueryRow(ctx, promotionCurrentSelect+` WHERE environment_id = $1 AND target_key = $2`, environmentID, targetKey)
+	p, err := scanPromotion(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, repository.ErrNotFound
+		}
+		return nil, err
+	}
+	return &p, nil
+}
+
+func (r *promotionRepo) GetPrevious(ctx context.Context, environmentID, targetKey string) (*repository.Promotion, error) {
+	row := r.ex.QueryRow(ctx, promotionSelectBase+`
+		WHERE p.environment_id = $1 AND p.target_key = $2 AND p.valid_to IS NOT NULL
+		ORDER BY p.valid_from DESC LIMIT 1`, environmentID, targetKey)
+	p, err := scanPromotion(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, repository.ErrNotFound
+		}
+		return nil, err
+	}
+	return &p, nil
+}
+
+func (r *promotionRepo) StateAt(ctx context.Context, environmentID string, at *time.Time) ([]repository.Promotion, error) {
+	var rows pgx.Rows
+	var err error
+	if at == nil {
+		rows, err = r.ex.Query(ctx, promotionCurrentSelect+` WHERE environment_id = $1`, environmentID)
+	} else {
+		// The SCD2 window query from ARCHITECTURE.md "SCD2 on promotion":
+		// the incident query, "what was live at time T".
+		rows, err = r.ex.Query(ctx, promotionSelectBase+`
+			WHERE p.environment_id = $1 AND p.valid_from <= $2 AND (p.valid_to IS NULL OR p.valid_to > $2)`,
+			environmentID, *at)
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanPromotions(rows)
+}
+
+func (r *promotionRepo) ListPromotions(ctx context.Context, filter repository.PromotionListFilter) ([]repository.Promotion, error) {
+	base := promotionSelectBase + `
+		LEFT JOIN app ON a.app_id = app.app_id
+		LEFT JOIN chart ON a.chart_id = chart.chart_id
+		WHERE 1=1`
+	var args []any
+	if filter.EnvironmentKey != "" {
+		args = append(args, filter.EnvironmentKey)
+		base += fmt.Sprintf(" AND e.key = $%d", len(args))
+	}
+	if filter.OwnerFullName != "" {
+		args = append(args, filter.OwnerFullName)
+		base += fmt.Sprintf(" AND (app.domain || '-' || app.name = $%d OR chart.domain || '-' || chart.name = $%d)", len(args), len(args))
+	}
+	if !filter.IncludeHistory {
+		base += " AND p.valid_to IS NULL"
+	}
+	base += " ORDER BY p.valid_from DESC"
+
+	rows, err := r.ex.Query(ctx, base, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanPromotions(rows)
+}
+
+func scanPromotions(rows pgx.Rows) ([]repository.Promotion, error) {
+	var out []repository.Promotion
+	for rows.Next() {
+		p, err := scanPromotion(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, p)
+	}
+	return out, rows.Err()
+}
+
+func (r *promotionRepo) RecordEvent(ctx context.Context, e repository.PromotionEvent) (*repository.PromotionEvent, error) {
+	e.EventID = uuid.NewString()
+	if e.OccurredAt.IsZero() {
+		e.OccurredAt = time.Now().UTC()
+	}
+	if _, err := r.ex.Exec(ctx, `
+		INSERT INTO promotion_event (event_id, promotion_id, action, actor, reason, temporal_workflow_id, temporal_run_id, occurred_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+		e.EventID, e.PromotionID, string(e.Action), e.Actor, e.Reason, e.TemporalWorkflowID, e.TemporalRunID, e.OccurredAt); err != nil {
+		return nil, fmt.Errorf("record promotion event for %s: %w", e.PromotionID, err)
+	}
+	return &e, nil
+}
+
+const promotionEventColumns = `pe.event_id, pe.promotion_id, pe.action, pe.actor, pe.reason, pe.temporal_workflow_id, pe.temporal_run_id, pe.occurred_at`
+
+func scanPromotionEvent(row pgx.Row) (repository.PromotionEvent, error) {
+	var e repository.PromotionEvent
+	var action string
+	if err := row.Scan(&e.EventID, &e.PromotionID, &action, &e.Actor, &e.Reason, &e.TemporalWorkflowID, &e.TemporalRunID, &e.OccurredAt); err != nil {
+		return repository.PromotionEvent{}, err
+	}
+	e.Action = repository.PromotionAction(action)
+	return e, nil
+}
+
+func (r *promotionRepo) ListEvents(ctx context.Context, filter repository.PromotionEventListFilter) ([]repository.PromotionEvent, error) {
+	query := `SELECT ` + promotionEventColumns + `
+		FROM promotion_event pe
+		JOIN promotion p ON p.promotion_id = pe.promotion_id
+		JOIN environment e ON e.environment_id = p.environment_id
+		JOIN artifact a ON a.artifact_id = p.artifact_id
+		LEFT JOIN app ON a.app_id = app.app_id
+		LEFT JOIN chart ON a.chart_id = chart.chart_id
+		WHERE 1=1`
+	var args []any
+	if filter.PromotionID != "" {
+		args = append(args, filter.PromotionID)
+		query += fmt.Sprintf(" AND pe.promotion_id = $%d", len(args))
+	}
+	if filter.EnvironmentKey != "" {
+		args = append(args, filter.EnvironmentKey)
+		query += fmt.Sprintf(" AND e.key = $%d", len(args))
+	}
+	if filter.OwnerFullName != "" {
+		args = append(args, filter.OwnerFullName)
+		query += fmt.Sprintf(" AND (app.domain || '-' || app.name = $%d OR chart.domain || '-' || chart.name = $%d)", len(args), len(args))
+	}
+	if filter.Actor != "" {
+		args = append(args, filter.Actor)
+		query += fmt.Sprintf(" AND pe.actor = $%d", len(args))
+	}
+	if !filter.Since.IsZero() {
+		args = append(args, filter.Since)
+		query += fmt.Sprintf(" AND pe.occurred_at >= $%d", len(args))
+	}
+	query += " ORDER BY pe.occurred_at DESC"
+
+	rows, err := r.ex.Query(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []repository.PromotionEvent
+	for rows.Next() {
+		e, err := scanPromotionEvent(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, e)
+	}
+	return out, rows.Err()
+}

--- a/tools/app_registry/server/repository/postgres/repository.go
+++ b/tools/app_registry/server/repository/postgres/repository.go
@@ -49,6 +49,7 @@ func (r *Registry) Idempotency() repository.IdempotencyRepository { return &idem
 func (r *Registry) Environments() repository.EnvironmentRepository {
 	return &environmentRepo{ex: r.ex}
 }
+func (r *Registry) Promotions() repository.PromotionRepository { return &promotionRepo{ex: r.ex} }
 
 // WithTx runs fn inside a single Postgres transaction, committing iff fn
 // returns nil and rolling back otherwise. This is the atomicity boundary

--- a/tools/app_registry/server/repository/repository.go
+++ b/tools/app_registry/server/repository/repository.go
@@ -10,6 +10,7 @@ package repository
 import (
 	"context"
 	"errors"
+	"time"
 
 	appmetapb "github.com/whale-net/everything/tools/appmeta/proto"
 )
@@ -127,6 +128,52 @@ type EnvironmentRepository interface {
 	Archive(ctx context.Context, key, reason string) (*Environment, error)
 }
 
+// PromotionRepository covers `promotion` (SCD2) and `promotion_event`
+// (append-only) — see ARCHITECTURE.md "SCD2 on promotion". Every method
+// here must be called from inside Registry.WithTx when it participates in a
+// write: none of them open their own transaction, matching every other
+// repository in this package.
+type PromotionRepository interface {
+	// Promote performs the SCD2 close-and-open write described in
+	// AGENTS.md: it closes any current row for (p.EnvironmentID,
+	// p.TargetKey) by setting its valid_to, then inserts p as the new
+	// current row. current is the freshly written row; superseded is the
+	// row that was just closed, or nil if this is the first promotion ever
+	// recorded for this target. The partial unique index
+	// promotion_current_idx is what makes two concurrent callers racing
+	// this method structurally unable to both end up current.
+	Promote(ctx context.Context, p Promotion) (current *Promotion, superseded *Promotion, err error)
+
+	// GetCurrent returns the current (valid_to IS NULL) promotion for
+	// (environmentID, targetKey), or ErrNotFound.
+	GetCurrent(ctx context.Context, environmentID, targetKey string) (*Promotion, error)
+
+	// GetPrevious returns the most recently superseded row for
+	// (environmentID, targetKey) — the state Rollback re-promotes.
+	// ErrNotFound when there is no history to roll back to (the target has
+	// never been promoted, or has been promoted exactly once).
+	GetPrevious(ctx context.Context, environmentID, targetKey string) (*Promotion, error)
+
+	// StateAt returns every target's promotion row valid in environmentID
+	// at instant at. at == nil means "now": rows with valid_to IS NULL —
+	// this is the SCD2 window query from ARCHITECTURE.md "SCD2 on
+	// promotion", parameterized so the same method serves both
+	// GetEnvironmentState's current and historical (`at`) reads.
+	StateAt(ctx context.Context, environmentID string, at *time.Time) ([]Promotion, error)
+
+	// ListPromotions supports ListPromotionsRequest's filters. Ordered by
+	// valid_from descending.
+	ListPromotions(ctx context.Context, filter PromotionListFilter) ([]Promotion, error)
+
+	// RecordEvent appends one row to promotion_event. Not SCD2 — see
+	// AGENTS.md, event logs get their own shape.
+	RecordEvent(ctx context.Context, e PromotionEvent) (*PromotionEvent, error)
+
+	// ListEvents supports ListPromotionEventsRequest's filters. Ordered by
+	// occurred_at descending.
+	ListEvents(ctx context.Context, filter PromotionEventListFilter) ([]PromotionEvent, error)
+}
+
 // Registry aggregates the per-entity repositories and provides a
 // unit-of-work boundary. Handlers call WithTx to make a business operation
 // (reconcile, idempotency check-and-store, etc.) atomic: fn receives a
@@ -137,6 +184,7 @@ type Registry interface {
 	Artifacts() ArtifactRepository
 	Idempotency() IdempotencyRepository
 	Environments() EnvironmentRepository
+	Promotions() PromotionRepository
 
 	WithTx(ctx context.Context, fn func(ctx context.Context, r Registry) error) error
 }


### PR DESCRIPTION
Stacked on #508 (AR-3b). Implements `PromotionRegistry`: `Promote`, `Rollback`, `GetEnvironmentState`, `ListPromotions`, `ListPromotionEvents` — replacing the AR-1 stub.

## Schema (migration `003`)

- **`promotion`** — SCD2 history on `valid_from`/`valid_to` per AGENTS.md. It stores only `promotion_id, environment_id, target_key, artifact_id, state, is_override` plus the window; repository/version/digest/kind/owner are read via a join to `artifact`, so there is exactly one place that data can drift from.
- **`target_key`** is `"<kind>:<owner_full_name>"`, denormalized deliberately. The natural target is a two-column `(app_id, chart_id)` pair where one is always NULL — and a unique index cannot treat two NULLs as equal, so the partial unique index below would not be expressible without it.
- **`promotion_current_idx`** — `UNIQUE (environment_id, target_key) WHERE valid_to IS NULL`. This is load-bearing, not an optimization: it makes two current rows for the same target structurally impossible rather than merely unlikely.
- **`promotion_event`** — append-only audit log, *not* SCD2. AGENTS.md is explicit that event logs get their own shape.
- **`v_current_promotion`** — pre-joins promotion → artifact → environment so the CLI, the AR-4 writeback worker, and any future UI never re-derive the join.

## Business rules (all enforced in `server/handlers/promotion.go`)

| Rule | Behaviour |
|---|---|
| Promotability | `NOT_PROMOTABLE` → `FailedPrecondition` |
| Chart-owned image | `VIA_CHART` requires `allow_override`; stored as `is_override = true` |
| Drift | `GetEnvironmentState` cross-references overridden image promotions against chart pins, emitting `DriftEntry` |
| `reason` | Required when the target environment's `rank > 0`, on both `Promote` and `Rollback` |
| Auth | `Promote`/`Rollback` → `auth.RequirePromoter(ctx, <env key>)`; reads → `auth.RequireAuthenticated` |

Re-promoting the artifact that is already current short-circuits and sets the response's existing `already_promoted` flag rather than writing an identical redundant SCD2 row.

## Verification

`bazel test //tools/app_registry/...` → 4/4 pass. `bazel test //tools/app_registry/server/repository/postgres:postgres_integration_test --nocache_test_results` → passes against a real Postgres container (27s), applying the real migrations so schema drift is caught too.

Every guard was verified by **deliberately breaking it** and confirming a test goes red — a green test that would stay green with the guard removed proves nothing:

| Guard removed | Test that failed |
|---|---|
| `auth.RequirePromoter` | `TestPromote_Authorization` |
| `promotion_current_idx` | `TestPromotion_CurrentIdxRejectsConcurrentCurrentRows` |
| the wrapping transaction | `TestPromotionRepo_Promote_TransactionAbortLeavesNoPartialWrite` — the close-half committed alone, leaving zero current rows |

That last one is the exact hazard AGENTS.md warns about and that AR-2a shipped a bug through. The in-memory fake cannot catch it; only the real-Postgres tier can.

This also lands the partial-unique-index test PLAN.md recorded as deliberately deferred from AR-3b.

## Deferred

Approval-gate states (schema-ready, never written), `writeback_outbox`/Temporal (AR-4), CLI + `promote.yml` (AR-3d), and real pagination on the two `List*` RPCs — consistent with every other `List*` in this package, none of which paginate.