### PR TITLE
AR-3d: CLI promote/rollback/status/history/diff, promote.yml, release.yml auth wiring

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -1,0 +1,149 @@
+name: Promote
+
+# Human-triggered promotion / rollback against the App Registry. See
+# tools/app_registry/PLAN.md -> "AR-3 -> Credential model (decided)" and
+# ARCHITECTURE.md -> "Authorization": the `environment:` declaration on the
+# `promote` job below is the entire security model for this workflow, not a
+# formality. It is what scopes the job to the target GitHub Environment's
+# secrets (so only that environment's `app-registry-promoter-<env>` client
+# secret is readable) and what triggers that environment's required
+# reviewers. A builder credential is never in scope here -- it lives in a
+# repository secret and carries no promoter role regardless.
+#
+# Unlike the best-effort AR-2c recording steps in release.yml, the promote
+# step below is NOT continue-on-error: a promotion that silently fails while
+# the workflow shows green is exactly the failure mode this system exists to
+# prevent.
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Target GitHub Environment / App Registry environment key (e.g. dev, stage, prod). Must have a matching GitHub Environment with the app-registry-promoter-<environment> secret configured.'
+        required: true
+      action:
+        description: 'promote a specific version, or roll back to whatever was previously current'
+        type: choice
+        options:
+          - promote
+          - rollback
+        default: promote
+      owner_full_name:
+        description: 'App or chart identity, as <domain>-<name> (e.g. manmanv2-host-manager)'
+        required: true
+      version:
+        description: 'Version to promote, e.g. v1.4.0. Required for action=promote; ignored for action=rollback.'
+        required: false
+      reason:
+        description: 'Why -- required above dev rank, recorded in the audit log'
+        required: false
+      allow_override:
+        description: 'Acknowledge promoting a VIA_CHART image directly, bypassing its chart (promote only)'
+        type: boolean
+        default: false
+      dry_run:
+        description: 'Compute the resulting state without writing'
+        type: boolean
+        default: false
+
+jobs:
+  promote:
+    name: ${{ inputs.action }} ${{ inputs.owner_full_name }} -> ${{ inputs.environment }}
+    runs-on: ubuntu-latest
+    # This is the security-critical line -- see the header comment above.
+    # It scopes the job to the named GitHub Environment's secrets and
+    # required reviewers.
+    environment: ${{ inputs.environment }}
+    steps:
+    # Every `run:` block in this workflow reads inputs through `env:` rather
+    # than interpolating `${{ inputs.* }}` directly into the script. Direct
+    # interpolation splices attacker-controlled text into bash before the
+    # shell ever sees it, so a crafted owner_full_name or reason would run as
+    # code in a job that holds a promoter client secret. Via `env:` the value
+    # is only ever a shell variable. Keep it that way when editing.
+    - name: Validate inputs
+      env:
+        ACTION: ${{ inputs.action }}
+        VERSION: ${{ inputs.version }}
+      run: |
+        if [[ "$ACTION" == "promote" && -z "$VERSION" ]]; then
+          echo "::error::version is required when action=promote"
+          exit 1
+        fi
+        echo "✅ inputs validated"
+
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Setup Build Environment
+      uses: ./.github/actions/setup-build-env
+      with:
+        cache-suffix: 'app-registry-cli'
+        bazel-remote-cache-url: ${{ secrets.BAZEL_REMOTE_CACHE_URL }}
+        bazel-remote-cache-user: ${{ secrets.BAZEL_REMOTE_CACHE_USER }}
+        bazel-remote-cache-password: ${{ secrets.BAZEL_REMOTE_CACHE_PASSWORD }}
+
+    - name: Build app-registry CLI
+      run: bazel build --config=ci //tools/app_registry/cli:app-registry
+
+    # Read from *this job's* Environment secrets (scoped by `environment:`
+    # above), never from repository secrets. See DEPLOY.md "Where each
+    # secret goes" -- promoter-<env> client secrets live only on the
+    # matching GitHub Environment.
+    - name: Promote
+      if: inputs.action == 'promote'
+      env:
+        APP_REGISTRY_ADDRESS: ${{ vars.APP_REGISTRY_ADDRESS }}
+        GRPC_AUTH_MODE: oidc
+        GRPC_AUTH_TOKEN_URL: ${{ vars.APP_REGISTRY_AUTH_TOKEN_URL }}
+        GRPC_AUTH_CLIENT_ID: app-registry-promoter-${{ inputs.environment }}
+        GRPC_AUTH_CLIENT_SECRET: ${{ secrets.APP_REGISTRY_PROMOTER_CLIENT_SECRET }}
+        ENVIRONMENT: ${{ inputs.environment }}
+        OWNER_FULL_NAME: ${{ inputs.owner_full_name }}
+        VERSION: ${{ inputs.version }}
+        REASON: ${{ inputs.reason }}
+        ALLOW_OVERRIDE: ${{ inputs.allow_override }}
+        DRY_RUN: ${{ inputs.dry_run }}
+      run: |
+        APP_REGISTRY_CLI="$(bazel info bazel-bin --config=ci)/tools/app_registry/cli/app-registry_/app-registry"
+
+        ARGS=(promote "$OWNER_FULL_NAME" "$VERSION" --env "$ENVIRONMENT")
+        if [[ -n "$REASON" ]]; then
+          ARGS+=(--reason "$REASON")
+        fi
+        if [[ "$ALLOW_OVERRIDE" == "true" ]]; then
+          ARGS+=(--allow-override)
+        fi
+        if [[ "$DRY_RUN" == "true" ]]; then
+          ARGS+=(--dry-run)
+        fi
+
+        "$APP_REGISTRY_CLI" "${ARGS[@]}"
+
+    - name: Rollback
+      if: inputs.action == 'rollback'
+      env:
+        APP_REGISTRY_ADDRESS: ${{ vars.APP_REGISTRY_ADDRESS }}
+        GRPC_AUTH_MODE: oidc
+        GRPC_AUTH_TOKEN_URL: ${{ vars.APP_REGISTRY_AUTH_TOKEN_URL }}
+        GRPC_AUTH_CLIENT_ID: app-registry-promoter-${{ inputs.environment }}
+        GRPC_AUTH_CLIENT_SECRET: ${{ secrets.APP_REGISTRY_PROMOTER_CLIENT_SECRET }}
+        ENVIRONMENT: ${{ inputs.environment }}
+        OWNER_FULL_NAME: ${{ inputs.owner_full_name }}
+        REASON: ${{ inputs.reason }}
+        DRY_RUN: ${{ inputs.dry_run }}
+      run: |
+        APP_REGISTRY_CLI="$(bazel info bazel-bin --config=ci)/tools/app_registry/cli/app-registry_/app-registry"
+
+        ARGS=(rollback "$OWNER_FULL_NAME" --env "$ENVIRONMENT")
+        if [[ -n "$REASON" ]]; then
+          ARGS+=(--reason "$REASON")
+        fi
+        if [[ "$DRY_RUN" == "true" ]]; then
+          ARGS+=(--dry-run)
+        fi
+
+        "$APP_REGISTRY_CLI" "${ARGS[@]}"
+
+    # No continue-on-error anywhere above: a failed promotion must fail the
+    # job loudly, unlike the best-effort recording steps in release.yml.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -401,6 +401,17 @@ jobs:
         DOMAIN: ${{ matrix.domain }}
         VERSION: ${{ matrix.version || needs.plan-release.outputs.version }}
         APP_REGISTRY_ADDRESS: ${{ vars.APP_REGISTRY_ADDRESS }}
+        # Builder credential -- repository secret, deliberately never an
+        # Environment secret (see DEPLOY.md "Where each secret goes"): this
+        # identity can record builds/artifacts but carries no promoter role,
+        # so it cannot promote regardless of who holds it. Without these,
+        # once the server runs GRPC_AUTH_MODE=oidc every call here fails
+        # Unauthenticated -- silently, because this step is
+        # continue-on-error (see DEPLOY.md section 4).
+        GRPC_AUTH_MODE: oidc
+        GRPC_AUTH_TOKEN_URL: ${{ vars.APP_REGISTRY_AUTH_TOKEN_URL }}
+        GRPC_AUTH_CLIENT_ID: app-registry-builder
+        GRPC_AUTH_CLIENT_SECRET: ${{ secrets.APP_REGISTRY_BUILDER_CLIENT_SECRET }}
       run: |
         FULL_APP_NAME="${DOMAIN}-${APP}"
         REPOSITORY="ghcr.io/${{ github.repository_owner }}/${FULL_APP_NAME}"
