### PR TITLE
AR-5a: version allocation foundations (inert) + semver addendum

### DIFF
--- a/libs/go/semver/BUILD.bazel
+++ b/libs/go/semver/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "semver",
+    srcs = ["semver.go"],
+    importpath = "github.com/whale-net/everything/libs/go/semver",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "semver_test",
+    size = "small",
+    srcs = ["semver_test.go"],
+    embed = [":semver"],
+)

--- a/libs/go/semver/semver.go
+++ b/libs/go/semver/semver.go
@@ -1,0 +1,130 @@
+// Package semver is the one shared implementation of "vMAJOR.MINOR.PATCH"
+// parsing, incrementing, and numeric comparison used across this repo's
+// release tooling.
+//
+// Before this package existed, tools/release_helper_go/cmd/plan.go had its
+// own regex-plus-strings.Split parser, and tools/app_registry (AR-5) needed
+// the same logic server-side to populate artifact.version_major/minor/patch
+// and to implement AllocateVersion — see tools/app_registry/PLAN.md's AR-5
+// addendum ("semver semantics"). Rather than add a third copy, both consume
+// this package: release_helper_go's incrementVersion is now a thin wrapper,
+// and tools/app_registry/server/repository/postgres imports it directly.
+// This is a plain shared library with no dependency on either caller, which
+// is why it lives in libs/go rather than under tools/release_helper_go or
+// tools/app_registry — the same reasoning ARCHITECTURE.md gives for
+// //tools/appmeta/proto living outside the registry.
+package semver
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// re matches an optional "v" prefix, three dot-separated integer components,
+// and optional prerelease (-foo) / build metadata (+bar) suffixes. Component
+// integers are unbounded-width digit runs; Parse itself doesn't limit magnitude.
+var re = regexp.MustCompile(`^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+([0-9A-Za-z.-]+))?$`)
+
+// Version is a parsed semantic version. Prerelease/Build are populated by
+// Parse but rejected by ParseRelease — see PLAN.md's AR-5 addendum item 3:
+// this repo's release tooling does not support prerelease ordering today,
+// but keeps the field so a caller can detect and reject one explicitly
+// rather than silently mis-sorting it.
+type Version struct {
+	Major, Minor, Patch int
+	Prerelease          string
+	Build               string
+}
+
+// Parse parses s as "[v]MAJOR.MINOR.PATCH[-prerelease][+build]". The "v"
+// prefix is optional on input; String() always emits it.
+func Parse(s string) (Version, error) {
+	m := re.FindStringSubmatch(strings.TrimSpace(s))
+	if m == nil {
+		return Version{}, fmt.Errorf("invalid version %q: expected v<major>.<minor>.<patch>", s)
+	}
+	major, err := strconv.Atoi(m[1])
+	if err != nil {
+		return Version{}, fmt.Errorf("invalid version %q: major component: %w", s, err)
+	}
+	minor, err := strconv.Atoi(m[2])
+	if err != nil {
+		return Version{}, fmt.Errorf("invalid version %q: minor component: %w", s, err)
+	}
+	patch, err := strconv.Atoi(m[3])
+	if err != nil {
+		return Version{}, fmt.Errorf("invalid version %q: patch component: %w", s, err)
+	}
+	return Version{Major: major, Minor: minor, Patch: patch, Prerelease: m[4], Build: m[5]}, nil
+}
+
+// ParseRelease parses like Parse but rejects a prerelease or build-metadata
+// suffix. This is the AllocateVersion contract from PLAN.md's AR-5 addendum
+// item 3: "AllocateVersion rejects a prerelease or build-metadata version
+// explicitly ... rather than half-accepting one and sorting it wrongly."
+func ParseRelease(s string) (Version, error) {
+	v, err := Parse(s)
+	if err != nil {
+		return Version{}, err
+	}
+	if v.Prerelease != "" || v.Build != "" {
+		return Version{}, fmt.Errorf("version %q has a prerelease or build-metadata suffix, which is not supported here", s)
+	}
+	return v, nil
+}
+
+// String renders v as "vMAJOR.MINOR.PATCH", dropping any prerelease/build
+// metadata — matching every version string this repo's tooling actually
+// produces (plan.go, RecordArtifact, AllocateVersion all reject or strip
+// prerelease before this point).
+func (v Version) String() string {
+	return fmt.Sprintf("v%d.%d.%d", v.Major, v.Minor, v.Patch)
+}
+
+// IsRelease reports whether v carries no prerelease or build metadata.
+func (v Version) IsRelease() bool { return v.Prerelease == "" && v.Build == "" }
+
+// Increment returns the result of bumping v by kind ("major", "minor", or
+// "patch"), following standard semver reset rules: a major bump zeros minor
+// and patch, a minor bump zeros patch. Prerelease/build metadata is dropped,
+// matching plan.go's pre-existing behaviour of stripping prerelease before
+// bumping.
+func (v Version) Increment(kind string) (Version, error) {
+	switch kind {
+	case "major":
+		return Version{Major: v.Major + 1}, nil
+	case "minor":
+		return Version{Major: v.Major, Minor: v.Minor + 1}, nil
+	case "patch":
+		return Version{Major: v.Major, Minor: v.Minor, Patch: v.Patch + 1}, nil
+	default:
+		return Version{}, fmt.Errorf("unknown increment type: %s", kind)
+	}
+}
+
+// Compare returns -1, 0, or 1 comparing a and b by MAJOR, then MINOR, then
+// PATCH — numerically, never lexically. This is the load-bearing behaviour
+// PLAN.md's AR-5 addendum item 2 exists to guarantee: lexical TEXT ordering
+// puts "v1.10.0" before "v1.9.0", which is wrong.
+func Compare(a, b Version) int {
+	if a.Major != b.Major {
+		return compareInt(a.Major, b.Major)
+	}
+	if a.Minor != b.Minor {
+		return compareInt(a.Minor, b.Minor)
+	}
+	return compareInt(a.Patch, b.Patch)
+}
+
+func compareInt(a, b int) int {
+	switch {
+	case a < b:
+		return -1
+	case a > b:
+		return 1
+	default:
+		return 0
+	}
+}

--- a/libs/go/semver/semver_test.go
+++ b/libs/go/semver/semver_test.go
@@ -1,0 +1,118 @@
+package semver
+
+import "testing"
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		in                  string
+		major, minor, patch int
+		prerelease, build   string
+	}{
+		{"v1.2.3", 1, 2, 3, "", ""},
+		{"1.2.3", 1, 2, 3, "", ""},
+		{"v0.0.1", 0, 0, 1, "", ""},
+		{"v1.2.3-beta.1", 1, 2, 3, "beta.1", ""},
+		{"v1.2.3+build.5", 1, 2, 3, "", "build.5"},
+		{"v1.2.3-rc.1+build.5", 1, 2, 3, "rc.1", "build.5"},
+	}
+	for _, tt := range tests {
+		v, err := Parse(tt.in)
+		if err != nil {
+			t.Errorf("Parse(%q): unexpected error: %v", tt.in, err)
+			continue
+		}
+		if v.Major != tt.major || v.Minor != tt.minor || v.Patch != tt.patch || v.Prerelease != tt.prerelease || v.Build != tt.build {
+			t.Errorf("Parse(%q) = %+v, want major=%d minor=%d patch=%d prerelease=%q build=%q",
+				tt.in, v, tt.major, tt.minor, tt.patch, tt.prerelease, tt.build)
+		}
+	}
+}
+
+func TestParse_Invalid(t *testing.T) {
+	for _, in := range []string{"", "vX.Y.Z", "1.2", "1.2.3.4", "not-a-version"} {
+		if _, err := Parse(in); err == nil {
+			t.Errorf("Parse(%q): expected an error, got none", in)
+		}
+	}
+}
+
+// TestParseRelease_RejectsPrereleaseAndBuild proves the AllocateVersion
+// contract from PLAN.md's AR-5 addendum item 3: a prerelease or
+// build-metadata suffix must be rejected explicitly, not silently accepted.
+func TestParseRelease_RejectsPrereleaseAndBuild(t *testing.T) {
+	for _, in := range []string{"v1.2.3-alpha", "v1.2.3-alpha.1", "v1.2.3+build.5", "v1.2.3-rc.1+build.5"} {
+		if _, err := ParseRelease(in); err == nil {
+			t.Errorf("ParseRelease(%q): expected rejection of prerelease/build metadata, got none", in)
+		}
+	}
+	// A plain release must still be accepted.
+	if _, err := ParseRelease("v1.2.3"); err != nil {
+		t.Errorf("ParseRelease(%q): unexpected error: %v", "v1.2.3", err)
+	}
+}
+
+func TestVersion_String(t *testing.T) {
+	v := Version{Major: 1, Minor: 2, Patch: 3, Prerelease: "beta"}
+	if got := v.String(); got != "v1.2.3" {
+		t.Errorf("String() = %q, want %q (prerelease must be dropped)", got, "v1.2.3")
+	}
+}
+
+func TestVersion_Increment(t *testing.T) {
+	tests := []struct {
+		in            string
+		incrementType string
+		want          string
+	}{
+		{"v1.2.3", "major", "v2.0.0"},
+		{"v1.2.3", "minor", "v1.3.0"},
+		{"v1.2.3", "patch", "v1.2.4"},
+		{"v0.0.0", "minor", "v0.1.0"},
+		{"v2.5.1", "patch", "v2.5.2"},
+		{"v1.9.9", "major", "v2.0.0"},
+	}
+	for _, tt := range tests {
+		v, err := Parse(tt.in)
+		if err != nil {
+			t.Fatalf("Parse(%q): %v", tt.in, err)
+		}
+		got, err := v.Increment(tt.incrementType)
+		if err != nil {
+			t.Errorf("Increment(%q, %q): %v", tt.in, tt.incrementType, err)
+			continue
+		}
+		if got.String() != tt.want {
+			t.Errorf("Increment(%q, %q) = %q, want %q", tt.in, tt.incrementType, got.String(), tt.want)
+		}
+	}
+}
+
+func TestVersion_Increment_UnknownKind(t *testing.T) {
+	v, _ := Parse("v1.2.3")
+	if _, err := v.Increment("bogus"); err == nil {
+		t.Fatalf("Increment(%q): expected an error for an unknown increment kind, got none", "bogus")
+	}
+}
+
+// TestCompare_NumericNotLexical is the specific bug PLAN.md's AR-5 addendum
+// item 2 exists to prevent: lexical TEXT ordering puts "v1.10.0" before
+// "v1.9.0" because '1' < '9' as characters. Compare must get this right.
+func TestCompare_NumericNotLexical(t *testing.T) {
+	v19, err := Parse("v1.9.0")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	v110, err := Parse("v1.10.0")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if Compare(v19, v110) != -1 {
+		t.Fatalf("Compare(v1.9.0, v1.10.0) = %d, want -1 (v1.9.0 < v1.10.0 numerically)", Compare(v19, v110))
+	}
+	if Compare(v110, v19) != 1 {
+		t.Fatalf("Compare(v1.10.0, v1.9.0) = %d, want 1", Compare(v110, v19))
+	}
+	if Compare(v19, v19) != 0 {
+		t.Fatalf("Compare(v1.9.0, v1.9.0) = %d, want 0", Compare(v19, v19))
+	}
+}

--- a/tools/app_registry/ARCHITECTURE.md
+++ b/tools/app_registry/ARCHITECTURE.md
@@ -64,13 +64,15 @@ erDiagram
 | `chart` | mutable, reconciled | `(domain, name)` unique. |
 | `chart_app` | join | Which apps a chart composes, per its manifest. |
 | `build` | append-only | `(workflow_run_id, workflow_attempt)` unique. |
-| `artifact` | append-only | `digest` globally unique. `(owner, kind, version)` unique. |
+| `artifact` | append-only | `digest` globally unique. `(owner, kind, version)` unique. `version_major/minor/patch` (AR-5a) back numeric ordering — see "Version model" below. |
 | `artifact_link` | append-only | Chart artifact → pinned image artifact. |
 | `environment` | mutable | `key` unique. `rank` orders promotion legality. |
 | `promotion` | **SCD2** | `valid_from` / `valid_to`. Partial unique index on current rows. |
 | `promotion_event` | append-only | Who, why, when, and the Temporal workflow id. |
 | `writeback_outbox` | append-only + claimed | Transactional outbox, drained by the worker. |
 | `idempotency_key` | append-only | Key → prior response, for safe CI retries. |
+| `version_allocation` | append-only | AR-5a. `AllocateVersion`'s reservation ledger — see "Version model" below. |
+| `domain_adoption` | mutable | One row per domain; `stage` ∈ observe/promote/allocate. See "Resolved questions" #3. |
 
 ### SCD2 on `promotion`
 
@@ -106,6 +108,69 @@ two-column target.
 
 A `v_current_promotion` view pre-joins promotion → artifact → app/chart → build
 so the CLI, the writeback worker, and any future UI never re-derive the join.