@@ -915,6 +926,13 @@ jobs:
       env:
         CHARTS: ${{ steps.plan.outputs.charts }}
         APP_REGISTRY_ADDRESS: ${{ vars.APP_REGISTRY_ADDRESS }}
+        # See the "Record build and artifact in App Registry" step above --
+        # same builder credential, same repository-secret placement, same
+        # reason (DEPLOY.md section 4).
+        GRPC_AUTH_MODE: oidc
+        GRPC_AUTH_TOKEN_URL: ${{ vars.APP_REGISTRY_AUTH_TOKEN_URL }}
+        GRPC_AUTH_CLIENT_ID: app-registry-builder
+        GRPC_AUTH_CLIENT_SECRET: ${{ secrets.APP_REGISTRY_BUILDER_CLIENT_SECRET }}
       run: |
         echo "Building release helper and app-registry CLI..."
         bazel build --config=ci //tools/release_helper_go:release_helper_go //tools/app_registry/cli:app-registry

--- a/tools/app_registry/DEPLOY.md
+++ b/tools/app_registry/DEPLOY.md
@@ -8,10 +8,10 @@ which is the *how* — click-by-click Keycloak configuration and the gotchas.
 This document is the *what for this service*: the exact objects, names, and
 secrets.
 
-> **Status: AR-3a.** The role model is merged and enforced on the recording
-> RPCs. Promotion does not exist yet. Anything marked **⏳ later** is defined in
-> code but enforces nothing until AR-3c/AR-3d land — safe to create now, but not
-> yet load-bearing. See [PLAN.md](PLAN.md).
+> **Status: AR-3d.** The role model, `PromotionRegistry`, its CLI commands, and
+> `promote.yml` are all merged. Promoter clients (marked ⏳ below) are safe to
+> create now and are load-bearing the moment `promote.yml` runs against a
+> `oidc`-mode server. See [PLAN.md](PLAN.md).
 
 ---
 
@@ -23,8 +23,9 @@ everything before it is inert.
 1. [Keycloak objects](#1-keycloak-objects)
 2. [Verify a token by hand](#2-verify-a-token-by-hand) ← before touching the deployment
 3. [Server configuration](#3-server-configuration)
-4. [CI credentials](#4-ci-credentials) ← **read the warning first**
+4. [CI credentials](#4-ci-credentials)
 5. [Turn CI recording on](#5-turn-ci-recording-on)
+6. [Promote via `promote.yml`](#6-promote-via-promoteyml)
 
 ---
 
@@ -43,9 +44,9 @@ every call returns `Unauthenticated`.
 | `app-registry-api` | Names the audience. Never obtains a token. | Client authentication **On**, **all** flows unchecked, no roles | **now** |
 | `app-registry-builder` | CI recording (`ReconcileApps`, `RecordBuild`, `RecordArtifact`) | Confidential, **Service accounts roles** only, realm role `app-registry-builder`, audience mapper → `app-registry-api` | **now** |
 | `app-registry-admin` | `EnvironmentRegistry`, `SetAppStatus` | Same shape, realm role `app-registry-admin` | **now** |
-| `app-registry-promoter-dev` | Promote to `dev` | Same shape, realm role `app-registry-promoter-dev` | ⏳ later |
-| `app-registry-promoter-stage` | Promote to `stage` | Same shape, realm role `app-registry-promoter-stage` | ⏳ later |
-| `app-registry-promoter-prod` | Promote to `prod` | Same shape, realm role `app-registry-promoter-prod` | ⏳ later |
+| `app-registry-promoter-dev` | Promote to `dev` (via `promote.yml`) | Same shape, realm role `app-registry-promoter-dev` | **now** — needed before `promote.yml` can run against `dev` |
+| `app-registry-promoter-stage` | Promote to `stage` (via `promote.yml`) | Same shape, realm role `app-registry-promoter-stage` | **now** — needed before `promote.yml` can run against `stage` |
+| `app-registry-promoter-prod` | Promote to `prod` (via `promote.yml`) | Same shape, realm role `app-registry-promoter-prod` | **now** — needed before `promote.yml` can run against `prod` |
 
 ### Realm roles
 
@@ -139,20 +140,23 @@ manifest, deliberately.
 
 ## 4. CI credentials
 
-> ### ⚠️ Read this before enabling `oidc`
+> ### Resolved in AR-3d
 >
-> **`.github/workflows/release.yml` currently sets no `GRPC_AUTH_*` variables
-> at all.** The AR-2c recording steps pass only `APP_REGISTRY_ADDRESS`, so the
-> CLI runs in `none` mode and sends no credentials.
+> Earlier versions of this doc warned that `.github/workflows/release.yml` set
+> no `GRPC_AUTH_*` variables, so the moment the server ran `oidc` the AR-2c
+> recording steps would fail `Unauthenticated` while `continue-on-error` hid
+> it — a release staying green while recording silently went stale.
 >
-> The moment the server runs `oidc`, those calls fail `Unauthenticated`. They
-> are `continue-on-error`, so **the release still succeeds and recording
-> silently stops** — the failure mode is a registry that quietly goes stale, not
-> a red build.
+> The `Record build and artifact in App Registry` and `Record chart artifacts
+> in App Registry` steps now set `GRPC_AUTH_MODE: oidc` and read the builder
+> client's credentials from the repository secret/variable named below. Their
+> `continue-on-error` and `APP_REGISTRY_CICD_OPT_IN` gating are unchanged —
+> recording is still best-effort and still off by default. What changed is
+> that when it *is* on, it can now actually authenticate once the server runs
+> `oidc`.
 >
-> Wiring the builder credential into `release.yml` is an outstanding task. Until
-> it is done, either leave `APP_REGISTRY_CICD_OPT_IN` unset, or accept that
-> recording is off while you exercise auth by hand with the CLI.
+> `promote.yml` (§5 below) exists as of AR-3d too, reading each environment's
+> promoter secret the same way.
 
 Client-side variables the CLI reads (see [ENV.md](ENV.md)):
 
@@ -160,7 +164,7 @@ Client-side variables the CLI reads (see [ENV.md](ENV.md)):
 |---|---|
 | `GRPC_AUTH_MODE` | `oidc` — must match the server |
 | `GRPC_AUTH_TOKEN_URL` | `https://<host>/realms/<realm>/protocol/openid-connect/token` |
-| `GRPC_AUTH_CLIENT_ID` | `app-registry-builder` |
+| `GRPC_AUTH_CLIENT_ID` | `app-registry-builder` (recording) or `app-registry-promoter-<environment>` (promotion) |
 | `GRPC_AUTH_CLIENT_SECRET` | that client's secret |
 
 ### Where each secret goes
@@ -170,23 +174,28 @@ promoting. Getting it wrong defeats the entire credential model.
 
 | Secret | Location | Why |
 |---|---|---|
-| builder client secret | **Repository** secret | Every release job needs it; it grants recording only |
-| `app-registry-promoter-prod` secret ⏳ | **Environment** secret on the `prod` GitHub Environment | Only a job declaring `environment: prod` can read it, and that declaration triggers the environment's required reviewers |
-| `app-registry-promoter-stage` / `-dev` ⏳ | Environment secret on the matching Environment | Same, per environment |
+| builder client secret (`APP_REGISTRY_BUILDER_CLIENT_SECRET`) | **Repository** secret | Every release job needs it; it grants recording only — wired into `release.yml`'s two recording steps |
+| `app-registry-promoter-prod` secret (`APP_REGISTRY_PROMOTER_CLIENT_SECRET`) | **Environment** secret on the `prod` GitHub Environment | Only a job declaring `environment: prod` can read it, and that declaration triggers the environment's required reviewers — `promote.yml` declares `environment: ${{ inputs.environment }}` for exactly this reason |
+| `app-registry-promoter-stage` / `-dev` (`APP_REGISTRY_PROMOTER_CLIENT_SECRET`) | Environment secret on the matching Environment, same secret name, different Environment | Same, per environment — the Environment scoping is what selects the right client, not the secret name |
 | admin client secret | Not in GitHub | Human-operated; keep it out of CI entirely |
 
 **Never put a promoter secret in a repository secret.** A repository secret is
 readable by any workflow, which removes the boundary between building and
 promoting — the one property the whole model exists to provide.
 
-Configure **required reviewers** on the `prod` Environment. That approval, not
-anything in the registry, is the human gate on promotion.
+Configure **required reviewers** on the `prod` Environment (and `stage` if
+desired). That approval, not anything in the registry, is the human gate on
+promotion. Create three GitHub Environments named exactly `dev`, `stage`,
+`prod` — matching the `environment` keys seeded by AR-3b and the promoter
+client names above — each holding its own
+`APP_REGISTRY_PROMOTER_CLIENT_SECRET`.
 
 Repository *variables* (not secrets):
 
 | Variable | Value |
 |---|---|
 | `APP_REGISTRY_ADDRESS` | the API's ingress host:port |
+| `APP_REGISTRY_AUTH_TOKEN_URL` | the Keycloak token endpoint, e.g. `https://<host>/realms/<realm>/protocol/openid-connect/token` — same for every client, so it is a variable, not a secret |
 | `APP_REGISTRY_CICD_OPT_IN` | `true` to enable recording — see below |
 
 ---
@@ -213,18 +222,29 @@ green job.
 
 ---
 
+## 6. Promote via `promote.yml`
+
+`.github/workflows/promote.yml` is a `workflow_dispatch` job with inputs
+`environment`, `action` (`promote`/`rollback`), `owner_full_name`, `version`,
+`reason`, `allow_override`, `dry_run`. Its job declares
+`environment: ${{ inputs.environment }}`, which is what scopes it to that
+GitHub Environment's `APP_REGISTRY_PROMOTER_CLIENT_SECRET` and triggers that
+Environment's required reviewers — see §4's secret table. Unlike the AR-2c
+recording steps it is **not** `continue-on-error`: a failed promotion fails
+the run.
+
+To promote to `prod`: create the `prod` GitHub Environment (§1's client table
+and §4's secret table), configure required reviewers on it, run the workflow
+with `environment: prod`, and approve the run when prompted.
+
+---
+
 ## Not settled yet
 
-Do not build infrastructure around these; they may change in AR-3b/3c/3d.
-
-- **Promoter roles enforce nothing.** `RequirePromoter` exists and is tested,
-  but `PromotionRegistry` is `Unimplemented` until AR-3c. Creating the promoter
-  clients now is harmless, just not yet meaningful.
 - **`allowed_principals`** — ARCHITECTURE.md describes a per-environment
-  narrowing beyond the role check. It lands in AR-3b/3c and may add a second
-  condition the prod promoter must satisfy.
-- **`promote.yml`** does not exist yet (AR-3d). The GitHub Environment names
-  above are the intended design, not a shipped contract.
+  narrowing beyond the role check. It lands alongside `EnvironmentRegistry`
+  admin tooling and may add a second condition the prod promoter must
+  satisfy.
 - **GitHub Actions OIDC** was considered and rejected for now in favour of
   Keycloak service accounts — see PLAN.md → AR-3 → "Credential model". Worth
   revisiting for secretless CI once this is proven.

--- a/tools/app_registry/ENV.md
+++ b/tools/app_registry/ENV.md
@@ -76,6 +76,24 @@ The CLI fetches and auto-refreshes a client-credentials token via
 KEYCLOAK.md section 6 "CI — GitHub Actions" for the shape of a workflow job
 setting these four variables.
 
+### CI wiring (AR-3d)
+
+`.github/workflows/release.yml`'s recording steps and
+`.github/workflows/promote.yml` set the four CLI variables above from GitHub
+Actions secrets/variables — see [DEPLOY.md](DEPLOY.md) §4 and §6 for the full
+placement rationale:
+
+| GitHub Actions name | Kind | Maps to | Used by |
+|---|---|---|---|
+| `vars.APP_REGISTRY_ADDRESS` | Repository variable | `APP_REGISTRY_ADDRESS` | both |
+| `vars.APP_REGISTRY_AUTH_TOKEN_URL` | Repository variable | `GRPC_AUTH_TOKEN_URL` | both |
+| `secrets.APP_REGISTRY_BUILDER_CLIENT_SECRET` | Repository secret | `GRPC_AUTH_CLIENT_SECRET` (`GRPC_AUTH_CLIENT_ID=app-registry-builder`) | `release.yml` recording steps only |
+| `secrets.APP_REGISTRY_PROMOTER_CLIENT_SECRET` | Environment secret, one per `dev`/`stage`/`prod` GitHub Environment | `GRPC_AUTH_CLIENT_SECRET` (`GRPC_AUTH_CLIENT_ID=app-registry-promoter-<environment>`) | `promote.yml` only |
+
+`GRPC_AUTH_MODE=oidc` is hardcoded in both workflows rather than read from a
+variable — the CLI must match whatever the server runs, and the server is
+expected to run `oidc` in every environment these workflows target.
+
 ## Local Development (Tilt)
 
 ```bash

--- a/tools/app_registry/PLAN.md
+++ b/tools/app_registry/PLAN.md
@@ -26,9 +26,59 @@ The registry is being deployed to `dev` by the repo owner. `app-registry-api`
 and `app-registry-migration` images publish from `apps=all`.
 `APP_REGISTRY_CICD_OPT_IN` is still unset, so CI makes no registry calls.
 
-**Next up:** AR-3d (CLI `promote`/`rollback`/`status`/`history`/`diff` +
-`promote.yml`). AR-2d, AR-3a, AR-3b, and AR-3c are done and stacked on top
-of `main`.
+**AR-3 is now fully implemented** (AR-3a through AR-3d), stacked on top of
+`main` and not yet merged. AR-2d is also done, not merged.
+
+### AR-3d — CLI + `promote.yml` — done
+
+- `app-registry promote`/`rollback`/`status`/`history`/`diff` filled in
+  (`tools/app_registry/cli/cmd/promote.go`) — these commands already existed
+  as an AR-1 skeleton wired to the RPCs AR-3c just implemented; AR-3d is the
+  pass that made them real. `--idempotency-key` on `promote`/`rollback` is
+  now optional: a UUID is generated when omitted
+  (`promoteIdempotencyKey`), matching ARCHITECTURE.md "Idempotency"'s
+  human-promotion convention. `promote`'s `already_promoted` and both
+  commands' `dry_run` are surfaced as explicit stderr notes so neither looks
+  like a write happened. `status` prints every `DriftEntry` as a stderr
+  banner ahead of the JSON body — the failure mode of a drifted environment
+  that looks clean was the whole reason this command exists. `diff` computes
+  its result client-side from two `GetEnvironmentState` calls (per this
+  document's AR-3d scope note below — no server-side diff RPC), matching
+  targets by `image:<app_id>` / `chart:<chart_id>` and omitting entries whose
+  digest agrees on both sides. `history` combines `ListPromotions` and
+  `ListPromotionEvents`, formatted together via a new `printCombinedResponse`
+  helper since no single RPC returns both.
+- Unit tests for `diffEnvironmentStates` (both-empty, only-in-A, only-in-B,
+  digest-differs, identical-digest-omitted) and `promoteIdempotencyKey`
+  (generates when empty, preserves when given) —
+  `tools/app_registry/cli/cmd/promote_test.go`. The identical-digest-omitted
+  guard was verified to actually matter: temporarily forcing the "different"
+  branch unconditionally turned that test red, then reverted.
+- `.github/workflows/promote.yml`: human-triggered `workflow_dispatch`,
+  inputs `environment`/`action` (promote or rollback)/`owner_full_name`/
+  `version`/`reason`/`allow_override`/`dry_run`. Its job declares
+  `environment: ${{ inputs.environment }}` — the security-critical line that
+  scopes the job to that GitHub Environment's `app-registry-promoter-<env>`
+  secret and triggers its required reviewers, per the credential model below.
+  Not `continue-on-error`, unlike the AR-2c recording steps: a failed
+  promotion must fail the run.
+- `.github/workflows/release.yml`: wired the builder credential (repository
+  secret `APP_REGISTRY_BUILDER_CLIENT_SECRET` + repository variable
+  `APP_REGISTRY_AUTH_TOKEN_URL`) into the two existing AR-2c recording steps
+  so they authenticate once the server runs `oidc` — this closes the gap
+  DEPLOY.md §4 flagged (recording silently going stale because
+  `continue-on-error` masked `Unauthenticated`). `continue-on-error` and the
+  `APP_REGISTRY_CICD_OPT_IN` gate are unchanged.
+- Docs: `cli/README.md` (all commands documented, no longer "not yet
+  implemented"), `ENV.md` (new CI-side variable/secret names and their
+  mapping), `DEPLOY.md` (§4 warning resolved, new §6 for `promote.yml`,
+  promoter clients moved from "⏳ later" to "now").
+- **Static-only, not executed:** `promote.yml` and the `release.yml` auth
+  wiring cannot run without a deployed, `oidc`-mode registry and real
+  Keycloak clients/secrets — neither exists yet outside this session. Both
+  were checked for YAML validity only (`python3 -c "import yaml..."`), not
+  run. `bazel test //tools/app_registry/...` and `bazel build
+  //tools/app_registry/...` are green.
 
 ### AR-2c — merged
 

--- a/tools/app_registry/TOC.md
+++ b/tools/app_registry/TOC.md
@@ -3,16 +3,18 @@
 gRPC service that records published artifacts and tracks per-environment
 promotion state.
 
-**Status: AR-M through AR-2c merged to `main`; AR-3 (Promotion) underway.**
-Recording works end to end — `ReconcileApps`, `RecordBuild`/`RecordArtifact`
-and the chart image lockfile are implemented and verified against real
-Postgres. The release workflow calls the CLI's write path after image/chart
-pushes, gated behind `APP_REGISTRY_CICD_OPT_IN`. The registry is being
-deployed to `dev`. AR-3 is split into a 4-PR stack (auth, environments,
-promotions, CLI). Auth (AR-3a), `EnvironmentRegistry` (AR-3b), and
-`PromotionRegistry` (AR-3c) are done, all verified against real Postgres;
-the CLI's `promote`/`rollback`/`status`/`history`/`diff` commands and the
-human-triggered `promote.yml` workflow (AR-3d) are next.
+**Status: AR-M through AR-2c merged to `main`; AR-3 (Promotion) implemented,
+not yet merged.** Recording works end to end — `ReconcileApps`,
+`RecordBuild`/`RecordArtifact` and the chart image lockfile are implemented
+and verified against real Postgres. The release workflow calls the CLI's
+write path after image/chart pushes, gated behind `APP_REGISTRY_CICD_OPT_IN`.
+The registry is being deployed to `dev`. AR-3 was split into a 4-PR stack
+(auth, environments, promotions, CLI), all now done: auth (AR-3a),
+`EnvironmentRegistry` (AR-3b), and `PromotionRegistry` (AR-3c) are verified
+against real Postgres; AR-3d filled in the CLI's
+`promote`/`rollback`/`status`/`history`/`diff` commands, added
+`.github/workflows/promote.yml` (human-triggered, `environment:`-scoped),
+and wired the builder credential into `release.yml`'s recording steps.
 
 **See [PLAN.md](PLAN.md) → "Current status" for the branch/PR map,
 what is next, and the carry-over items** — start there when picking this up.

--- a/tools/app_registry/cli/BUILD.bazel
+++ b/tools/app_registry/cli/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_binary")
+load("@rules_go//go:def.bzl", "go_binary", "go_library")
 load("//tools/bazel:release.bzl", "release_app")
 
 go_binary(
@@ -17,10 +17,18 @@ go_binary(
 # published for people and CI to pull.
 release_app(
     name = "cli",
-    binary_name = ":app-registry",
-    language = "go",
-    domain = "app-registry",
-    description = "App Registry CLI",
     app_type = "job",
+    binary_name = ":app-registry",
     deploy_unit = "none",
+    description = "App Registry CLI",
+    domain = "app-registry",
+    language = "go",
+)
+
+go_library(
+    name = "cli_lib",
+    srcs = ["main.go"],
+    importpath = "github.com/whale-net/everything/tools/app_registry/cli",
+    visibility = ["//visibility:private"],
+    deps = ["//tools/app_registry/cli/cmd"],
 )

--- a/tools/app_registry/cli/README.md
+++ b/tools/app_registry/cli/README.md
@@ -1,34 +1,38 @@
 # app-registry (CLI)
 
 Thin gRPC client for the App Registry. Skeleton in **AR-1**, commands added
-alongside the RPCs they call in **AR-2** / **AR-3**.
-
-Not yet implemented.
+alongside the RPCs they call in **AR-2** / **AR-3**. All commands below are
+implemented as of **AR-3d**.
 
 ## Thin means thin
 
 **No business logic lives here.** No version math, no promotability rules, no
 promotion-legality checks — those are server-side so a future UI cannot drift
-from the CLI. This file exists mostly to state that constraint.
+from the CLI. The one exception is `diff`, which does real client-side work,
+but only comparison of two already-computed server responses — see below.
 
-The CLI validates argument shape, calls one RPC, and formats the response.
+The CLI validates argument shape, calls one RPC (or two, for `diff`/`history`),
+and formats the response.
 
-## Intended commands
+## Commands
 
 ```
 app-registry apps list [--domain D] [--status S] [--deploy-unit U]
 app-registry apps get <domain-name>
 app-registry apps set-status <domain-name> --status archived --reason "..."
-app-registry apps reconcile --from-plan <file> [--dry-run]     # CI
+app-registry apps reconcile --from-plan <file> --idempotency-key K [--dry-run]     # CI
 
 app-registry artifacts list <domain-name> [--kind image|chart] [--promotable]
 app-registry artifacts get <domain-name> --version vX.Y.Z
 app-registry artifacts resolve <digest|artifact-id>            # chart -> images
-app-registry artifacts record ...                              # CI
+app-registry artifacts record ... --idempotency-key K          # CI
+
+app-registry builds record ... --idempotency-key K             # CI
 
 app-registry promote <domain-name> <version> --env prod --reason "..."
-                     [--allow-override] [--dry-run]
+                     [--allow-override] [--dry-run] [--idempotency-key K]
 app-registry rollback <domain-name> --env prod --reason "..."
+                     [--dry-run] [--idempotency-key K]
 app-registry status <env> [--domain D] [--at <RFC3339>]
 app-registry history <domain-name> [--env E]
 app-registry diff <env-a> <env-b>
@@ -39,6 +43,48 @@ app-registry env list | upsert | archive                       # admin
 `--promotable` on `artifacts list` is the answer to "what can I actually
 promote?" — it filters by the derived promotability described in
 [`../ARCHITECTURE.md`](../ARCHITECTURE.md#promotability).
+
+### `promote` / `rollback`
+
+`--idempotency-key` is optional on both: if omitted, the CLI generates a UUID
+(`promoteIdempotencyKey` in `promote.go`), matching ARCHITECTURE.md
+"Idempotency" — CI derives a key from the workflow run, humans get a
+client-generated one. `promote`'s response carries `already_promoted` when the
+requested artifact is already current in that environment; the CLI prints an
+explicit note to stderr rather than letting that look like a write happened.
+Both commands print a `dry run: no write performed` note to stderr on
+`--dry-run`, for the same reason.
+
+### `status`
+
+Renders `GetEnvironmentState`. Because a drifted environment (a `VIA_CHART`
+image promoted directly with `--allow-override`, now diverged from its
+chart's pin — see ARCHITECTURE.md "Promotability") is the exact failure mode
+this command exists to surface, any `DriftEntry` on the response is printed as
+a prominent stderr banner *in addition to* the JSON body on stdout, which
+still carries the same data under each entry's `drift` field. The stderr
+banner never affects `--format json` piped into a script — machine parsing
+sees only stdout. `--at <RFC3339>` reads historical state via the SCD2
+window; omit it for current state.
+
+### `history`
+
+Calls both `ListPromotions` (`include_history=true`) and
+`ListPromotionEvents` for the given target and prints them together as one
+JSON object (`{"promotions": ..., "events": ...}`) — there is no single RPC
+or response message that returns both, so `printCombinedResponse` formats
+each with `protojson` and combines them.
+
+### `diff`
+
+Calls `GetEnvironmentState` for each of `<env-a>` and `<env-b>` and computes
+the difference client-side (`diffEnvironmentStates` in `promote.go`) — per
+`PLAN.md`'s AR-3d scope note, there is deliberately no server-side diff RPC.
+Entries are matched by promotion target (`image:<app_id>` /
+`chart:<chart_id>`, the only stable identity `GetEnvironmentStateResponse`
+carries); entries whose digest is identical on both sides are omitted, so the
+output reads like a diff rather than a full state dump (that's what `status`
+is for). Each remaining entry is tagged `only_a`, `only_b`, or `different`.
 
 ## Conventions
 

--- a/tools/app_registry/cli/cmd/BUILD.bazel
+++ b/tools/app_registry/cli/cmd/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "cmd",
@@ -19,8 +19,16 @@ go_library(
         "//libs/go/grpcclient",
         "//tools/app_registry/protos:appregistrypb",
         "//tools/appmeta/proto:appmetapb",
+        "@com_github_google_uuid//:uuid",
         "@com_github_spf13_cobra//:cobra",
         "@org_golang_google_protobuf//encoding/protojson",
         "@org_golang_google_protobuf//proto",
     ],
+)
+
+go_test(
+    name = "cmd_test",
+    srcs = ["promote_test.go"],
+    embed = [":cmd"],
+    deps = ["//tools/app_registry/protos:appregistrypb"],
 )

--- a/tools/app_registry/cli/cmd/promote.go
+++ b/tools/app_registry/cli/cmd/promote.go
@@ -2,10 +2,27 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+	"sort"
 
+	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 	pb "github.com/whale-net/everything/tools/app_registry/protos"
+	"google.golang.org/protobuf/proto"
 )
+
+// promoteIdempotencyKey returns key, or a freshly generated UUID when key is
+// empty. ARCHITECTURE.md "Idempotency": CI uses a derived
+// <workflow_run_id>-<attempt>[-...] key; human promotions use a
+// client-generated UUID. `builds record` / `artifacts record` are CI-only
+// and keep --idempotency-key required; promote/rollback are the human path,
+// so they generate one rather than forcing an operator to invent one.
+func promoteIdempotencyKey(key string) string {
+	if key != "" {
+		return key
+	}
+	return uuid.NewString()
+}
 
 func newPromoteCmd() *cobra.Command {
 	var env, reason string
@@ -22,12 +39,22 @@ func newPromoteCmd() *cobra.Command {
 				Reason:         reason,
 				AllowOverride:  allowOverride,
 				DryRun:         dryRun,
-				IdempotencyKey: idempotencyKeyFlag,
+				IdempotencyKey: promoteIdempotencyKey(idempotencyKeyFlag),
 			}
 			return withClient(cmd, func(rc *registryClient) error {
 				resp, err := rc.Promotion.Promote(cmd.Context(), req)
 				if err != nil {
 					return err
+				}
+				// Surface these on stderr, ahead of the JSON body, so neither
+				// gets lost in output a human might skim past -- a dry run or
+				// an already-current no-op must never look like a write that
+				// happened.
+				if resp.GetDryRun() {
+					fmt.Fprintln(os.Stderr, "dry run: no write performed")
+				}
+				if resp.GetAlreadyPromoted() {
+					fmt.Fprintf(os.Stderr, "already promoted: %s is already current in %q; no new promotion recorded\n", args[0], env)
 				}
 				return printResponse(resp)
 			})
@@ -37,9 +64,8 @@ func newPromoteCmd() *cobra.Command {
 	c.Flags().StringVar(&reason, "reason", "", "Required above dev rank; recorded in the audit log")
 	c.Flags().BoolVar(&allowOverride, "allow-override", false, "Acknowledge promoting a VIA_CHART artifact directly")
 	c.Flags().BoolVar(&dryRun, "dry-run", false, "Compute the resulting state without writing")
-	c.Flags().StringVar(&idempotencyKeyFlag, "idempotency-key", "", "Required. Client-generated, makes retries safe")
+	c.Flags().StringVar(&idempotencyKeyFlag, "idempotency-key", "", "Client-generated; a UUID is generated if omitted (see ARCHITECTURE.md 'Idempotency')")
 	_ = c.MarkFlagRequired("env")
-	_ = c.MarkFlagRequired("idempotency-key")
 	return c
 }
 
@@ -57,10 +83,13 @@ func newRollbackCmd() *cobra.Command {
 					OwnerFullName:  args[0],
 					Reason:         reason,
 					DryRun:         dryRun,
-					IdempotencyKey: idempotencyKeyFlag,
+					IdempotencyKey: promoteIdempotencyKey(idempotencyKeyFlag),
 				})
 				if err != nil {
 					return err
+				}
+				if resp.GetDryRun() {
+					fmt.Fprintln(os.Stderr, "dry run: no write performed")
 				}
 				return printResponse(resp)
 			})
@@ -69,9 +98,8 @@ func newRollbackCmd() *cobra.Command {
 	c.Flags().StringVar(&env, "env", "", "Target environment key, e.g. prod")
 	c.Flags().StringVar(&reason, "reason", "", "Required above dev rank; recorded in the audit log")
 	c.Flags().BoolVar(&dryRun, "dry-run", false, "Compute the resulting state without writing")
-	c.Flags().StringVar(&idempotencyKeyFlag, "idempotency-key", "", "Required. Client-generated, makes retries safe")
+	c.Flags().StringVar(&idempotencyKeyFlag, "idempotency-key", "", "Client-generated; a UUID is generated if omitted (see ARCHITECTURE.md 'Idempotency')")
 	_ = c.MarkFlagRequired("env")
-	_ = c.MarkFlagRequired("idempotency-key")
 	return c
 }
 
@@ -99,6 +127,7 @@ func newStatusCmd() *cobra.Command {
 				if err != nil {
 					return err
 				}
+				printDriftWarning(args[0], resp)
 				return printResponse(resp)
 			})
 		},
@@ -108,23 +137,57 @@ func newStatusCmd() *cobra.Command {
 	return c
 }
 
+// printDriftWarning renders every DriftEntry in resp prominently, on stderr,
+// ahead of the JSON body on stdout. This exists because `status` is the
+// command that must never let a drifted environment look clean -- see
+// ARCHITECTURE.md "Promotability": an is_override image promotion that no
+// longer matches its chart's pinned digest is legal but must stay visible.
+// Written to stderr rather than folded into the JSON so `--format json`
+// output piped to a CI parser is unaffected.
+func printDriftWarning(env string, resp *pb.GetEnvironmentStateResponse) {
+	var drift []*pb.DriftEntry
+	for _, e := range resp.GetEntries() {
+		drift = append(drift, e.GetDrift()...)
+	}
+	if len(drift) == 0 {
+		fmt.Fprintf(os.Stderr, "status: no drift detected in %q\n", env)
+		return
+	}
+	fmt.Fprintf(os.Stderr, "\n*** DRIFT DETECTED in %q: %d entr(y/ies) do not match their chart's pinned digest ***\n", env, len(drift))
+	for _, d := range drift {
+		fmt.Fprintf(os.Stderr, "  - %s: chart pins %s, but promotion %s put %s live\n",
+			d.GetAppFullName(), d.GetChartPinnedDigest(), d.GetPromotionId(), d.GetPromotedDigest())
+	}
+	fmt.Fprintln(os.Stderr)
+}
+
 func newHistoryCmd() *cobra.Command {
 	var env string
 	c := &cobra.Command{
 		Use:   "history <domain-name>",
-		Short: "Promotion history for a target",
+		Short: "Promotion history and audit log for a target",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return withClient(cmd, func(rc *registryClient) error {
-				resp, err := rc.Promotion.ListPromotions(cmd.Context(), &pb.ListPromotionsRequest{
+				promotions, err := rc.Promotion.ListPromotions(cmd.Context(), &pb.ListPromotionsRequest{
 					OwnerFullName:  args[0],
 					EnvironmentKey: env,
 					IncludeHistory: true,
 				})
 				if err != nil {
-					return err
+					return fmt.Errorf("listing promotions: %w", err)
 				}
-				return printResponse(resp)
+				events, err := rc.Promotion.ListPromotionEvents(cmd.Context(), &pb.ListPromotionEventsRequest{
+					OwnerFullName:  args[0],
+					EnvironmentKey: env,
+				})
+				if err != nil {
+					return fmt.Errorf("listing promotion events: %w", err)
+				}
+				return printCombinedResponse(map[string]proto.Message{
+					"promotions": promotions,
+					"events":     events,
+				})
 			})
 		},
 	}
@@ -135,7 +198,7 @@ func newHistoryCmd() *cobra.Command {
 func newDiffCmd() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "diff <env-a> <env-b>",
-		Short: "Diff what is running between two environments",
+		Short: "Diff what is currently running between two environments",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return withClient(cmd, func(rc *registryClient) error {
@@ -147,15 +210,130 @@ func newDiffCmd() *cobra.Command {
 				if err != nil {
 					return fmt.Errorf("fetching state for %s: %w", args[1], err)
 				}
-				// AR-1: no diffing logic yet, print both states side by side
-				// via two calls. Real diffing is server-side once
-				// GetEnvironmentState is implemented (AR-3).
-				if err := printResponse(stateA); err != nil {
-					return err
-				}
-				return printResponse(stateB)
+				return printJSON(diffEnvironmentStates(args[0], args[1], stateA, stateB))
 			})
 		},
 	}
 	return c
+}
+
+// environmentDiff is the CLI-computed comparison of two environments'
+// current state. Not a wire type: GetEnvironmentState has no server-side
+// diff RPC by design (AR-3d scope note in PLAN.md -- "compute client-side
+// from two GetEnvironmentState calls; do not add an RPC"), so this struct
+// only ever exists on the CLI side of the wire.
+type environmentDiff struct {
+	EnvironmentA string      `json:"environment_a"`
+	EnvironmentB string      `json:"environment_b"`
+	Entries      []diffEntry `json:"entries"`
+}
+
+// diffEntry describes one promotion target that differs between the two
+// environments compared, or is present in only one of them. Status is one
+// of "only_a", "only_b", "different". Targets with an identical digest on
+// both sides are omitted entirely -- this is meant to read like a diff, not
+// a full state dump (`status` already covers that).
+type diffEntry struct {
+	Target     string `json:"target"`
+	Kind       string `json:"kind"`
+	Repository string `json:"repository"`
+	Status     string `json:"status"`
+	VersionA   string `json:"version_a,omitempty"`
+	DigestA    string `json:"digest_a,omitempty"`
+	VersionB   string `json:"version_b,omitempty"`
+	DigestB    string `json:"digest_b,omitempty"`
+}
+
+// diffEnvironmentStates computes environmentDiff from two
+// GetEnvironmentStateResponse values already fetched by the caller. Pure and
+// side-effect free so it can be unit tested without a server.
+func diffEnvironmentStates(envA, envB string, a, b *pb.GetEnvironmentStateResponse) environmentDiff {
+	aByKey := indexStateEntries(a)
+	bByKey := indexStateEntries(b)
+
+	keys := make(map[string]struct{}, len(aByKey)+len(bByKey))
+	for k := range aByKey {
+		keys[k] = struct{}{}
+	}
+	for k := range bByKey {
+		keys[k] = struct{}{}
+	}
+	sortedKeys := make([]string, 0, len(keys))
+	for k := range keys {
+		sortedKeys = append(sortedKeys, k)
+	}
+	sort.Strings(sortedKeys)
+
+	entries := make([]diffEntry, 0, len(sortedKeys))
+	for _, k := range sortedKeys {
+		ea, inA := aByKey[k]
+		eb, inB := bByKey[k]
+		switch {
+		case inA && !inB:
+			entries = append(entries, diffEntry{
+				Target:     k,
+				Kind:       artifactKindLabel(ea.GetArtifact().GetKind()),
+				Repository: ea.GetArtifact().GetRepository(),
+				Status:     "only_a",
+				VersionA:   ea.GetArtifact().GetVersion(),
+				DigestA:    ea.GetArtifact().GetDigest(),
+			})
+		case inB && !inA:
+			entries = append(entries, diffEntry{
+				Target:     k,
+				Kind:       artifactKindLabel(eb.GetArtifact().GetKind()),
+				Repository: eb.GetArtifact().GetRepository(),
+				Status:     "only_b",
+				VersionB:   eb.GetArtifact().GetVersion(),
+				DigestB:    eb.GetArtifact().GetDigest(),
+			})
+		default:
+			if ea.GetArtifact().GetDigest() != eb.GetArtifact().GetDigest() {
+				entries = append(entries, diffEntry{
+					Target:     k,
+					Kind:       artifactKindLabel(ea.GetArtifact().GetKind()),
+					Repository: ea.GetArtifact().GetRepository(),
+					Status:     "different",
+					VersionA:   ea.GetArtifact().GetVersion(),
+					DigestA:    ea.GetArtifact().GetDigest(),
+					VersionB:   eb.GetArtifact().GetVersion(),
+					DigestB:    eb.GetArtifact().GetDigest(),
+				})
+			}
+		}
+	}
+
+	return environmentDiff{EnvironmentA: envA, EnvironmentB: envB, Entries: entries}
+}
+
+// indexStateEntries keys entries by promotion target: "image:<app_id>" or
+// "chart:<chart_id>". GetEnvironmentStateResponse carries no owner_full_name
+// (unlike repository.TargetKey server-side), so app/chart id is the best
+// available stable identity for matching the same target across two
+// environments.
+func indexStateEntries(resp *pb.GetEnvironmentStateResponse) map[string]*pb.EnvironmentStateEntry {
+	m := make(map[string]*pb.EnvironmentStateEntry, len(resp.GetEntries()))
+	for _, e := range resp.GetEntries() {
+		m[stateEntryTargetKey(e)] = e
+	}
+	return m
+}
+
+func stateEntryTargetKey(e *pb.EnvironmentStateEntry) string {
+	p := e.GetPromotion()
+	if p.GetAppId() != "" {
+		return "image:" + p.GetAppId()
+	}
+	return "chart:" + p.GetChartId()
+}
+
+func artifactKindLabel(k pb.ArtifactKind) string {
+	switch k {
+	case pb.ArtifactKind_ARTIFACT_KIND_IMAGE:
+		return "image"
+	case pb.ArtifactKind_ARTIFACT_KIND_CHART:
+		return "chart"
+	default:
+		return "unknown"
+	}
 }

--- a/tools/app_registry/cli/cmd/promote_test.go
+++ b/tools/app_registry/cli/cmd/promote_test.go
@@ -1,0 +1,167 @@
+package cmd
+
+import (
+	"testing"
+
+	pb "github.com/whale-net/everything/tools/app_registry/protos"
+)
+
+func TestDiffEnvironmentStates_BothEmpty(t *testing.T) {
+	a := &pb.GetEnvironmentStateResponse{}
+	b := &pb.GetEnvironmentStateResponse{}
+
+	d := diffEnvironmentStates("dev", "prod", a, b)
+
+	if d.EnvironmentA != "dev" || d.EnvironmentB != "prod" {
+		t.Fatalf("unexpected environment labels: %+v", d)
+	}
+	if len(d.Entries) != 0 {
+		t.Fatalf("expected no entries for two empty states, got %+v", d.Entries)
+	}
+}
+
+func TestDiffEnvironmentStates_OnlyInA(t *testing.T) {
+	a := &pb.GetEnvironmentStateResponse{
+		Entries: []*pb.EnvironmentStateEntry{
+			{
+				Promotion: &pb.Promotion{AppId: "app-1"},
+				Artifact: &pb.Artifact{
+					Kind:       pb.ArtifactKind_ARTIFACT_KIND_IMAGE,
+					Repository: "ghcr.io/whale-net/demo-app",
+					Version:    "v1.0.0",
+					Digest:     "sha256:aaa",
+				},
+			},
+		},
+	}
+	b := &pb.GetEnvironmentStateResponse{}
+
+	d := diffEnvironmentStates("dev", "prod", a, b)
+
+	if len(d.Entries) != 1 {
+		t.Fatalf("expected exactly one entry, got %+v", d.Entries)
+	}
+	e := d.Entries[0]
+	if e.Status != "only_a" {
+		t.Errorf("status = %q, want only_a", e.Status)
+	}
+	if e.Target != "image:app-1" {
+		t.Errorf("target = %q, want image:app-1", e.Target)
+	}
+	if e.VersionA != "v1.0.0" || e.DigestA != "sha256:aaa" {
+		t.Errorf("unexpected A-side fields: %+v", e)
+	}
+	if e.VersionB != "" || e.DigestB != "" {
+		t.Errorf("expected empty B-side fields, got %+v", e)
+	}
+}
+
+func TestDiffEnvironmentStates_OnlyInB(t *testing.T) {
+	a := &pb.GetEnvironmentStateResponse{}
+	b := &pb.GetEnvironmentStateResponse{
+		Entries: []*pb.EnvironmentStateEntry{
+			{
+				Promotion: &pb.Promotion{ChartId: "chart-1"},
+				Artifact: &pb.Artifact{
+					Kind:       pb.ArtifactKind_ARTIFACT_KIND_CHART,
+					Repository: "https://charts.whalenet.dev/demo-app",
+					Version:    "v2.0.0",
+					Digest:     "sha256:bbb",
+				},
+			},
+		},
+	}
+
+	d := diffEnvironmentStates("dev", "prod", a, b)
+
+	if len(d.Entries) != 1 {
+		t.Fatalf("expected exactly one entry, got %+v", d.Entries)
+	}
+	e := d.Entries[0]
+	if e.Status != "only_b" {
+		t.Errorf("status = %q, want only_b", e.Status)
+	}
+	if e.Target != "chart:chart-1" {
+		t.Errorf("target = %q, want chart:chart-1", e.Target)
+	}
+	if e.Kind != "chart" {
+		t.Errorf("kind = %q, want chart", e.Kind)
+	}
+	if e.VersionB != "v2.0.0" || e.DigestB != "sha256:bbb" {
+		t.Errorf("unexpected B-side fields: %+v", e)
+	}
+	if e.VersionA != "" || e.DigestA != "" {
+		t.Errorf("expected empty A-side fields, got %+v", e)
+	}
+}
+
+func TestDiffEnvironmentStates_DifferentDigest(t *testing.T) {
+	entry := func(digest, version string) *pb.EnvironmentStateEntry {
+		return &pb.EnvironmentStateEntry{
+			Promotion: &pb.Promotion{AppId: "app-1"},
+			Artifact: &pb.Artifact{
+				Kind:       pb.ArtifactKind_ARTIFACT_KIND_IMAGE,
+				Repository: "ghcr.io/whale-net/demo-app",
+				Version:    version,
+				Digest:     digest,
+			},
+		}
+	}
+	a := &pb.GetEnvironmentStateResponse{Entries: []*pb.EnvironmentStateEntry{entry("sha256:aaa", "v1.0.0")}}
+	b := &pb.GetEnvironmentStateResponse{Entries: []*pb.EnvironmentStateEntry{entry("sha256:bbb", "v1.1.0")}}
+
+	d := diffEnvironmentStates("dev", "prod", a, b)
+
+	if len(d.Entries) != 1 {
+		t.Fatalf("expected exactly one entry, got %+v", d.Entries)
+	}
+	e := d.Entries[0]
+	if e.Status != "different" {
+		t.Errorf("status = %q, want different", e.Status)
+	}
+	if e.VersionA != "v1.0.0" || e.VersionB != "v1.1.0" {
+		t.Errorf("unexpected versions: %+v", e)
+	}
+	if e.DigestA != "sha256:aaa" || e.DigestB != "sha256:bbb" {
+		t.Errorf("unexpected digests: %+v", e)
+	}
+}
+
+func TestDiffEnvironmentStates_SameDigestOmitted(t *testing.T) {
+	entry := func() *pb.EnvironmentStateEntry {
+		return &pb.EnvironmentStateEntry{
+			Promotion: &pb.Promotion{AppId: "app-1"},
+			Artifact: &pb.Artifact{
+				Kind:       pb.ArtifactKind_ARTIFACT_KIND_IMAGE,
+				Repository: "ghcr.io/whale-net/demo-app",
+				Version:    "v1.0.0",
+				Digest:     "sha256:aaa",
+			},
+		}
+	}
+	a := &pb.GetEnvironmentStateResponse{Entries: []*pb.EnvironmentStateEntry{entry()}}
+	b := &pb.GetEnvironmentStateResponse{Entries: []*pb.EnvironmentStateEntry{entry()}}
+
+	d := diffEnvironmentStates("dev", "prod", a, b)
+
+	if len(d.Entries) != 0 {
+		t.Fatalf("expected identical entries to be omitted, got %+v", d.Entries)
+	}
+}
+
+func TestPromoteIdempotencyKey_GeneratesWhenEmpty(t *testing.T) {
+	k1 := promoteIdempotencyKey("")
+	k2 := promoteIdempotencyKey("")
+	if k1 == "" || k2 == "" {
+		t.Fatal("expected a non-empty generated key")
+	}
+	if k1 == k2 {
+		t.Fatal("expected distinct generated keys across calls")
+	}
+}
+
+func TestPromoteIdempotencyKey_PreservesProvided(t *testing.T) {
+	if got := promoteIdempotencyKey("explicit-key"); got != "explicit-key" {
+		t.Fatalf("got %q, want explicit-key", got)
+	}
+}

--- a/tools/app_registry/cli/cmd/util.go
+++ b/tools/app_registry/cli/cmd/util.go
@@ -1,8 +1,12 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"time"
+
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 )
 
 // parseRFC3339 parses a --at flag value into a Unix timestamp, the wire
@@ -13,4 +17,47 @@ func parseRFC3339(s string) (int64, error) {
 		return 0, fmt.Errorf("invalid --at %q, want RFC3339 (e.g. 2026-01-15T00:00:00Z): %w", s, err)
 	}
 	return t.Unix(), nil
+}
+
+// printJSON formats a plain Go value (not a proto message) the same way
+// printResponse formats one -- used by CLI-side computations that have no
+// wire type of their own, e.g. `diff`'s client-side comparison (AR-3d:
+// GetEnvironmentState offers no server-side diff RPC, so the CLI computes it
+// from two calls -- see promote.go's diffEnvironmentStates).
+func printJSON(v any) error {
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to format response: %w", err)
+	}
+	if format == "table" {
+		fmt.Println("# table format not implemented yet, showing json")
+	}
+	fmt.Println(string(b))
+	return nil
+}
+
+// printCombinedResponse formats several proto responses as one JSON object,
+// keyed by name. Each part is protojson-formatted individually so enums
+// still print as names (encoding/json alone would print raw ints), then
+// combined -- used by `history`, which calls both ListPromotions and
+// ListPromotionEvents and has no single response message to hand to
+// printResponse.
+func printCombinedResponse(parts map[string]proto.Message) error {
+	raw := make(map[string]json.RawMessage, len(parts))
+	for k, v := range parts {
+		b, err := protojson.MarshalOptions{Multiline: true, Indent: "  "}.Marshal(v)
+		if err != nil {
+			return fmt.Errorf("failed to format response: %w", err)
+		}
+		raw[k] = b
+	}
+	b, err := json.MarshalIndent(raw, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to format response: %w", err)
+	}
+	if format == "table" {
+		fmt.Println("# table format not implemented yet, showing json")
+	}
+	fmt.Println(string(b))
+	return nil
 }

--- a/tools/app_registry/protos/BUILD.bazel
+++ b/tools/app_registry/protos/BUILD.bazel
@@ -9,10 +9,10 @@ go_proto_library(
     compilers = ["@rules_go//proto:go_grpc"],
     importpath = "github.com/whale-net/everything/tools/app_registry/protos",
     proto = ":appregistrypb_proto",
+    visibility = ["//visibility:public"],
     # The manifest schema is owned by //tools/appmeta/proto, not by the
     # registry — release_helper_go and the helm composer consume it too.
     deps = ["//tools/appmeta/proto:appmetapb"],
-    visibility = ["//visibility:public"],
 )
 
 proto_library(
@@ -25,6 +25,6 @@ proto_library(
         "api_messages_promotion.proto",
         "messages.proto",
     ],
-    deps = ["//tools/appmeta/proto:appmetapb_proto"],
     visibility = ["//visibility:public"],
+    deps = ["//tools/appmeta/proto:appmetapb_proto"],
 )

--- a/uv.lock
+++ b/uv.lock
@@ -450,7 +450,6 @@ dependencies = [
     { name = "fastapi" },
     { name = "fastmcp" },
     { name = "google-generativeai" },
-    { name = "grpcio-tools" },
     { name = "gunicorn" },
     { name = "httpx" },
     { name = "opentelemetry-api" },
@@ -458,7 +457,6 @@ dependencies = [
     { name = "opentelemetry-instrumentation-fastapi" },
     { name = "opentelemetry-instrumentation-sqlalchemy" },
     { name = "opentelemetry-sdk" },
-    { name = "protobuf" },
     { name = "psycopg2-binary" },
     { name = "pydantic" },
     { name = "pyserial" },
@@ -490,7 +488,6 @@ requires-dist = [
     { name = "fastapi" },
     { name = "fastmcp" },
     { name = "google-generativeai" },
-    { name = "grpcio-tools" },
     { name = "gunicorn" },
     { name = "httpx" },
     { name = "opentelemetry-api" },
@@ -498,7 +495,6 @@ requires-dist = [
     { name = "opentelemetry-instrumentation-fastapi" },
     { name = "opentelemetry-instrumentation-sqlalchemy" },
     { name = "opentelemetry-sdk" },
-    { name = "protobuf" },
     { name = "psycopg2-binary" },
     { name = "pydantic" },
     { name = "pyserial" },
@@ -836,29 +832,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/fd/d1/b6e9877fedae3add1afdeae1f89d1927d296da9cf977eca0eb08fb8a460e/grpcio_status-1.71.2.tar.gz", hash = "sha256:c7a97e176df71cdc2c179cd1847d7fc86cca5832ad12e9798d7fed6b7a1aab50", size = 13677, upload-time = "2025-06-28T04:24:05.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/67/58/317b0134129b556a93a3b0afe00ee675b5657f0155509e22fcb853bafe2d/grpcio_status-1.71.2-py3-none-any.whl", hash = "sha256:803c98cb6a8b7dc6dbb785b1111aed739f241ab5e9da0bba96888aa74704cfd3", size = 14424, upload-time = "2025-06-28T04:23:42.136Z" },
-]
-
-[[package]]
-name = "grpcio-tools"
-version = "1.71.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "grpcio" },
-    { name = "protobuf" },
-    { name = "setuptools" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ad/9a/edfefb47f11ef6b0f39eea4d8f022c5bb05ac1d14fcc7058e84a51305b73/grpcio_tools-1.71.2.tar.gz", hash = "sha256:b5304d65c7569b21270b568e404a5a843cf027c66552a6a0978b23f137679c09", size = 5330655, upload-time = "2025-06-28T04:22:00.308Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/60/9c/bdf9c5055a1ad0a09123402d73ecad3629f75b9cf97828d547173b328891/grpcio_tools-1.71.2-cp313-cp313-linux_armv7l.whl", hash = "sha256:b0f0a8611614949c906e25c225e3360551b488d10a366c96d89856bcef09f729", size = 2384758, upload-time = "2025-06-28T04:21:26.712Z" },
-    { url = "https://files.pythonhosted.org/packages/49/d0/6aaee4940a8fb8269c13719f56d69c8d39569bee272924086aef81616d4a/grpcio_tools-1.71.2-cp313-cp313-macosx_10_14_universal2.whl", hash = "sha256:7931783ea7ac42ac57f94c5047d00a504f72fbd96118bf7df911bb0e0435fc0f", size = 5443127, upload-time = "2025-06-28T04:21:28.383Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/11/50a471dcf301b89c0ed5ab92c533baced5bd8f796abfd133bbfadf6b60e5/grpcio_tools-1.71.2-cp313-cp313-manylinux_2_17_aarch64.whl", hash = "sha256:d188dc28e069aa96bb48cb11b1338e47ebdf2e2306afa58a8162cc210172d7a8", size = 2349627, upload-time = "2025-06-28T04:21:30.254Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/66/e3dc58362a9c4c2fbe98a7ceb7e252385777ebb2bbc7f42d5ab138d07ace/grpcio_tools-1.71.2-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f36c4b3cc42ad6ef67430639174aaf4a862d236c03c4552c4521501422bfaa26", size = 2742932, upload-time = "2025-06-28T04:21:32.325Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/1e/1e07a07ed8651a2aa9f56095411198385a04a628beba796f36d98a5a03ec/grpcio_tools-1.71.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4bd9ed12ce93b310f0cef304176049d0bc3b9f825e9c8c6a23e35867fed6affd", size = 2473627, upload-time = "2025-06-28T04:21:33.752Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/f9/3b7b32e4acb419f3a0b4d381bc114fe6cd48e3b778e81273fc9e4748caad/grpcio_tools-1.71.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:7ce27e76dd61011182d39abca38bae55d8a277e9b7fe30f6d5466255baccb579", size = 2850879, upload-time = "2025-06-28T04:21:35.241Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/99/cd9e1acd84315ce05ad1fcdfabf73b7df43807cf00c3b781db372d92b899/grpcio_tools-1.71.2-cp313-cp313-musllinux_1_1_i686.whl", hash = "sha256:dcc17bf59b85c3676818f2219deacac0156492f32ca165e048427d2d3e6e1157", size = 3300216, upload-time = "2025-06-28T04:21:36.826Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/c0/66eab57b14550c5b22404dbf60635c9e33efa003bd747211981a9859b94b/grpcio_tools-1.71.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:706360c71bdd722682927a1fb517c276ccb816f1e30cb71f33553e5817dc4031", size = 2913521, upload-time = "2025-06-28T04:21:38.347Z" },
-    { url = "https://files.pythonhosted.org/packages/05/9b/7c90af8f937d77005625d705ab1160bc42a7e7b021ee5c788192763bccd6/grpcio_tools-1.71.2-cp313-cp313-win32.whl", hash = "sha256:bcf751d5a81c918c26adb2d6abcef71035c77d6eb9dd16afaf176ee096e22c1d", size = 945322, upload-time = "2025-06-28T04:21:39.864Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/80/6db6247f767c94fe551761772f89ceea355ff295fd4574cb8efc8b2d1199/grpcio_tools-1.71.2-cp313-cp313-win_amd64.whl", hash = "sha256:b1581a1133552aba96a730178bc44f6f1a071f0eb81c5b6bc4c0f89f5314e2b8", size = 1117234, upload-time = "2025-06-28T04:21:41.893Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Stacked on #509 (AR-3c). Final layer of the AR-3 stack.

## CLI

| Command | Notes |
|---|---|
| `promote <domain-name> <version> --env E` | `--reason`, `--allow-override`, `--dry-run`, `--idempotency-key` (a UUID is generated when omitted, per ARCHITECTURE.md's "human promotions get a client-generated UUID") |
| `rollback <domain-name> --env E` | `--reason`, `--dry-run` |
| `status <env>` | `--domain`, `--at <RFC3339>` for SCD2 historical reads |
| `history <domain-name>` | Calls both `ListPromotions(include_history=true)` and `ListPromotionEvents` |
| `diff <env-a> <env-b>` | Client-side, two `GetEnvironmentState` calls — no new RPC |

Two output decisions worth noting:

- **Drift is printed to stderr *before* the JSON body on stdout.** `status` exists to stop a drifted environment looking clean, so drift must not be something you have to `jq` for — but putting it on stderr keeps `--format json | jq` working unchanged in CI.
- `already_promoted` and `dry_run` get explicit stderr notes, so neither can be mistaken for a write that happened.

`diff` omits identical-digest entries so the output reads as a diff rather than a full dump, and tags the rest `only_a`/`only_b`/`different`.

## `promote.yml`

The job declares `environment: ${{ inputs.environment }}`. That single line **is** the security model: it scopes the job to that GitHub Environment's secrets, so only the matching `app-registry-promoter-<env>` secret is readable, and it triggers that environment's required reviewers. `GRPC_AUTH_CLIENT_ID` is derived as `app-registry-promoter-${{ inputs.environment }}`.

Nothing in the job is `continue-on-error` — unlike the best-effort AR-2c recording steps, a promotion that fails silently while the workflow shows green is the exact failure this system exists to prevent.

**Inputs reach every `run:` block through `env:`, never by direct `${{ inputs.* }}` interpolation.** Direct interpolation splices caller-controlled text into bash before the shell parses it, so a crafted `owner_full_name` or `reason` would execute as code inside a job holding a promoter client secret. A comment in the file says so, because this is easy to reintroduce.

## `release.yml`

Closes the gap DEPLOY.md §4 flagged: the AR-2c recording steps set no `GRPC_AUTH_*`, so the moment the server runs `oidc` they fail `Unauthenticated` — and being `continue-on-error`, the release stays green while recording silently stops. Both steps now pass the builder credential from a **repository** secret (correct placement: it can record but holds no promoter role). `continue-on-error` and the `APP_REGISTRY_CICD_OPT_IN` gate are untouched.

## Verification

`bazel test //tools/app_registry/...` → 5/5 pass. The `diff` guard was verified by deliberately breaking it (`if ea.Digest != eb.Digest` → `if true`), confirming `TestDiffEnvironmentStates_SameDigestOmitted` goes red, then reverting.

**Both workflows are statically checked only — neither has ever run.** They parse as YAML, and that is the whole of the evidence. There is no deployed `oidc`-mode registry, no Keycloak `app-registry-builder`/`app-registry-promoter-*` clients, and no GitHub Environments or secrets to run them against. The CLI's gRPC path (dial, token fetch, RPC round-trip) is likewise unexercised beyond compiling. First real promotion will be the first execution of this code.

## Deferred

`--format table` remains unimplemented across the CLI (pre-existing). Creating the GitHub Environments and secrets is human deployment-time setup, documented in DEPLOY.md.