+
+## Version model (AR-5a)
+
+Full rationale lives in PLAN.md's AR-5 "Addendum — semver semantics
+(decided)" — this section is the as-built summary. **AR-5a ships this
+schema and RPC fully working but wired to nothing**: no domain is at
+adoption stage `allocate`, and `tools/release_helper_go/cmd/plan.go`'s
+git-tag path (`autoIncrementVersion`) is untouched. See "AR-5" in PLAN.md
+for what remains before any domain can be cut over for real.
+
+**Parsing is shared, not duplicated.** `libs/go/semver` is the one semver
+parser/incrementer/comparator this repo's release tooling uses —
+`release_helper_go`'s `incrementVersion` and this package's `AllocateVersion`
+both call it, rather than each keeping its own regex. It lives in `libs/go`
+(not under either caller) for the same reason `//tools/appmeta/proto` lives
+outside the registry: neither side should depend on the other to get parsing
+right.
+
+**Numeric ordering, not lexical.** `artifact.version` is `TEXT`; lexical
+`ORDER BY` on it is wrong — `"v1.9.0" > "v1.10.0"` as strings. Migration 004
+adds `version_major`/`version_minor`/`version_patch` (`INT NOT NULL`,
+populated from the same parse at record/allocate time) plus an index
+ordering by that triple. `UNIQUE (owner_id, kind, version)` stays on the TEXT
+column as the collision guard; the integer columns are for ordering only. A
+version that fails to parse (a real, if rare, historical condition — see
+migration 004's comments) backfills to the `0/0/0` sentinel, which sorts
+before every real release rather than blocking the migration or winning a
+"latest" query it shouldn't.
+
+**`AllocateVersion` writes to `version_allocation`, not `artifact`.**
+`AllocateVersionRequest` carries no digest or build id (allocation happens
+*before* a build exists — see `protos/api_messages_artifact.proto`), and
+`artifact` requires both `NOT NULL`. `version_allocation` is a lightweight
+table with the same `(owner_id, kind, version)` unique-index shape, so a
+transactional `INSERT` against it is what makes concurrent `AllocateVersion`
+calls for the same owner structurally unable to collide — the unique
+constraint does the work, not application-level locking. "Next version" is
+computed as the max across **both** `artifact` (already-published) and
+`version_allocation` (reserved but not yet recorded), so a version reserved
+a moment ago by a concurrent caller is never handed out twice even though
+`RecordArtifact` hasn't run for it yet. A unique-violation aborts the whole
+transaction (see "Idempotency" and the transaction-abort hazard noted
+throughout this doc); the caller (`handlers.ArtifactServer.AllocateVersion`)
+retries in a **fresh** transaction, recomputing "next" against the
+now-committed state.
+
+**Prereleases and build metadata are rejected, not mis-sorted.**
+`AllocateVersion` calls `semver.ParseRelease`, which rejects a
+`-prerelease`/`+build` suffix outright — real semver orders a prerelease
+*before* its release, which nothing here implements, so half-accepting one
+would sort it wrongly. **Extension point:** a later `version_prerelease TEXT`
+column can be added to `artifact` without changing the `(owner_id, kind,
+version)` constraint or the integer triple; the ordering index would gain a
+trailing term. Do not add it speculatively — it lands with the change that
+actually needs prerelease ordering.
+
+**Per-domain cutover gate.** `AllocateVersion` rejects any domain not at
+`domain_adoption.stage = 'allocate'` (see "Resolved questions" #3) with
+`FailedPrecondition`. `domain_adoption` ships from AR-1's migration with a
+row-per-domain-on-cutover shape (no row = implicit `observe`); AR-5a adds no
+mechanism to move a domain to `allocate` — that is deliberately still a
+direct `UPDATE domain_adoption` (or a future admin RPC/CLI command, not yet
+built), so the first real cutover is a reviewable, explicit action.
 
 ## Promotability
 

--- a/tools/app_registry/PLAN.md
+++ b/tools/app_registry/PLAN.md
@@ -33,6 +33,10 @@ AR-4b) is now also fully implemented**, stacked on `ar-4a-temporal` /
 workflow, stub activity) is done; the real gitops/S3 publish is deliberately
 still out of scope (see AR-4b below).
 
+**AR-5a (inert foundations) is also done, not merged** — see "AR-5" below
+for what it delivered and what is deliberately still missing before any
+domain can be cut over.
+
 ### AR-3d — CLI + `promote.yml` — done
 
 - `app-registry promote`/`rollback`/`status`/`history`/`diff` filled in
@@ -590,6 +594,85 @@ it as verified before then.
 
 **Goal:** the registry becomes the version source of truth. Highest risk —
 CI now depends on the registry being up.
+
+### AR-5a — Inert foundations — done, not merged
+
+**Goal:** everything `AllocateVersion` needs, fully implemented and tested,
+with no release able to reach it. See ARCHITECTURE.md's "Version model
+(AR-5a)" for the as-built design.
+
+**Delivered**
+- Migration `005_version_allocation`: `artifact.version_major/minor/patch`
+  (`INT NOT NULL`, backfilled — an unparseable legacy version becomes the
+  documented `0/0/0` sentinel, not a failed deploy) plus
+  `artifact_version_order_idx` for numeric "latest" ordering, and the new
+  `version_allocation` reservation table (own unique index on `(owner_id,
+  kind, version)`, since `AllocateVersionRequest` carries no digest/build_id
+  and `artifact` requires both). `writeback_outbox`'s planned migration
+  number moves from `004` to `005` — see `migrate/README.md`.
+- `libs/go/semver`: the one shared parser/incrementer/comparator. Both
+  `release_helper_go`'s `incrementVersion` (now delegating instead of
+  hand-rolling regex/`strings.Split`) and the registry server consume it —
+  no third copy. `incrementVersion` gained `major`; `plan.go` gained
+  `--increment-major`, purely additive alongside the existing
+  `--increment-minor`/`--increment-patch`.
+- `ArtifactServer.AllocateVersion` fully implemented: validates the request,
+  resolves the owner's domain, checks `domain_adoption.stage == 'allocate'`
+  (`FailedPrecondition` otherwise), then runs a transactional insert into
+  `version_allocation` inside `runIdempotent`'s `WithTx`, retrying in a
+  **fresh** transaction (bounded, 5 attempts) on an auto-increment
+  `ErrAlreadyExists` collision — an `explicit_version` collision is not
+  retried, per the RPC's "fails if taken" contract. Idempotency-key replay
+  sets `already_allocated = true` on the replayed response.
+- `repository.DomainAdoptionRepository.GetStage` (postgres + fake), reading
+  the `domain_adoption` table AR-1's migration already shipped. No write
+  path/RPC exists yet in this change — cutting a domain to `allocate` is a
+  direct `UPDATE domain_adoption` (or a raw INSERT, as the postgres
+  integration tests do) until a real admin path is built.
+- Unit tests (`libs/go/semver`): parse/increment including `major`,
+  rejection of prerelease/build metadata, and the numeric-vs-lexical
+  `Compare` guard directly.
+- Handler tests against the fake (`server/handlers/artifact_test.go`):
+  validation errors, the adoption-stage gate, major/minor/patch increments
+  against a previously recorded artifact, idempotency-key replay, and
+  explicit-version collision.
+- **Real-Postgres integration tests** (mandatory — the fake cannot catch
+  transactional/constraint bugs): `v1.9.0` vs `v1.10.0` ordering (seeded in
+  reverse insertion order — proves the numeric columns, not insertion
+  order, drive "latest"), 8 real concurrent goroutines each opening their
+  own transaction racing to allocate the same owner's next patch (zero
+  collisions, exactly 8 `version_allocation` rows), idempotency-key replay
+  against the real handler, the adoption-stage gate rejecting a domain with
+  no `domain_adoption` row, and migration 004's backfill (a clean version
+  parses correctly, a garbage one backfills to `0/0/0`).
+- **Every guard was deliberately broken and its test confirmed red before
+  reverting**: the ordering index (`ORDER BY version` instead of the
+  integer columns) → `TestAllocateVersion_OrderingIsNumericNotLexical` fails
+  with `previous_version="v1.9.0"` instead of `"v1.10.0"`; the
+  `version_allocation` unique index (made non-unique) →
+  `TestAllocateVersion_ConcurrentCallsNeverCollide` fails with one version
+  allocated 5 times out of 8; the adoption-stage gate (short-circuited with
+  `if false &&`) → both the fake-backed and postgres-backed gate tests fail
+  with `<nil>` instead of `FailedPrecondition`.
+- Docs: this section, ARCHITECTURE.md's "Version model (AR-5a)",
+  `migrate/README.md`'s planned-migrations table.
+
+**Deliberately NOT done — the actual cutover remains AR-5b+**
+- `plan.go`'s `autoIncrementVersion` call site is untouched: the git-tag
+  path is the only one any release can reach, byte-for-byte identical to
+  before this change, for every domain.
+- No domain's `domain_adoption.stage` is set to `allocate` — the table has
+  no rows written by this change at all.
+- No CLI/admin path exists yet to move a domain to `allocate`; that is
+  real, separate scope (probably its own small RPC/CLI surface) before a
+  real cutover can happen without hand-editing the database.
+- Seeding a domain's starting version from its existing tags at cutover
+  time (this section's original scope item) is not implemented — nothing
+  calls it yet, so building it now would be untested and unused.
+- The "allocated versions match tag-scanning" parity check against AR-2 soak
+  data has not been run (the soak itself, gating AR-5's start per this
+  section's own note below, has not happened).
+- The release workflow's version-allocation concurrency group is untouched.
 
 **Scope**
 - Implement `ArtifactRegistry.AllocateVersion` against a unique

--- a/tools/app_registry/PLAN.md
+++ b/tools/app_registry/PLAN.md
@@ -617,6 +617,71 @@ CI now depends on the registry being up.
 **Do not start** until AR-2's parity check has been clean across a meaningful
 number of real releases.
 
+### Addendum — semver semantics (decided)
+
+Added after an audit of the existing version path found three gaps between
+what `tools/release_helper_go` does today and what the registry needs in order
+to *replace* git tags. These are decided; implement them as specified.
+
+Today `plan.go` parses semver with a regex and bumps by splitting on dots, but
+the "which version is latest" question is answered entirely by
+`git tag --sort=-version:refname` — **git supplies the semver ordering, and it
+disappears along with the tags.**
+
+**1. Major bumps become first-class.** `incrementVersion`'s switch handles only
+`minor` and `patch`; `major` returns `unknown increment type`, and `plan.go`
+exposes only `--increment-minor` / `--increment-patch`. Chart bumping
+(`build_helm.go`) already accepts all three, so the two halves of the release
+system disagree. `AllocateVersionRequest.increment` is already documented as
+`"major" | "minor" | "patch"`.
+
+Add `major` to `incrementVersion` and an `--increment-major` flag to `plan.go`,
+so the tag path and the registry path agree. Note the consequence for AR-5's
+parity exit criterion: allocation is now a **superset** of what tag-scanning
+produced, since the tag path could not express a major bump at all. That is
+intentional — parity is asserted for minor/patch, not for a capability that
+did not previously exist.
+
+**2. Versions get a sortable representation. This is the load-bearing change.**
+`artifact.version` is `TEXT` and the only index is
+`UNIQUE (owner_id, kind, version)` — there is no ordering at all. Once tags are
+gone, "what is the next patch?" is a SQL query, and `ORDER BY version DESC` on
+`TEXT` is **wrong**: lexically `v1.9.0` sorts above `v1.10.0`, so the release
+after `v1.10.0` would be computed as `v1.10.0` again — colliding with the
+unique constraint, or silently renumbering.
+
+Store the parsed version alongside the text:
+
+- `version_major`, `version_minor`, `version_patch` — `INT NOT NULL`,
+  populated at record/allocate time from the same parse.
+- Index `(owner_id, kind, version_major DESC, version_minor DESC,
+  version_patch DESC)` so "latest" and "next major/minor/patch" are one
+  indexed lookup with correct ordering.
+- The `UNIQUE (owner_id, kind, version)` constraint stays on the **text** form
+  — it is the collision guard and must keep matching what is published.
+
+A zero-padded sort key was rejected: it caps each component and reads badly in
+`psql`. The integer triple also makes range queries ("every 1.x of this app")
+expressible, which tags cannot answer without a client-side scan.
+
+Existing rows must be backfilled by the migration. A row whose version does not
+parse is a real condition, not a theoretical one (`plan.go` already tolerates
+unparseable tags by falling back to `v0.0.1`) — the migration must decide
+explicitly and say so in a comment rather than failing the deploy.
+
+**3. Prereleases are not supported, but the door is left open.** The regex
+accepts `v1.2.3-alpha.1` and `incrementVersion` strips the prerelease before
+bumping; build metadata (`+build`) is not accepted at all. Real semver also
+sorts a prerelease *before* its release, which nothing here implements.
+
+Patch releases cover the actual need. Therefore: **`AllocateVersion` rejects a
+prerelease or build-metadata version explicitly**, with an error saying it is
+unsupported — rather than half-accepting one and sorting it wrongly. Leave room
+for it: a later `version_prerelease TEXT` column can be added without changing
+the constraint or the integer triple, and the ordering index would gain a
+trailing term. Do not add the column now; do note the extension point in
+`ARCHITECTURE.md`.
+
 ---
 
 ## Explicitly out of scope

--- a/tools/app_registry/migrate/README.md
+++ b/tools/app_registry/migrate/README.md
@@ -33,13 +33,20 @@ ArgoCD sync waves. See `friendly_computing_machine/docs/argocd-integration.md`.
 | `002_environment_registry` | `environment`, seeded with `dev`/`stage`/`prod` |
 | `003_promotion` (AR-3c) | `promotion` (SCD2), `promotion_event`, `v_current_promotion` |
 | `004_writeback_outbox` (AR-4b) | `writeback_outbox` |
+| `005_version_allocation` (AR-5a) | `artifact.version_major/minor/patch` + backfill, `artifact_version_order_idx`, `version_allocation` |
 
 Split this way so AR-2 needs only `001`, AR-3b adds `002`, AR-3c adds `003`,
-and AR-4b adds `004` — each phase ships an independently applicable
-migration. `002` was originally planned to also carry `promotion`, but
-AR-3b's scope is environments only (no promotion logic), so that table moved
-out to its own migration in AR-3c, which needs `environment.environment_id`
-to already exist as an FK target.
+AR-4b adds `004`, and AR-5a adds `005` — each phase ships an independently
+applicable migration. `002` was originally planned to also carry `promotion`,
+but AR-3b's scope is environments only (no promotion logic), so that table
+moved out to its own migration in AR-3c, which needs
+`environment.environment_id` to already exist as an FK target.
+
+AR-4b and AR-5a were developed in parallel and both initially claimed `004`.
+AR-4b is the lower branch in the stack, so it kept `004` and AR-5a renumbered
+to `005`. Migration numbers must be unique: golang-migrate fails on a
+duplicate version at **deploy** time, not build time, so a collision is
+invisible to CI.
 
 ## Required indexes
 
@@ -60,6 +67,16 @@ CREATE UNIQUE INDEX artifact_digest_idx ON artifact (digest);
 
 -- version allocation collision guard (AR-5 depends on this)
 CREATE UNIQUE INDEX artifact_version_idx ON artifact (owner_id, kind, version);
+
+-- numeric ordering for "latest"/"next" -- TEXT ordering on `version` is
+-- lexical and wrong ("v1.10.0" sorts before "v1.9.0"); see the AR-5
+-- addendum in PLAN.md and migration 004's comments.
+CREATE INDEX artifact_version_order_idx
+  ON artifact (owner_id, kind, version_major DESC, version_minor DESC, version_patch DESC);
+
+-- AllocateVersion's reservation ledger -- same collision guard shape as
+-- artifact_version_idx, but on a table that doesn't require a digest/build.
+CREATE UNIQUE INDEX version_allocation_idx ON version_allocation (owner_id, kind, version);
 ```
 
 `domain_adoption` gates the per-domain cutover described in

--- a/tools/app_registry/migrate/schema/migrations/005_version_allocation.down.sql
+++ b/tools/app_registry/migrate/schema/migrations/005_version_allocation.down.sql
@@ -1,0 +1,9 @@
+-- Rollback App Registry Version Allocation schema (AR-5a)
+
+DROP TABLE IF EXISTS version_allocation;
+
+DROP INDEX IF EXISTS artifact_version_order_idx;
+
+ALTER TABLE artifact DROP COLUMN IF EXISTS version_major;
+ALTER TABLE artifact DROP COLUMN IF EXISTS version_minor;
+ALTER TABLE artifact DROP COLUMN IF EXISTS version_patch;

--- a/tools/app_registry/migrate/schema/migrations/005_version_allocation.up.sql
+++ b/tools/app_registry/migrate/schema/migrations/005_version_allocation.up.sql
@@ -1,0 +1,90 @@
+-- App Registry — Version allocation schema (AR-5a)
+--
+-- Ships the schema AllocateVersion needs. See PLAN.md's AR-5 addendum
+-- ("semver semantics") for the full rationale; summarized inline below.
+-- AR-5a wires nothing to this -- no domain_adoption row is set to
+-- 'allocate' by this migration, and plan.go's git-tag path is unchanged.
+-- This is schema plus a server-side RPC implementation only.
+
+-- 1. artifact.version_major/minor/patch: TEXT ordering is lexical, not
+-- numeric -- "v1.9.0" sorts above "v1.10.0" -- so ORDER BY on the existing
+-- `version` column cannot answer "what is the latest / next version"
+-- correctly. Store the parsed integer triple alongside the text so ordering
+-- queries are correct and indexed. UNIQUE (owner_id, kind, version) on the
+-- TEXT column (artifact_version_idx, from migration 001) is UNCHANGED --
+-- it remains the collision guard; these new columns are for ordering only.
+ALTER TABLE artifact ADD COLUMN version_major INTEGER;
+ALTER TABLE artifact ADD COLUMN version_minor INTEGER;
+ALTER TABLE artifact ADD COLUMN version_patch INTEGER;
+
+-- Backfill existing rows by parsing the TEXT version. A row whose version
+-- does not match v<major>.<minor>.<patch> (optionally with a trailing
+-- prerelease/build suffix, which is ignored here the same way
+-- release_helper_go's incrementVersion strips it before bumping) is a real
+-- condition, not a theoretical one -- plan.go's own autoIncrementVersion
+-- falls back to "v0.0.1" for tags it can't parse. This migration's decision:
+-- backfill an unparseable row to 0/0/0 rather than failing the deploy. 0.0.0
+-- sorts before every real release, so an unparseable legacy row can never
+-- win a "latest" ORDER BY ... DESC query, and it stays visible/queryable
+-- (not deleted, not blocking) rather than being silently dropped. As of this
+-- migration no such rows are known to exist in any deployed environment
+-- (every artifact recorded via RecordArtifact already passed its
+-- v<major>.<minor>.<patch> validation), but the columns are NOT NULL below,
+-- so this must be an explicit decision either way.
+UPDATE artifact SET
+    version_major = COALESCE((regexp_match(version, '^v?(\d+)\.(\d+)\.(\d+)'))[1]::INTEGER, 0),
+    version_minor = COALESCE((regexp_match(version, '^v?(\d+)\.(\d+)\.(\d+)'))[2]::INTEGER, 0),
+    version_patch = COALESCE((regexp_match(version, '^v?(\d+)\.(\d+)\.(\d+)'))[3]::INTEGER, 0);
+
+ALTER TABLE artifact ALTER COLUMN version_major SET NOT NULL;
+ALTER TABLE artifact ALTER COLUMN version_minor SET NOT NULL;
+ALTER TABLE artifact ALTER COLUMN version_patch SET NOT NULL;
+-- DEFAULT 0 only guards against some future INSERT that forgets to set
+-- these explicitly; RecordArtifact and AllocateVersion (see
+-- server/repository/postgres/artifact.go) always populate them from the
+-- same parse that produces `version`, never relying on this default.
+ALTER TABLE artifact ALTER COLUMN version_major SET DEFAULT 0;
+ALTER TABLE artifact ALTER COLUMN version_minor SET DEFAULT 0;
+ALTER TABLE artifact ALTER COLUMN version_patch SET DEFAULT 0;
+
+-- Load-bearing, not an optimization (see migrate/README.md "Required
+-- indexes"): "latest" / "next major/minor/patch" is one indexed lookup with
+-- correct numeric ordering. A zero-padded TEXT sort key was rejected (see
+-- PLAN.md's addendum) -- it caps each component's width and reads badly in
+-- psql.
+CREATE INDEX artifact_version_order_idx
+    ON artifact (owner_id, kind, version_major DESC, version_minor DESC, version_patch DESC);
+
+-- 2. version_allocation: the reservation ledger AllocateVersion writes to.
+-- Deliberately NOT the `artifact` table itself: AllocateVersionRequest
+-- carries owner/kind/increment/explicit_version but no digest or build_id
+-- (see protos/api_messages_artifact.proto) -- allocation happens before a
+-- build exists, and `artifact` requires both NOT NULL. version_allocation
+-- is a lightweight table with the same (owner_id, kind, version) collision
+-- shape as artifact, so a transactional INSERT against its unique index is
+-- what makes concurrent AllocateVersion calls for the same owner unable to
+-- collide -- see server/repository/postgres/artifact.go's AllocateVersion
+-- for how "next version" is computed as the max across both this table and
+-- `artifact` (an allocated-but-not-yet-recorded version must not be handed
+-- out twice, and a version already recorded via RecordArtifact must not be
+-- re-allocated).
+CREATE TABLE version_allocation (
+    version_allocation_id  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    owner_id                UUID NOT NULL,
+    kind                    TEXT NOT NULL CHECK (kind IN ('image', 'chart')),
+    version                 TEXT NOT NULL,
+    version_major           INTEGER NOT NULL,
+    version_minor           INTEGER NOT NULL,
+    version_patch           INTEGER NOT NULL,
+    allocated_at            TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX version_allocation_idx ON version_allocation (owner_id, kind, version);
+CREATE INDEX version_allocation_order_idx
+    ON version_allocation (owner_id, kind, version_major DESC, version_minor DESC, version_patch DESC);
+
+-- domain_adoption already exists (migration 001, one row per domain,
+-- default stage 'observe'); AllocateVersion's per-domain gate
+-- (ARCHITECTURE.md "Resolved questions" #3) reads it as-is. No schema
+-- change needed here, and no domain is moved to 'allocate' by this
+-- migration.

--- a/tools/app_registry/server/handlers/BUILD.bazel
+++ b/tools/app_registry/server/handlers/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//libs/go/grpcauth",
+        "//libs/go/semver",
         "//tools/app_registry/protos:appregistrypb",
         "//tools/app_registry/server/auth",
         "//tools/app_registry/server/repository",
@@ -39,6 +40,7 @@ go_test(
         "//libs/go/grpcauth",
         "//tools/app_registry/protos:appregistrypb",
         "//tools/app_registry/server/auth",
+        "//tools/app_registry/server/repository",
         "//tools/app_registry/server/repository/fake",
         "//tools/appmeta/proto:appmetapb",
         "@org_golang_google_grpc//codes",

--- a/tools/app_registry/server/handlers/artifact.go
+++ b/tools/app_registry/server/handlers/artifact.go
@@ -2,10 +2,12 @@ package handlers
 
 import (
 	"context"
+	"errors"
 	"regexp"
 	"strings"
 	"time"
 
+	"github.com/whale-net/everything/libs/go/semver"
 	pb "github.com/whale-net/everything/tools/app_registry/protos"
 	"github.com/whale-net/everything/tools/app_registry/server/auth"
 	"github.com/whale-net/everything/tools/app_registry/server/repository"
@@ -17,8 +19,7 @@ import (
 var semverRe = regexp.MustCompile(`^v\d+\.\d+\.\d+$`)
 
 // ArtifactServer implements pb.ArtifactRegistryServer, backed by
-// repository.Registry. AllocateVersion stays codes.Unimplemented — that's
-// AR-5.
+// repository.Registry.
 type ArtifactServer struct {
 	pb.UnimplementedArtifactRegistryServer
 	repo repository.Registry
@@ -237,6 +238,119 @@ func (s *ArtifactServer) ResolveArtifact(ctx context.Context, req *pb.ResolveArt
 	}, nil
 }
 
+// maxAllocateVersionAttempts bounds the retry loop below. A collision means
+// a concurrent caller's INSERT into version_allocation won the race for the
+// version this attempt computed (see postgres/errors.go's ErrAlreadyExists
+// doc comment) — retrying recomputes "next" against the now-committed
+// state, so it converges quickly under realistic contention; this is a
+// backstop against a pathological hot loop, not an expected steady state.
+const maxAllocateVersionAttempts = 5
+
+// AllocateVersion implements phase AR-5's version allocation RPC. AR-5a
+// ships this fully working and tested but wired to nothing: no
+// domain_adoption row is ever set to 'allocate' by this change, and
+// tools/release_helper_go/cmd/plan.go's git-tag path (autoIncrementVersion)
+// is untouched — see PLAN.md's AR-5 status for what remains before any
+// domain can actually be cut over.
 func (s *ArtifactServer) AllocateVersion(ctx context.Context, req *pb.AllocateVersionRequest) (*pb.AllocateVersionResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "AllocateVersion not implemented")
+	if err := auth.Require(ctx, auth.RoleBuilder); err != nil {
+		return nil, err
+	}
+	kind := artifactKindFromPB(req.Kind)
+	if kind == "" {
+		return nil, status.Error(codes.InvalidArgument, "kind is required")
+	}
+	if req.OwnerFullName == "" {
+		return nil, status.Error(codes.InvalidArgument, "owner_full_name is required")
+	}
+	if req.IdempotencyKey == "" {
+		return nil, status.Error(codes.InvalidArgument, "idempotency_key is required")
+	}
+	if req.ExplicitVersion != "" {
+		// AR-5 addendum item 3: reject a prerelease or build-metadata
+		// version explicitly, rather than half-accepting one and sorting it
+		// wrongly (see libs/go/semver.ParseRelease).
+		if _, err := semver.ParseRelease(req.ExplicitVersion); err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "explicit_version: %v", err)
+		}
+	} else if req.Increment != "major" && req.Increment != "minor" && req.Increment != "patch" {
+		return nil, status.Errorf(codes.InvalidArgument, `increment must be "major", "minor", or "patch" (got %q); or set explicit_version`, req.Increment)
+	}
+
+	domain, ownerID, err := s.resolveOwnerAndDomain(ctx, kind, req.OwnerFullName)
+	if err != nil {
+		return nil, err
+	}
+
+	// Per-domain adoption gate — ARCHITECTURE.md "Resolved questions" #3 and
+	// PLAN.md's AR-5 scope: AllocateVersion serves only domains explicitly
+	// cut over to stage "allocate", so a misconfigured caller fails loudly
+	// rather than silently allocating from the wrong source of truth. No
+	// domain is at "allocate" as of AR-5a.
+	stage, err := s.repo.DomainAdoption().GetStage(ctx, domain)
+	if err != nil {
+		return nil, mapRepoErr(err)
+	}
+	if stage != repository.DomainAdoptionStageAllocate {
+		return nil, status.Errorf(codes.FailedPrecondition,
+			"domain %q is at adoption stage %q; AllocateVersion only serves domains at stage \"allocate\"", domain, stage)
+	}
+
+	var resp *pb.AllocateVersionResponse
+	var replayed bool
+	for attempt := 0; attempt < maxAllocateVersionAttempts; attempt++ {
+		out, wasReplayed, ferr := runIdempotent(ctx, s.repo, req.IdempotencyKey, "AllocateVersion",
+			func() proto.Message { return &pb.AllocateVersionResponse{} },
+			func(ctx context.Context, r repository.Registry) (proto.Message, error) {
+				alloc, aerr := r.Artifacts().AllocateVersion(ctx, kind, ownerID, req.Increment, req.ExplicitVersion)
+				if aerr != nil {
+					return nil, aerr
+				}
+				return &pb.AllocateVersionResponse{Version: alloc.Version, PreviousVersion: alloc.PreviousVersion}, nil
+			},
+		)
+		if ferr == nil {
+			resp = out.(*pb.AllocateVersionResponse)
+			replayed = wasReplayed
+			err = nil
+			break
+		}
+		err = ferr
+		// An explicit_version collision is a real "fails if taken" per
+		// api_messages_artifact.proto's doc comment — not a race worth
+		// retrying. Only an auto-increment collision (someone else's
+		// concurrent allocation took the version THIS attempt computed) is
+		// retried, in a fresh transaction — the aborted one carries no
+		// partial state to resume from (see postgres/errors.go).
+		if req.ExplicitVersion == "" && errors.Is(ferr, repository.ErrAlreadyExists) {
+			continue
+		}
+		break
+	}
+	if err != nil {
+		return nil, mapRepoErr(err)
+	}
+	if replayed {
+		resp.AlreadyAllocated = true
+	}
+	return resp, nil
+}
+
+// resolveOwnerAndDomain resolves owner_full_name to its owning row's id and
+// domain, for AllocateVersion's storage key and adoption-stage gate
+// respectively. Mirrors resolveOwner but also needs Domain, which
+// resolveOwner's callers (RecordArtifact) don't.
+func (s *ArtifactServer) resolveOwnerAndDomain(ctx context.Context, kind repository.ArtifactKind, ownerFullName string) (domain, ownerID string, err error) {
+	if kind == repository.ArtifactKindImage {
+		app, aerr := s.repo.Apps().GetAppByFullName(ctx, ownerFullName)
+		if aerr != nil {
+			return "", "", status.Errorf(codes.InvalidArgument, "unknown app %q", ownerFullName)
+		}
+		return app.Domain, app.AppID, nil
+	}
+	chart, cerr := s.repo.Apps().GetChartByFullName(ctx, ownerFullName)
+	if cerr != nil {
+		return "", "", status.Errorf(codes.InvalidArgument, "unknown chart %q", ownerFullName)
+	}
+	return chart.Domain, chart.ChartID, nil
 }

--- a/tools/app_registry/server/handlers/artifact_test.go
+++ b/tools/app_registry/server/handlers/artifact_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	pb "github.com/whale-net/everything/tools/app_registry/protos"
+	"github.com/whale-net/everything/tools/app_registry/server/repository"
 	"github.com/whale-net/everything/tools/app_registry/server/repository/fake"
 	appmetapb "github.com/whale-net/everything/tools/appmeta/proto"
 	"google.golang.org/grpc/codes"
@@ -284,10 +285,198 @@ func TestRecordArtifact_RejectsMissingIdempotencyKey(t *testing.T) {
 	}
 }
 
-func TestArtifactServer_AllocateVersionStillUnimplemented(t *testing.T) {
-	_, artifactSrv, _ := setup(t)
-	_, err := artifactSrv.AllocateVersion(authedCtx(), &pb.AllocateVersionRequest{})
-	if status.Code(err) != codes.Unimplemented {
-		t.Fatalf("expected Unimplemented, got %v", err)
+// setupAllocate builds its own fake registry (rather than reusing setup(t))
+// because AllocateVersion tests need direct access to the fake so they can
+// set a domain's adoption stage via fake.Registry.SetDomainAdoptionStage —
+// there is no RPC to do that in this change (see PLAN.md's AR-5 status).
+func setupAllocate(t *testing.T) (*fake.Registry, *ArtifactServer) {
+	t.Helper()
+	repo := fake.New()
+	appSrv := NewAppServer(repo)
+	artifactSrv := NewArtifactServer(repo)
+	ctx := authedCtx()
+
+	if _, err := appSrv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
+		Manifests: manifestSet([]*appmetapb.AppManifest{
+			{Domain: "demo", Name: "image-app", DeployUnit: appmetapb.DeployUnit_DEPLOY_UNIT_IMAGE},
+		}, nil),
+		IdempotencyKey: "setup-allocate-1",
+	}); err != nil {
+		t.Fatalf("setupAllocate reconcile: %v", err)
+	}
+	return repo, artifactSrv
+}
+
+// TestAllocateVersion_ValidationErrors covers the request-shape checks that
+// run before the adoption-stage gate or any repository call.
+func TestAllocateVersion_ValidationErrors(t *testing.T) {
+	_, artifactSrv := setupAllocate(t)
+	ctx := authedCtx()
+
+	cases := []struct {
+		name string
+		req  *pb.AllocateVersionRequest
+	}{
+		{"missing kind", &pb.AllocateVersionRequest{OwnerFullName: "demo-image-app", Increment: "patch", IdempotencyKey: "k"}},
+		{"missing owner", &pb.AllocateVersionRequest{Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE, Increment: "patch", IdempotencyKey: "k"}},
+		{"missing idempotency key", &pb.AllocateVersionRequest{Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE, OwnerFullName: "demo-image-app", Increment: "patch"}},
+		{"bad increment", &pb.AllocateVersionRequest{Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE, OwnerFullName: "demo-image-app", Increment: "bogus", IdempotencyKey: "k"}},
+		{"prerelease explicit_version", &pb.AllocateVersionRequest{Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE, OwnerFullName: "demo-image-app", ExplicitVersion: "v1.2.3-alpha", IdempotencyKey: "k"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := artifactSrv.AllocateVersion(ctx, tc.req)
+			if status.Code(err) != codes.InvalidArgument {
+				t.Fatalf("expected InvalidArgument, got %v", err)
+			}
+		})
+	}
+}
+
+// TestAllocateVersion_AdoptionStageGate proves the per-domain cutover gate:
+// a domain that has never been set to "allocate" (every domain, as of
+// AR-5a — see PLAN.md's AR-5 status) is rejected with FailedPrecondition,
+// and only after the fixture explicitly cuts "demo" over does the same
+// request succeed. This is the mechanism a future phase would use to cut a
+// real domain over — see fake.Registry.SetDomainAdoptionStage's doc comment
+// and postgres_integration_test.go's version of this same proof against a
+// real domain_adoption row.
+func TestAllocateVersion_AdoptionStageGate(t *testing.T) {
+	repo, artifactSrv := setupAllocate(t)
+	ctx := authedCtx()
+
+	req := &pb.AllocateVersionRequest{
+		Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE, OwnerFullName: "demo-image-app",
+		Increment: "patch", IdempotencyKey: "gate-1",
+	}
+	_, err := artifactSrv.AllocateVersion(ctx, req)
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("expected FailedPrecondition for a domain not at stage 'allocate', got %v", err)
+	}
+
+	repo.SetDomainAdoptionStage("demo", repository.DomainAdoptionStageAllocate)
+	resp, err := artifactSrv.AllocateVersion(ctx, req)
+	if err != nil {
+		t.Fatalf("expected success once 'demo' is cut over to 'allocate', got %v", err)
+	}
+	if resp.Version != "v0.0.1" {
+		t.Fatalf("expected first patch allocation to be v0.0.1, got %q", resp.Version)
+	}
+}
+
+// TestAllocateVersion_IncrementsFromLatestRecordedArtifact proves
+// AllocateVersion accounts for artifacts already recorded via
+// RecordArtifact, not just prior allocations, and that major/minor/patch
+// all behave as PLAN.md's AR-5 addendum item 1 specifies.
+func TestAllocateVersion_IncrementsFromLatestRecordedArtifact(t *testing.T) {
+	cases := []struct {
+		increment string
+		want      string
+	}{
+		{"patch", "v1.2.4"},
+		{"minor", "v1.3.0"},
+		{"major", "v2.0.0"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.increment, func(t *testing.T) {
+			// A fresh registry per case: each must increment from the SAME
+			// seeded v1.2.3, not from a previous subtest's allocation.
+			repo, artifactSrv := setupAllocate(t)
+			ctx := authedCtx()
+			repo.SetDomainAdoptionStage("demo", repository.DomainAdoptionStageAllocate)
+
+			build := recordBuild(t, artifactSrv, "run-allocate-seed-"+tc.increment)
+			if _, err := artifactSrv.RecordArtifact(ctx, &pb.RecordArtifactRequest{
+				BuildId: build.BuildId, Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE,
+				OwnerFullName: "demo-image-app", Digest: "sha256:seed-" + tc.increment, Version: "v1.2.3",
+				IdempotencyKey: "seed-artifact-" + tc.increment,
+			}); err != nil {
+				t.Fatalf("seed RecordArtifact: %v", err)
+			}
+
+			resp, err := artifactSrv.AllocateVersion(ctx, &pb.AllocateVersionRequest{
+				Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE, OwnerFullName: "demo-image-app",
+				Increment: tc.increment, IdempotencyKey: "alloc-" + tc.increment,
+			})
+			if err != nil {
+				t.Fatalf("AllocateVersion(%s): %v", tc.increment, err)
+			}
+			if resp.Version != tc.want {
+				t.Fatalf("AllocateVersion(%s) = %q, want %q", tc.increment, resp.Version, tc.want)
+			}
+			if resp.PreviousVersion != "v1.2.3" {
+				t.Fatalf("AllocateVersion(%s): expected previous_version v1.2.3, got %q", tc.increment, resp.PreviousVersion)
+			}
+		})
+	}
+}
+
+// TestAllocateVersion_IdempotencyKeyReplay proves a repeated call with the
+// same idempotency_key returns the SAME version with already_allocated set,
+// rather than allocating a second version — the AllocateVersion analogue of
+// TestRecordBuild_IdempotencyKeyReplay_DoesNotDoubleWrite.
+func TestAllocateVersion_IdempotencyKeyReplay(t *testing.T) {
+	repo, artifactSrv := setupAllocate(t)
+	ctx := authedCtx()
+	repo.SetDomainAdoptionStage("demo", repository.DomainAdoptionStageAllocate)
+
+	req := &pb.AllocateVersionRequest{
+		Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE, OwnerFullName: "demo-image-app",
+		Increment: "patch", IdempotencyKey: "replay-key",
+	}
+	first, err := artifactSrv.AllocateVersion(ctx, req)
+	if err != nil {
+		t.Fatalf("first AllocateVersion: %v", err)
+	}
+	if first.AlreadyAllocated {
+		t.Fatalf("expected already_allocated=false on the first call")
+	}
+
+	second, err := artifactSrv.AllocateVersion(ctx, req)
+	if err != nil {
+		t.Fatalf("replayed AllocateVersion: %v", err)
+	}
+	if second.Version != first.Version {
+		t.Fatalf("replay allocated a different version: first=%q second=%q", first.Version, second.Version)
+	}
+	if !second.AlreadyAllocated {
+		t.Fatalf("expected already_allocated=true on the replayed call")
+	}
+
+	// A DIFFERENT idempotency key must allocate a genuinely new version.
+	third, err := artifactSrv.AllocateVersion(ctx, &pb.AllocateVersionRequest{
+		Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE, OwnerFullName: "demo-image-app",
+		Increment: "patch", IdempotencyKey: "different-key",
+	})
+	if err != nil {
+		t.Fatalf("third AllocateVersion: %v", err)
+	}
+	if third.Version == first.Version {
+		t.Fatalf("expected a fresh idempotency key to allocate a NEW version, got the same one: %q", third.Version)
+	}
+}
+
+// TestAllocateVersion_ExplicitVersionCollisionFails proves the "fails if
+// taken" contract for explicit_version from
+// api_messages_artifact.proto's AllocateVersionRequest doc comment.
+func TestAllocateVersion_ExplicitVersionCollisionFails(t *testing.T) {
+	repo, artifactSrv := setupAllocate(t)
+	ctx := authedCtx()
+	repo.SetDomainAdoptionStage("demo", repository.DomainAdoptionStageAllocate)
+
+	req := &pb.AllocateVersionRequest{
+		Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE, OwnerFullName: "demo-image-app",
+		ExplicitVersion: "v5.0.0", IdempotencyKey: "explicit-1",
+	}
+	if _, err := artifactSrv.AllocateVersion(ctx, req); err != nil {
+		t.Fatalf("first explicit allocation: %v", err)
+	}
+
+	_, err := artifactSrv.AllocateVersion(ctx, &pb.AllocateVersionRequest{
+		Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE, OwnerFullName: "demo-image-app",
+		ExplicitVersion: "v5.0.0", IdempotencyKey: "explicit-2",
+	})
+	if status.Code(err) != codes.AlreadyExists {
+		t.Fatalf("expected AlreadyExists for a taken explicit_version, got %v", err)
 	}
 }

--- a/tools/app_registry/server/main_test.go
+++ b/tools/app_registry/server/main_test.go
@@ -141,10 +141,28 @@ func TestRegisterServices_AllFourServicesReachable(t *testing.T) {
 		}
 	})
 
-	t.Run("ArtifactRegistry_AllocateVersion_StillUnimplemented", func(t *testing.T) {
+	// AllocateVersion is real as of AR-5a (see PLAN.md's AR-5 status), but
+	// still unreachable in production: every domain defaults to adoption
+	// stage "observe" (no domain_adoption row), so an empty request reaches
+	// the real handler and fails validation ("kind is required") rather
+	// than codes.Unimplemented's "unknown service"/"not implemented" —
+	// still enough to prove pb.RegisterArtifactRegistryServer wasn't
+	// dropped, which is this whole test's job. See handlers/artifact_test.go
+	// for AllocateVersion's actual business-logic coverage (gate, retry,
+	// idempotency replay).
+	t.Run("ArtifactRegistry_AllocateVersion_ReachesRealHandler", func(t *testing.T) {
 		client := pb.NewArtifactRegistryClient(conn)
 		_, err := client.AllocateVersion(ctx, &pb.AllocateVersionRequest{})
-		assertUnimplementedFromHandler(t, "ArtifactRegistry.AllocateVersion", "AllocateVersion not implemented", err)
+		st, ok := status.FromError(err)
+		if !ok {
+			t.Fatalf("ArtifactRegistry.AllocateVersion: expected a gRPC status error, got %v", err)
+		}
+		if st.Code() != codes.InvalidArgument {
+			t.Fatalf("ArtifactRegistry.AllocateVersion: expected codes.InvalidArgument, got %v (%v)", st.Code(), err)
+		}
+		if strings.Contains(st.Message(), "unknown service") || strings.Contains(st.Message(), "unknown method") {
+			t.Fatalf("ArtifactRegistry.AllocateVersion: got grpc's own %q — the service was never registered", st.Message())
+		}
 	})
 
 	t.Run("PromotionRegistry", func(t *testing.T) {

--- a/tools/app_registry/server/repository/fake/BUILD.bazel
+++ b/tools/app_registry/server/repository/fake/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     importpath = "github.com/whale-net/everything/tools/app_registry/server/repository/fake",
     visibility = ["//visibility:public"],
     deps = [
+        "//libs/go/semver",
         "//tools/app_registry/server/repository",
         "//tools/appmeta/proto:appmetapb",
         "@com_github_google_uuid//:uuid",

--- a/tools/app_registry/server/repository/fake/fake.go
+++ b/tools/app_registry/server/repository/fake/fake.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/whale-net/everything/libs/go/semver"
 	"github.com/whale-net/everything/tools/app_registry/server/repository"
 	appmetapb "github.com/whale-net/everything/tools/appmeta/proto"
 )
@@ -45,19 +46,31 @@ type state struct {
 	Promotions      map[string]repository.Promotion       // keyed by promotion_id
 	PromotionEvents map[string]repository.PromotionEvent  // keyed by event_id
 	WritebackOutbox map[string]repository.WritebackOutbox // keyed by outbox_id
+	// VersionAllocations mirrors postgres's version_allocation table: the
+	// reservation ledger AllocateVersion writes to, keyed by
+	// "<owner_id>/<kind>/<version>" -- see
+	// repository/postgres/artifact.go's AllocateVersion doc comment for why
+	// this isn't just the Artifacts map.
+	VersionAllocations map[string]repository.VersionAllocation
+	// DomainAdoption mirrors the `domain_adoption` table, keyed by domain.
+	// Absent means DomainAdoptionStageObserve -- see
+	// DomainAdoptionRepository.GetStage's doc comment.
+	DomainAdoption map[string]repository.DomainAdoptionStage
 }
 
 func newState() *state {
 	return &state{
-		Apps:            map[string]repository.App{},
-		Charts:          map[string]repository.Chart{},
-		Builds:          map[string]repository.Build{},
-		Artifacts:       map[string]repository.Artifact{},
-		Idempotency:     map[string]idemEntry{},
-		Environments:    map[string]repository.Environment{},
-		Promotions:      map[string]repository.Promotion{},
-		PromotionEvents: map[string]repository.PromotionEvent{},
-		WritebackOutbox: map[string]repository.WritebackOutbox{},
+		Apps:               map[string]repository.App{},
+		Charts:             map[string]repository.Chart{},
+		Builds:             map[string]repository.Build{},
+		Artifacts:          map[string]repository.Artifact{},
+		Idempotency:        map[string]idemEntry{},
+		Environments:       map[string]repository.Environment{},
+		Promotions:         map[string]repository.Promotion{},
+		PromotionEvents:    map[string]repository.PromotionEvent{},
+		WritebackOutbox:    map[string]repository.WritebackOutbox{},
+		VersionAllocations: map[string]repository.VersionAllocation{},
+		DomainAdoption:     map[string]repository.DomainAdoptionStage{},
 	}
 }
 
@@ -86,6 +99,18 @@ func New() *Registry {
 	return &Registry{mu: &sync.Mutex{}, state: newState()}
 }
 
+// SetDomainAdoptionStage is a test-only fixture setter: there is no RPC to
+// cut a domain over to a new adoption stage in this change (see PLAN.md's
+// AR-5 status — AR-5a ships the gate but no cutover mechanism), so handler
+// tests that need to exercise the "allocate" path reach in here directly,
+// the same way postgres integration tests do via a raw
+// `INSERT INTO domain_adoption` (see postgres_integration_test.go).
+func (r *Registry) SetDomainAdoptionStage(domain string, stage repository.DomainAdoptionStage) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.state.DomainAdoption[domain] = stage
+}
+
 func (r *Registry) Apps() repository.AppRepository                { return r }
 func (r *Registry) Builds() repository.BuildRepository            { return r }
 func (r *Registry) Artifacts() repository.ArtifactRepository      { return r }
@@ -103,6 +128,10 @@ func (r *Registry) Promotions() repository.PromotionRepository { return promotio
 
 // Writeback returns a distinct type for the same reason Environments does.
 func (r *Registry) Writeback() repository.WritebackRepository { return writebackFake{r} }
+
+// DomainAdoption returns a distinct type for the same reason Environments
+// does.
+func (r *Registry) DomainAdoption() repository.DomainAdoptionRepository { return domainAdoptionFake{r} }
 
 // WithTx snapshots state, runs fn against a Registry sharing that snapshot,
 // and commits the snapshot back only if fn succeeds — giving the fake the
@@ -332,6 +361,83 @@ func ownerID(a repository.Artifact) string {
 		return a.AppID
 	}
 	return a.ChartID
+}
+
+// syntheticOwnerArtifact builds a zero artifact carrying just enough (Kind +
+// owner id in the right field + Version) to reuse ownerID()/
+// findByOwnerKindVersion()'s existing owner-matching logic — AllocateVersion
+// only ever has an ownerID, not a full Artifact, to look up with.
+func syntheticOwnerArtifact(kind repository.ArtifactKind, ownerID, version string) repository.Artifact {
+	a := repository.Artifact{Kind: kind, Version: version}
+	if kind == repository.ArtifactKindImage {
+		a.AppID = ownerID
+	} else {
+		a.ChartID = ownerID
+	}
+	return a
+}
+
+// AllocateVersion mirrors postgres's artifactRepo.AllocateVersion: "next" is
+// computed from the highest version already claimed for (ownerID, kind)
+// across both real artifacts and prior allocations, so an
+// allocated-but-not-yet-recorded version is never handed out twice.
+func (r *Registry) AllocateVersion(ctx context.Context, kind repository.ArtifactKind, owner, increment, explicitVersion string) (*repository.VersionAllocation, error) {
+	var hasPrevious bool
+	var previous semver.Version
+	var previousText string
+	consider := func(text string) {
+		v, err := semver.Parse(text)
+		if err != nil {
+			return
+		}
+		if !hasPrevious || semver.Compare(v, previous) > 0 {
+			hasPrevious = true
+			previous = v
+			previousText = text
+		}
+	}
+	for _, a := range r.state.Artifacts {
+		if a.Kind == kind && owner == ownerID(a) {
+			consider(a.Version)
+		}
+	}
+	prefix := owner + "/" + string(kind) + "/"
+	for key, alloc := range r.state.VersionAllocations {
+		if len(key) >= len(prefix) && key[:len(prefix)] == prefix {
+			consider(alloc.Version)
+		}
+	}
+
+	var next semver.Version
+	if explicitVersion != "" {
+		v, err := semver.ParseRelease(explicitVersion)
+		if err != nil {
+			return nil, fmt.Errorf("%w: %v", repository.ErrInvalidArgument, err)
+		}
+		next = v
+	} else {
+		base := semver.Version{}
+		if hasPrevious {
+			base = previous
+		}
+		v, err := base.Increment(increment)
+		if err != nil {
+			return nil, fmt.Errorf("%w: %v", repository.ErrInvalidArgument, err)
+		}
+		next = v
+	}
+
+	versionStr := next.String()
+	key := prefix + versionStr
+	if _, exists := r.state.VersionAllocations[key]; exists {
+		return nil, fmt.Errorf("%w: version %s is already allocated or recorded for this owner", repository.ErrAlreadyExists, versionStr)
+	}
+	if _, found := r.findByOwnerKindVersion(syntheticOwnerArtifact(kind, owner, versionStr)); found {
+		return nil, fmt.Errorf("%w: version %s is already allocated or recorded for this owner", repository.ErrAlreadyExists, versionStr)
+	}
+
+	r.state.VersionAllocations[key] = repository.VersionAllocation{Version: versionStr, PreviousVersion: previousText}
+	return &repository.VersionAllocation{Version: versionStr, PreviousVersion: previousText}, nil
 }
 
 func (r *Registry) findImageByDigest(digest string) (*repository.Artifact, error) {
@@ -806,6 +912,27 @@ func sortPromotions(promotions []repository.Promotion) {
 // timeNow is a thin indirection so a future test could freeze it; today it's
 // just time.Now().UTC(), matching every other fake's timestamp handling.
 func timeNow() time.Time { return time.Now().UTC() }
+
+// ============================================================================
+// DomainAdoptionRepository
+// ============================================================================
+
+// domainAdoptionFake implements repository.DomainAdoptionRepository over
+// the same *Registry.state every other repository reads/writes -- see
+// Environments's doc comment for why this can't be a method directly on
+// Registry.
+type domainAdoptionFake struct{ r *Registry }
+
+// GetStage mirrors postgres's domainAdoptionRepo.GetStage: an absent row
+// (the default for every domain in a fresh fake, matching production where
+// domain_adoption seeds no rows automatically) means
+// DomainAdoptionStageObserve.
+func (f domainAdoptionFake) GetStage(ctx context.Context, domain string) (repository.DomainAdoptionStage, error) {
+	if stage, ok := f.r.state.DomainAdoption[domain]; ok {
+		return stage, nil
+	}
+	return repository.DomainAdoptionStageObserve, nil
+}
 
 // ============================================================================
 // helpers shared with reconcile.go

--- a/tools/app_registry/server/repository/models.go
+++ b/tools/app_registry/server/repository/models.go
@@ -327,3 +327,23 @@ type WritebackOutbox struct {
 
 	CreatedAt time.Time
 }
+
+// DomainAdoptionStage mirrors the `domain_adoption.stage` CHECK constraint
+// (migration 001) and ARCHITECTURE.md "Resolved questions" #3's per-domain
+// cutover table. AllocateVersion (AR-5) is the only capability gated on
+// this today; recording (AR-2) is deliberately never gated.
+type DomainAdoptionStage string
+
+const (
+	DomainAdoptionStageObserve  DomainAdoptionStage = "observe"
+	DomainAdoptionStagePromote  DomainAdoptionStage = "promote"
+	DomainAdoptionStageAllocate DomainAdoptionStage = "allocate"
+)
+
+// VersionAllocation is the result of a successful AllocateVersion call: the
+// newly reserved version, and what it was incremented from (empty for a
+// first release).
+type VersionAllocation struct {
+	Version         string
+	PreviousVersion string
+}

--- a/tools/app_registry/server/repository/postgres/BUILD.bazel
+++ b/tools/app_registry/server/repository/postgres/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "app.go",
         "artifact.go",
+        "domain_adoption.go",
         "environment.go",
         "errors.go",
         "idempotency.go",
@@ -15,6 +16,7 @@ go_library(
     importpath = "github.com/whale-net/everything/tools/app_registry/server/repository/postgres",
     visibility = ["//visibility:public"],
     deps = [
+        "//libs/go/semver",
         "//tools/app_registry/server/repository",
         "//tools/appmeta/proto:appmetapb",
         "@com_github_google_uuid//:uuid",
@@ -74,5 +76,7 @@ go_test(
         "@com_github_jackc_pgx_v5//pgconn",
         "@com_github_jackc_pgx_v5//pgxpool",
         "@com_github_jackc_pgx_v5//stdlib",
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//status",
     ],
 )

--- a/tools/app_registry/server/repository/postgres/artifact.go
+++ b/tools/app_registry/server/repository/postgres/artifact.go
@@ -8,9 +8,30 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/whale-net/everything/libs/go/semver"
 	"github.com/whale-net/everything/tools/app_registry/server/repository"
 	appmetapb "github.com/whale-net/everything/tools/appmeta/proto"
 )
+
+// parseVersionTriple parses v into (major, minor, patch) for the
+// version_major/minor/patch columns migration 004 added. Mirrors the
+// migration's own backfill decision exactly (see 005_version_allocation.up.sql):
+// a version that doesn't parse becomes the 0/0/0 sentinel rather than
+// failing the write, so an unparseable/legacy version can never win a
+// "latest" ORDER BY ... DESC query but the row is still written. This is
+// deliberately lenient (unlike AllocateVersion's ParseRelease, which
+// rejects prerelease/build metadata outright) because RecordArtifact
+// already accepts only v<major>.<minor>.<patch> at the handler layer
+// (see handlers/artifact.go's semverRe) — by the time SQL sees a version
+// here it is expected to be clean, but this must never be the reason a
+// write fails.
+func parseVersionTriple(v string) (major, minor, patch int) {
+	parsed, err := semver.Parse(v)
+	if err != nil {
+		return 0, 0, 0
+	}
+	return parsed.Major, parsed.Minor, parsed.Patch
+}
 
 // ============================================================================
 // BuildRepository
@@ -132,11 +153,12 @@ func (r *artifactRepo) RecordArtifact(ctx context.Context, a repository.Artifact
 	// afterwards fails too and ownerFullName would degrade to the raw UUID —
 	// which is exactly what a client should never be shown.
 	ownerName := r.ownerFullName(ctx, a)
+	versionMajor, versionMinor, versionPatch := parseVersionTriple(a.Version)
 
 	if _, err := r.ex.Exec(ctx, `
-		INSERT INTO artifact (artifact_id, kind, app_id, chart_id, repository, version, digest, build_id, published_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
-		a.ArtifactID, string(a.Kind), appID, chartID, a.Repository, a.Version, a.Digest, a.BuildID, a.PublishedAt); err != nil {
+		INSERT INTO artifact (artifact_id, kind, app_id, chart_id, repository, version, digest, build_id, published_at, version_major, version_minor, version_patch)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`,
+		a.ArtifactID, string(a.Kind), appID, chartID, a.Repository, a.Version, a.Digest, a.BuildID, a.PublishedAt, versionMajor, versionMinor, versionPatch); err != nil {
 		msg := fmt.Sprintf("artifact %s %s already recorded", ownerName, a.Version)
 		if de, ok := translatePgError(err, msg); ok {
 			return nil, false, de
@@ -343,4 +365,76 @@ func (r *artifactRepo) ResolveArtifact(ctx context.Context, lookup repository.Ar
 	a.Contains = links
 
 	return a, images, builds, nil
+}
+
+// ============================================================================
+// AllocateVersion (AR-5a)
+// ============================================================================
+
+// AllocateVersion implements repository.ArtifactRepository.AllocateVersion.
+// See that interface's doc comment and migration 004's comments for why this
+// writes to `version_allocation` rather than `artifact`, and
+// server/handlers/artifact.go's AllocateVersion for the retry loop this is
+// designed to be called from (a unique-constraint collision here aborts the
+// surrounding transaction; the caller must retry in a fresh one).
+func (r *artifactRepo) AllocateVersion(ctx context.Context, kind repository.ArtifactKind, ownerID, increment, explicitVersion string) (*repository.VersionAllocation, error) {
+	// "Next" is computed from the highest version already claimed for this
+	// owner+kind, across BOTH the real artifact table (already-published
+	// versions) and version_allocation (reserved but not yet published) --
+	// a version reserved a moment ago by a concurrent caller must not be
+	// handed out again just because RecordArtifact hasn't run yet.
+	row := r.ex.QueryRow(ctx, `
+		SELECT version, version_major, version_minor, version_patch FROM (
+			SELECT version, version_major, version_minor, version_patch
+			  FROM artifact WHERE owner_id = $1 AND kind = $2
+			UNION ALL
+			SELECT version, version_major, version_minor, version_patch
+			  FROM version_allocation WHERE owner_id = $1 AND kind = $2
+		) claimed
+		ORDER BY version_major DESC, version_minor DESC, version_patch DESC
+		LIMIT 1`, ownerID, string(kind))
+
+	var previousVersion string
+	var curMajor, curMinor, curPatch int
+	hasPrevious := true
+	switch err := row.Scan(&previousVersion, &curMajor, &curMinor, &curPatch); {
+	case errors.Is(err, pgx.ErrNoRows):
+		hasPrevious = false
+	case err != nil:
+		return nil, fmt.Errorf("determine current version for allocation: %w", err)
+	}
+
+	var next semver.Version
+	if explicitVersion != "" {
+		v, perr := semver.ParseRelease(explicitVersion)
+		if perr != nil {
+			return nil, fmt.Errorf("%w: %v", repository.ErrInvalidArgument, perr)
+		}
+		next = v
+	} else {
+		base := semver.Version{}
+		if hasPrevious {
+			base = semver.Version{Major: curMajor, Minor: curMinor, Patch: curPatch}
+		}
+		v, ierr := base.Increment(increment)
+		if ierr != nil {
+			return nil, fmt.Errorf("%w: %v", repository.ErrInvalidArgument, ierr)
+		}
+		next = v
+	}
+
+	versionStr := next.String()
+	allocationID := uuid.NewString()
+	if _, err := r.ex.Exec(ctx, `
+		INSERT INTO version_allocation (version_allocation_id, owner_id, kind, version, version_major, version_minor, version_patch)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+		allocationID, ownerID, string(kind), versionStr, next.Major, next.Minor, next.Patch); err != nil {
+		msg := fmt.Sprintf("version %s is already allocated or recorded for this owner", versionStr)
+		if de, ok := translatePgError(err, msg); ok {
+			return nil, de
+		}
+		return nil, fmt.Errorf("allocate version %s: %w", versionStr, err)
+	}
+
+	return &repository.VersionAllocation{Version: versionStr, PreviousVersion: previousVersion}, nil
 }

--- a/tools/app_registry/server/repository/postgres/domain_adoption.go
+++ b/tools/app_registry/server/repository/postgres/domain_adoption.go
@@ -1,0 +1,27 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/whale-net/everything/tools/app_registry/server/repository"
+)
+
+// domainAdoptionRepo implements repository.DomainAdoptionRepository over
+// the `domain_adoption` table (migration 001).
+type domainAdoptionRepo struct{ ex dbtx }
+
+func (r *domainAdoptionRepo) GetStage(ctx context.Context, domain string) (repository.DomainAdoptionStage, error) {
+	var stage string
+	err := r.ex.QueryRow(ctx, `SELECT stage FROM domain_adoption WHERE domain = $1`, domain).Scan(&stage)
+	if errors.Is(err, pgx.ErrNoRows) {
+		// No row means the domain has never been cut over from the
+		// implicit default -- see the interface doc comment on GetStage.
+		return repository.DomainAdoptionStageObserve, nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return repository.DomainAdoptionStage(stage), nil
+}

--- a/tools/app_registry/server/repository/postgres/postgres_integration_test.go
+++ b/tools/app_registry/server/repository/postgres/postgres_integration_test.go
@@ -19,12 +19,16 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 	_ "github.com/jackc/pgx/v5/stdlib" // database/sql driver for the migration runner
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/whale-net/everything/libs/go/dbtest"
 	"github.com/whale-net/everything/libs/go/grpcauth"
@@ -951,5 +955,294 @@ func TestEnvironmentRepo_UpsertCreateThenUpdate(t *testing.T) {
 	}
 	if len(updated.AllowedPrincipals) != 2 {
 		t.Fatalf("expected allowed_principals persisted as a real TEXT[] round-trip, got %+v", updated.AllowedPrincipals)
+	}
+}
+
+// --- 7. version allocation (AR-5a) --------------------------------------
+
+// setDomainAdoptionStage cuts domain over directly via SQL -- there is no
+// RPC to do this in AR-5a (see PLAN.md's AR-5 status), the same way a real
+// operator would today: `INSERT ... ON CONFLICT DO UPDATE` against
+// domain_adoption.
+func setDomainAdoptionStage(t *testing.T, pool *pgxpool.Pool, domain, stage string) {
+	t.Helper()
+	_, err := pool.Exec(context.Background(), `
+		INSERT INTO domain_adoption (domain, stage) VALUES ($1, $2)
+		ON CONFLICT (domain) DO UPDATE SET stage = EXCLUDED.stage`, domain, stage)
+	if err != nil {
+		t.Fatalf("set domain_adoption stage for %s: %v", domain, err)
+	}
+}
+
+// allocateVersionTx runs Artifacts().AllocateVersion inside a real WithTx
+// transaction, exactly as handlers.ArtifactServer.AllocateVersion's retry
+// loop does in production -- the postgres repository method relies on its
+// caller providing transactional scope.
+func allocateVersionTx(t *testing.T, reg *Registry, kind repository.ArtifactKind, ownerID, increment, explicitVersion string) (*repository.VersionAllocation, error) {
+	t.Helper()
+	var out *repository.VersionAllocation
+	err := reg.WithTx(context.Background(), func(ctx context.Context, r repository.Registry) error {
+		var ferr error
+		out, ferr = r.Artifacts().AllocateVersion(ctx, kind, ownerID, increment, explicitVersion)
+		return ferr
+	})
+	return out, err
+}
+
+// TestAllocateVersion_OrderingIsNumericNotLexical is the specific bug
+// PLAN.md's AR-5 addendum item 2 exists to prevent: with a v1.9.0 artifact
+// already recorded, the next patch allocation must be v1.9.1 -- if
+// "latest" were computed by ORDER BY on the TEXT `version` column instead
+// of the version_major/minor/patch integer columns, "v1.9.0" would sort
+// ABOVE "v1.10.0" lexically and this would go wrong the moment a major/minor
+// version reaches double digits. This seeds v1.10.0 as a decoy: if ordering
+// ever reverted to the TEXT column, "v1.10.0" (lexically greater than
+// "v1.9.0") would be picked as "latest" and patched to v1.10.1 -- silently
+// wrong versus the numerically-correct v1.9.1.
+func TestAllocateVersion_OrderingIsNumericNotLexical(t *testing.T) {
+	reg, pool := newTestRegistry(t)
+
+	appID := seedApp(t, pool, "acme", "widget", "image")
+	buildID := seedBuild(t, pool, "run-order")
+	setDomainAdoptionStage(t, pool, "acme", "allocate")
+
+	// Record v1.10.0 FIRST, then v1.9.0 -- insertion order must not matter;
+	// only the numeric columns should. Both use recordArtifactTx so
+	// version_major/minor/patch are populated exactly as production does.
+	if _, _, err := recordArtifactTx(t, reg, repository.Artifact{
+		Kind: repository.ArtifactKindImage, AppID: appID,
+		Repository: "ghcr.io/acme/widget", Version: "v1.10.0",
+		Digest: "sha256:order-v1-10-0", BuildID: buildID,
+	}, nil); err != nil {
+		t.Fatalf("seed v1.10.0: %v", err)
+	}
+	if _, _, err := recordArtifactTx(t, reg, repository.Artifact{
+		Kind: repository.ArtifactKindImage, AppID: appID,
+		Repository: "ghcr.io/acme/widget", Version: "v1.9.0",
+		Digest: "sha256:order-v1-9-0", BuildID: buildID,
+	}, nil); err != nil {
+		t.Fatalf("seed v1.9.0: %v", err)
+	}
+
+	alloc, err := allocateVersionTx(t, reg, repository.ArtifactKindImage, appID, "patch", "")
+	if err != nil {
+		t.Fatalf("AllocateVersion: %v", err)
+	}
+	if alloc.PreviousVersion != "v1.10.0" {
+		t.Fatalf("expected numeric ordering to pick v1.10.0 as latest (not v1.9.0), got previous_version=%q", alloc.PreviousVersion)
+	}
+	if alloc.Version != "v1.10.1" {
+		t.Fatalf("expected the next patch after v1.10.0 to be v1.10.1, got %q (a lexical-ordering bug would produce v1.9.1's sibling from the wrong base)", alloc.Version)
+	}
+}
+
+// TestAllocateVersion_ConcurrentCallsNeverCollide drives real concurrent
+// goroutines, each opening its own transaction via reg.WithTx, racing to
+// allocate the same owner's next patch version. The unique index on
+// version_allocation (owner_id, kind, version) — not application-level
+// locking — is what PLAN.md and ARCHITECTURE.md promise makes this safe;
+// this test would go red if AllocateVersion were changed to compute "next"
+// without that constraint backing it (e.g. reading and returning a version
+// without inserting anything transactionally first).
+func TestAllocateVersion_ConcurrentCallsNeverCollide(t *testing.T) {
+	reg, pool := newTestRegistry(t)
+	appID := seedApp(t, pool, "acme", "widget", "image")
+	setDomainAdoptionStage(t, pool, "acme", "allocate")
+
+	const workers = 8
+	var wg sync.WaitGroup
+	versions := make([]string, workers)
+	errs := make([]error, workers)
+
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			// Mirrors handlers.ArtifactServer.AllocateVersion's retry loop:
+			// a unique-violation aborts the transaction, so each retry opens
+			// a FRESH one via allocateVersionTx.
+			for attempt := 0; attempt < 20; attempt++ {
+				alloc, err := allocateVersionTx(t, reg, repository.ArtifactKindImage, appID, "patch", "")
+				if err == nil {
+					versions[idx] = alloc.Version
+					return
+				}
+				if !errors.Is(err, repository.ErrAlreadyExists) {
+					errs[idx] = err
+					return
+				}
+			}
+			errs[idx] = fmt.Errorf("worker %d: exhausted retries", idx)
+		}(i)
+	}
+	wg.Wait()
+
+	seen := map[string]int{}
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("worker %d: %v", i, err)
+		}
+		seen[versions[i]]++
+	}
+	for v, count := range seen {
+		if count > 1 {
+			t.Fatalf("version %s was allocated %d times concurrently -- expected every one of %d concurrent allocations to be unique, got %v", v, count, workers, versions)
+		}
+	}
+	if len(seen) != workers {
+		t.Fatalf("expected %d distinct versions from %d concurrent allocations, got %d: %v", workers, workers, len(seen), versions)
+	}
+
+	var allocationRows int
+	if err := pool.QueryRow(context.Background(), `SELECT count(*) FROM version_allocation WHERE owner_id = $1`, appID).Scan(&allocationRows); err != nil {
+		t.Fatalf("count version_allocation rows: %v", err)
+	}
+	if allocationRows != workers {
+		t.Fatalf("expected exactly %d version_allocation rows (one per successful allocation, no double-writes from retries), found %d", workers, allocationRows)
+	}
+}
+
+// TestAllocateVersion_IdempotencyKeyReplay proves the same idempotency-key
+// replay guarantee ArtifactServer's other write RPCs have, driven through
+// the real handler against real Postgres (not the fake) -- see
+// handlers/artifact_test.go's TestAllocateVersion_IdempotencyKeyReplay for
+// the fake-backed version of this same proof.
+func TestAllocateVersion_IdempotencyKeyReplay(t *testing.T) {
+	reg, pool := newTestRegistry(t)
+	ctx := authedCtx()
+	seedApp(t, pool, "acme", "widget", "image")
+	setDomainAdoptionStage(t, pool, "acme", "allocate")
+
+	srv := handlers.NewArtifactServer(reg)
+	req := &pb.AllocateVersionRequest{
+		Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE, OwnerFullName: "acme-widget",
+		Increment: "patch", IdempotencyKey: "replay-key",
+	}
+
+	first, err := srv.AllocateVersion(ctx, req)
+	if err != nil {
+		t.Fatalf("first AllocateVersion: %v", err)
+	}
+	if first.AlreadyAllocated {
+		t.Fatalf("expected already_allocated=false on the first call")
+	}
+
+	second, err := srv.AllocateVersion(ctx, req)
+	if err != nil {
+		t.Fatalf("replayed AllocateVersion: %v", err)
+	}
+	if second.Version != first.Version {
+		t.Fatalf("replay allocated a NEW version instead of returning the stored one: first=%q second=%q", first.Version, second.Version)
+	}
+	if !second.AlreadyAllocated {
+		t.Fatalf("expected already_allocated=true on the replayed call")
+	}
+
+	var allocationRows int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM version_allocation`).Scan(&allocationRows); err != nil {
+		t.Fatalf("count version_allocation rows: %v", err)
+	}
+	if allocationRows != 1 {
+		t.Fatalf("idempotency replay double-wrote: expected exactly 1 version_allocation row, found %d", allocationRows)
+	}
+}
+
+// TestAllocateVersion_AdoptionStageGateRejectsNonAllocateDomain proves the
+// per-domain cutover gate end to end through the real handler: a domain
+// with no domain_adoption row (every domain's implicit default -- see
+// migration 001) is rejected, and only after being explicitly cut over does
+// the identical request succeed.
+func TestAllocateVersion_AdoptionStageGateRejectsNonAllocateDomain(t *testing.T) {
+	reg, pool := newTestRegistry(t)
+	ctx := authedCtx()
+	seedApp(t, pool, "acme", "widget", "image")
+
+	srv := handlers.NewArtifactServer(reg)
+	req := &pb.AllocateVersionRequest{
+		Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE, OwnerFullName: "acme-widget",
+		Increment: "patch", IdempotencyKey: "gate-1",
+	}
+
+	_, err := srv.AllocateVersion(ctx, req)
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("expected FailedPrecondition for a domain with no domain_adoption row, got %v", err)
+	}
+
+	setDomainAdoptionStage(t, pool, "acme", "allocate")
+	resp, err := srv.AllocateVersion(ctx, req)
+	if err != nil {
+		t.Fatalf("expected success once 'acme' is cut over to 'allocate', got %v", err)
+	}
+	if resp.Version != "v0.0.1" {
+		t.Fatalf("expected the first-ever patch allocation to be v0.0.1, got %q", resp.Version)
+	}
+}
+
+// TestMigration004BackfillsVersionColumns proves migration 004's backfill:
+// a pre-existing artifact row (inserted directly via SQL as it would have
+// been before this migration existed) gets its version_major/minor/patch
+// populated correctly, and an unparseable legacy version is backfilled to
+// the documented 0/0/0 sentinel rather than blocking the migration -- see
+// 005_version_allocation.up.sql's comments for the decision.
+//
+// newTestRegistry already applies every migration including 004 before this
+// test runs, so this proves the backfill UPDATE that ran as PART of 004
+// against rows that existed in 001's `artifact` table state at that point
+// in the migration sequence.
+func TestMigration004BackfillsVersionColumns(t *testing.T) {
+	// This needs artifact rows to exist BEFORE migration 004 runs, so it
+	// can't use newTestRegistry (which applies every migration up front).
+	// Instead: apply only 001-003, insert rows directly (bypassing the
+	// version_major/minor/patch columns that don't exist yet), then apply
+	// 004 and assert the backfill.
+	ctx := context.Background()
+	db := dbtest.NewPostgres(ctx, t, dbtest.Options{})
+
+	sqlDB, err := sql.Open("pgx", db.ConnString)
+	if err != nil {
+		t.Fatalf("open database/sql handle: %v", err)
+	}
+	defer sqlDB.Close()
+
+	runner := migrate.NewRunner(sqlDB, schema.Migrations, schema.Dir)
+	if err := runner.Steps(3); err != nil {
+		t.Fatalf("apply migrations 001-003: %v", err)
+	}
+
+	appID := seedApp(t, db.Pool, "acme", "widget", "image")
+	buildID := seedBuild(t, db.Pool, "run-backfill")
+
+	type seed struct{ digest, version string }
+	seeds := []seed{
+		{"sha256:backfill-clean", "v3.4.5"},
+		{"sha256:backfill-garbage", "not-a-version-at-all"},
+	}
+	for _, s := range seeds {
+		if _, err := db.Pool.Exec(ctx, `
+			INSERT INTO artifact (kind, app_id, repository, version, digest, build_id)
+			VALUES ('image', $1, 'ghcr.io/acme/widget', $2, $3, $4)`,
+			appID, s.version, s.digest, buildID); err != nil {
+			t.Fatalf("seed pre-migration-004 artifact %s: %v", s.digest, err)
+		}
+	}
+
+	if err := runner.Up(); err != nil {
+		t.Fatalf("apply migration 004 (and any later): %v", err)
+	}
+
+	type got struct{ major, minor, patch int }
+	fetch := func(digest string) got {
+		var g got
+		if err := db.Pool.QueryRow(ctx, `SELECT version_major, version_minor, version_patch FROM artifact WHERE digest = $1`, digest).Scan(&g.major, &g.minor, &g.patch); err != nil {
+			t.Fatalf("read back backfilled columns for %s: %v", digest, err)
+		}
+		return g
+	}
+
+	if g := fetch("sha256:backfill-clean"); g != (got{3, 4, 5}) {
+		t.Fatalf("expected v3.4.5 to backfill to (3,4,5), got %+v", g)
+	}
+	if g := fetch("sha256:backfill-garbage"); g != (got{0, 0, 0}) {
+		t.Fatalf("expected an unparseable legacy version to backfill to the documented 0/0/0 sentinel, got %+v", g)
 	}
 }

--- a/tools/app_registry/server/repository/postgres/repository.go
+++ b/tools/app_registry/server/repository/postgres/repository.go
@@ -51,6 +51,9 @@ func (r *Registry) Environments() repository.EnvironmentRepository {
 }
 func (r *Registry) Promotions() repository.PromotionRepository { return &promotionRepo{ex: r.ex} }
 func (r *Registry) Writeback() repository.WritebackRepository  { return &writebackRepo{ex: r.ex} }
+func (r *Registry) DomainAdoption() repository.DomainAdoptionRepository {
+	return &domainAdoptionRepo{ex: r.ex}
+}
 
 // WithTx runs fn inside a single Postgres transaction, committing iff fn
 // returns nil and rolling back otherwise. This is the atomicity boundary

--- a/tools/app_registry/server/repository/repository.go
+++ b/tools/app_registry/server/repository/repository.go
@@ -90,6 +90,33 @@ type ArtifactRepository interface {
 	// and their originating builds. lookup identifies the chart artifact by
 	// artifact_id or digest.
 	ResolveArtifact(ctx context.Context, lookup ArtifactLookup) (artifact *Artifact, images []Artifact, builds []Build, err error)
+
+	// AllocateVersion reserves the next version for (kind, ownerID) per
+	// ARCHITECTURE.md's version model (AR-5) and PLAN.md's AR-5 addendum:
+	// increment is "major"|"minor"|"patch" and is ignored when
+	// explicitVersion is set. Implementations must perform this as a
+	// transactional INSERT against a unique (owner, kind, version)
+	// constraint so concurrent callers cannot be handed the same version —
+	// see ARCHITECTURE.md and postgres/errors.go's doc comment on
+	// ErrAlreadyExists. Must be called inside Registry.WithTx: a
+	// unique-constraint collision aborts the whole transaction (the
+	// "transaction abort" hazard PLAN.md flags), so a caller retrying on
+	// ErrAlreadyExists MUST do so in a FRESH WithTx call, not the same one —
+	// see server/handlers/artifact.go's AllocateVersion for the retry loop.
+	AllocateVersion(ctx context.Context, kind ArtifactKind, ownerID, increment, explicitVersion string) (*VersionAllocation, error)
+}
+
+// DomainAdoptionRepository covers the `domain_adoption` table (migration
+// 001), which gates the per-domain cutover described in ARCHITECTURE.md
+// "Resolved questions" #3. Recording (AR-2) is never gated on this; only
+// AllocateVersion (AR-5) is.
+type DomainAdoptionRepository interface {
+	// GetStage returns domain's current adoption stage, defaulting to
+	// DomainAdoptionStageObserve when no row exists yet — every domain
+	// starts at "observe" implicitly; a row is written only on explicit
+	// cutover (there is no bulk-seed of one row per domain, unlike
+	// `environment`'s dev/stage/prod seed).
+	GetStage(ctx context.Context, domain string) (DomainAdoptionStage, error)
 }
 
 // IdempotencyRepository stores key -> serialized response for write RPCs.
@@ -225,6 +252,7 @@ type Registry interface {
 	Environments() EnvironmentRepository
 	Promotions() PromotionRepository
 	Writeback() WritebackRepository
+	DomainAdoption() DomainAdoptionRepository
 
 	WithTx(ctx context.Context, fn func(ctx context.Context, r Registry) error) error
 }

--- a/tools/release_helper_go/BUILD.bazel
+++ b/tools/release_helper_go/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     ),
     importpath = "github.com/whale-net/everything/tools/release_helper_go/cmd",
     deps = [
+        "//libs/go/semver",
         "//tools/appmeta/proto:appmetapb",
         "//tools/helm:helm_lib",
         "@com_github_spf13_cobra//:cobra",

--- a/tools/release_helper_go/cmd/plan.go
+++ b/tools/release_helper_go/cmd/plan.go
@@ -7,6 +7,16 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+
+	// Aliased: this package already declares a local (unrelated) `semver`
+	// type in cleanup.go for GHCR tag-retention sorting. That one stays as
+	// is — it's a different concern (sorting existing published tags for
+	// deletion, not allocating new ones) and out of scope for AR-5. This
+	// import is the shared parser plan.go's incrementVersion now delegates
+	// to instead of its own regex/strings.Split logic — see PLAN.md's AR-5
+	// addendum and libs/go/semver's package doc for why it's shared with
+	// tools/app_registry instead of copied a second time.
+	sharedsemver "github.com/whale-net/everything/libs/go/semver"
 )
 
 var validEventTypes = []string{"workflow_dispatch", "tag_push", "pull_request", "push", "fallback"}
@@ -26,6 +36,7 @@ func newPlanCmd() *cobra.Command {
 		eventType      string
 		apps           string
 		version        string
+		incrementMajor bool
 		incrementMinor bool
 		incrementPatch bool
 		baseCommit     string
@@ -47,13 +58,13 @@ func newPlanCmd() *cobra.Command {
 				fmt.Fprintf(cmd.ErrOrStderr(), "Error: format must be one of: json, github\n")
 				return fmt.Errorf("invalid format")
 			}
-			versionOpts := boolCount(version != "", incrementMinor, incrementPatch)
+			versionOpts := boolCount(version != "", incrementMajor, incrementMinor, incrementPatch)
 			if versionOpts > 1 {
-				fmt.Fprintf(cmd.ErrOrStderr(), "Error: --version, --increment-minor, and --increment-patch are mutually exclusive\n")
+				fmt.Fprintf(cmd.ErrOrStderr(), "Error: --version, --increment-major, --increment-minor, and --increment-patch are mutually exclusive\n")
 				return fmt.Errorf("mutually exclusive options")
 			}
 			if eventType == "workflow_dispatch" && versionOpts == 0 {
-				fmt.Fprintf(cmd.ErrOrStderr(), "Error: manual releases require --version, --increment-minor, or --increment-patch\n")
+				fmt.Fprintf(cmd.ErrOrStderr(), "Error: manual releases require --version, --increment-major, --increment-minor, or --increment-patch\n")
 				return fmt.Errorf("missing version option")
 			}
 			if version != "" && version != "latest" && !semverRE.MatchString(version) {
@@ -70,6 +81,7 @@ func newPlanCmd() *cobra.Command {
 				eventType:      eventType,
 				requestedApps:  apps,
 				version:        version,
+				incrementMajor: incrementMajor,
 				incrementMinor: incrementMinor,
 				incrementPatch: incrementPatch,
 				baseCommit:     baseCommit,
@@ -99,6 +111,7 @@ func newPlanCmd() *cobra.Command {
 	cmd.Flags().StringVar(&eventType, "event-type", "", "Type of trigger event")
 	cmd.Flags().StringVar(&apps, "apps", "", "Comma-separated list of apps, domain names, or 'all'")
 	cmd.Flags().StringVar(&version, "version", "", "Release version")
+	cmd.Flags().BoolVar(&incrementMajor, "increment-major", false, "Auto-increment major version")
 	cmd.Flags().BoolVar(&incrementMinor, "increment-minor", false, "Auto-increment minor version")
 	cmd.Flags().BoolVar(&incrementPatch, "increment-patch", false, "Auto-increment patch version")
 	cmd.Flags().StringVar(&baseCommit, "base-commit", "", "Compare changes against this commit")
@@ -111,6 +124,7 @@ type planParams struct {
 	eventType      string
 	requestedApps  string
 	version        string
+	incrementMajor bool
 	incrementMinor bool
 	incrementPatch bool
 	baseCommit     string
@@ -148,7 +162,7 @@ func planRelease(p planParams) (*PlanResult, error) {
 				return nil, err
 			}
 		}
-		if err := assignVersions(releaseApps, p.version, p.incrementMinor, p.incrementPatch, p.git, perAppVersions); err != nil {
+		if err := assignVersions(releaseApps, p.version, p.incrementMajor, p.incrementMinor, p.incrementPatch, p.git, perAppVersions); err != nil {
 			return nil, err
 		}
 
@@ -235,16 +249,19 @@ func buildPlanResult(apps []AppMetadata, version, eventType string, perAppVersio
 // (keyed by the app's FullName). AppManifest.Version — the manifest's own
 // declared default (normally "latest") — is left untouched: it describes
 // the app definition, not the version being planned for this release.
-func assignVersions(apps []AppMetadata, version string, minor, patch bool, git GitRunner, out map[string]string) error {
+func assignVersions(apps []AppMetadata, version string, major, minor, patch bool, git GitRunner, out map[string]string) error {
 	for i := range apps {
 		if version != "" {
 			out[apps[i].FullName()] = version
 			continue
 		}
-		if minor || patch {
-			incrementType := "minor"
-			if patch {
-				incrementType = "patch"
+		if major || minor || patch {
+			incrementType := "patch"
+			switch {
+			case major:
+				incrementType = "major"
+			case minor:
+				incrementType = "minor"
 			}
 			newVer, err := autoIncrementVersion(apps[i].Domain, apps[i].Name, incrementType, git)
 			if err != nil {
@@ -256,7 +273,12 @@ func assignVersions(apps []AppMetadata, version string, minor, patch bool, git G
 	return nil
 }
 
-// autoIncrementVersion computes the next version for an app based on git tags.
+// autoIncrementVersion computes the next version for an app based on git
+// tags. This is the live, git-tag-based path AR-5's AllocateVersion is
+// meant to eventually replace (per domain, once a domain is cut over to
+// adoption stage "allocate") — see tools/app_registry/PLAN.md's AR-5. It is
+// deliberately untouched by AR-5a beyond gaining "major" alongside the
+// pre-existing "minor"/"patch": no call site here talks to the registry.
 func autoIncrementVersion(domain, name, incrementType string, git GitRunner) (string, error) {
 	prefix := fmt.Sprintf("%s-%s.", domain, name)
 	tagsOut, err := git.Run("tag", "--sort=-version:refname", "--list", prefix+"v*")
@@ -277,28 +299,23 @@ func autoIncrementVersion(domain, name, incrementType string, git GitRunner) (st
 	return incrementVersion(ver, incrementType)
 }
 
+// incrementVersion bumps ver (accepting an optional "v" prefix and
+// prerelease suffix, which is stripped — matching this function's
+// pre-existing behaviour) by incrementType ("major", "minor", or "patch"),
+// via the shared libs/go/semver parser rather than a second hand-rolled one.
+// See tools/app_registry/PLAN.md's AR-5 addendum item 1: chart bumping
+// (build_helm.go) already accepted all three; "major" was the one this
+// function was missing.
 func incrementVersion(ver, incrementType string) (string, error) {
-	ver = strings.TrimPrefix(ver, "v")
-	// strip prerelease
-	if idx := strings.Index(ver, "-"); idx >= 0 {
-		ver = ver[:idx]
+	v, err := sharedsemver.Parse(ver)
+	if err != nil {
+		return "", fmt.Errorf("invalid version: %s", strings.TrimPrefix(ver, "v"))
 	}
-	parts := strings.Split(ver, ".")
-	if len(parts) != 3 {
-		return "", fmt.Errorf("invalid version: %s", ver)
+	next, err := v.Increment(incrementType)
+	if err != nil {
+		return "", err
 	}
-	var major, minor, patch int
-	fmt.Sscanf(parts[0], "%d", &major)
-	fmt.Sscanf(parts[1], "%d", &minor)
-	fmt.Sscanf(parts[2], "%d", &patch)
-	switch incrementType {
-	case "minor":
-		return fmt.Sprintf("v%d.%d.0", major, minor+1), nil
-	case "patch":
-		return fmt.Sprintf("v%d.%d.%d", major, minor, patch+1), nil
-	default:
-		return "", fmt.Errorf("unknown increment type: %s", incrementType)
-	}
+	return next.String(), nil
 }
 
 // resolveApps matches requested app names (full, short, or domain) against allApps.
@@ -337,7 +354,9 @@ func resolveApps(requested []string, allApps []AppMetadata) ([]AppMetadata, erro
 				continue
 			}
 			names := make([]string, len(nameApps))
-			for i, a := range nameApps { names[i] = a.FullName() }
+			for i, a := range nameApps {
+				names[i] = a.FullName()
+			}
 			invalid = append(invalid, fmt.Sprintf("%s (ambiguous: %s)", req, strings.Join(names, ", ")))
 			continue
 		}
@@ -388,7 +407,11 @@ func boolCount(bs ...bool) int {
 }
 
 func isValidEventType(et string) bool {
-	for _, v := range validEventTypes { if et == v { return true } }
+	for _, v := range validEventTypes {
+		if et == v {
+			return true
+		}
+	}
 	return false
 }
 


### PR DESCRIPTION
Stacked on #512 (AR-4a). **Currently a sibling of AR-4b — will be rebased onto it, see "Migration renumber" below.**

## This is deliberately inert

AR-5's own gate in PLAN.md is *"do not start until AR-2's parity check has been clean across a meaningful number of real releases"*, and that soak has zero data points — `APP_REGISTRY_CICD_OPT_IN` is still unset. AR-5 is where the registry stops observing and becomes the source of truth for version numbers, so a registry that is down or wrong stops releases repo-wide.

So this builds the whole allocation path and connects it to nothing:

- `AllocateVersion` serves only domains at adoption stage `allocate`, and **no domain is at `allocate`**. Everything else gets `FailedPrecondition`.
- `plan.go`'s live git-tag path is unchanged — `autoIncrementVersion`'s call site is untouched and no code outside `server/` calls `AllocateVersion`.
- `.github/workflows/**` has an empty diff.

Cutover later is an `UPDATE domain_adoption`, not a build.

The one behavior change that does reach real releases is the additive `--increment-major` flag, which is specified below.

## Semver addendum (decided by the repo owner)

An audit of the existing version path found three gaps between what `release_helper_go` does today and what is needed to *replace* git tags. Today `plan.go` bumps versions by hand, but **git supplies the semver ordering** via `git tag --sort=-version:refname` — and that disappears with the tags. The decisions are recorded in PLAN.md → AR-5 → "Addendum".

**1. Major becomes first-class.** `incrementVersion` handled only `minor`/`patch`; `major` returned `unknown increment type`, while chart bumping already accepted all three. Added `major` plus `--increment-major`. Consequence, recorded deliberately: allocation is now a *superset* of tag-scanning, so AR-5's parity criterion holds for minor/patch but not for a capability the tag path never had.

**2. Sortable version columns — the load-bearing change.** `artifact.version` was `TEXT` with no ordering. `ORDER BY version DESC` on text is **wrong**: lexically `v1.9.0` sorts above `v1.10.0`, so the release after `v1.10.0` would be computed as `v1.10.0` again — a unique-constraint collision or a silent renumber. Added `version_major/minor/patch INTEGER NOT NULL` plus `(owner_id, kind, version_major DESC, version_minor DESC, version_patch DESC)`. `UNIQUE (owner_id, kind, version)` stays on the **text** form: it is the collision guard and must match what is published.

**3. Prereleases rejected, door left open.** `libs/go/semver` splits this cleanly: `Parse` is permissive (preserving `plan.go`'s pre-existing prerelease-stripping behavior byte for byte) and `ParseRelease` is strict, rejecting prerelease/build metadata with a clear error. `AllocateVersion` uses the strict one. A future `version_prerelease` column needs no change to the constraint or the integer triple.

Semver parsing lives in `libs/go/semver` rather than being copied a third time — `release_helper_go` and the registry are peers with no dependency relationship, the same reasoning ARCHITECTURE.md already applies to `//tools/appmeta/proto`.

## Backfill

Existing rows with unparseable versions backfill to sentinel `0/0/0` — they sort below every real release so they can never win a "latest" query, but the row is not dropped and the deploy is not blocked. This is not hypothetical: `plan.go` already tolerates junk tags by falling back to `v0.0.1`.

## Verification

`bazel test //libs/go/semver/... //tools/release_helper_go/... //tools/app_registry/...` → 8/8 pass. Postgres integration suite → PASS in 37s against a real container. `bazel build //...` → 458 targets, success.

Guards verified by deliberately breaking them:

| Broken | Result |
|---|---|
| `ORDER BY version_major DESC…` → `ORDER BY version DESC` | ordering test failed — `previous_version="v1.9.0"` instead of `"v1.10.0"` |
| `version_allocation_idx` made non-unique | concurrency test failed — one version allocated 5 times out of 8 |
| stage check short-circuited | both fake- and Postgres-backed gate tests failed |

Concurrency is tested with 8 real goroutines in independent transactions, not sequential calls. A unique-violation retry opens a **fresh** transaction rather than reusing the aborted one — the transaction-abort hazard that already produced a real bug in AR-2a.

I reviewed `plan.go`'s diff line by line rather than trusting the summary, since it is the live release path: the `assignVersions` refactor is behavior-preserving (the flags are mutually exclusive, enforced before dispatch), and the rest is gofmt.

## Migration renumber (pending)

AR-4b independently claimed `004` for `writeback_outbox`. AR-4b is downstack, so it keeps `004` and **this PR's migration will be renumbered `005` when rebased onto it**, along with the `migrate/README.md` "Planned migrations" table. Flagged rather than silently resolved, because two migrations sharing a number fails at deploy time, not build time.