### PR TITLE
AR-6a: fix promote/rollback never sending ArtifactKind

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -31,6 +31,13 @@ on:
       owner_full_name:
         description: 'App or chart identity, as <domain>-<name> (e.g. manmanv2-host-manager)'
         required: true
+      kind:
+        description: 'Which artifact kind owner_full_name refers to. Charts and images can share a name, so this is what disambiguates them.'
+        type: choice
+        options:
+          - image
+          - chart
+        default: image
       version:
         description: 'Version to promote, e.g. v1.4.0. Required for action=promote; ignored for action=rollback.'
         required: false
@@ -100,6 +107,7 @@ jobs:
         GRPC_AUTH_CLIENT_SECRET: ${{ secrets.APP_REGISTRY_PROMOTER_CLIENT_SECRET }}
         ENVIRONMENT: ${{ inputs.environment }}
         OWNER_FULL_NAME: ${{ inputs.owner_full_name }}
+        KIND: ${{ inputs.kind }}
         VERSION: ${{ inputs.version }}
         REASON: ${{ inputs.reason }}
         ALLOW_OVERRIDE: ${{ inputs.allow_override }}
@@ -107,7 +115,7 @@ jobs:
       run: |
         APP_REGISTRY_CLI="$(bazel info bazel-bin --config=ci)/tools/app_registry/cli/app-registry_/app-registry"
 
-        ARGS=(promote "$OWNER_FULL_NAME" "$VERSION" --env "$ENVIRONMENT")
+        ARGS=(promote "$OWNER_FULL_NAME" "$VERSION" --env "$ENVIRONMENT" --kind "$KIND")
         if [[ -n "$REASON" ]]; then
           ARGS+=(--reason "$REASON")
         fi
@@ -130,12 +138,13 @@ jobs:
         GRPC_AUTH_CLIENT_SECRET: ${{ secrets.APP_REGISTRY_PROMOTER_CLIENT_SECRET }}
         ENVIRONMENT: ${{ inputs.environment }}
         OWNER_FULL_NAME: ${{ inputs.owner_full_name }}
+        KIND: ${{ inputs.kind }}
         REASON: ${{ inputs.reason }}
         DRY_RUN: ${{ inputs.dry_run }}
       run: |
         APP_REGISTRY_CLI="$(bazel info bazel-bin --config=ci)/tools/app_registry/cli/app-registry_/app-registry"
 
-        ARGS=(rollback "$OWNER_FULL_NAME" --env "$ENVIRONMENT")
+        ARGS=(rollback "$OWNER_FULL_NAME" --env "$ENVIRONMENT" --kind "$KIND")
         if [[ -n "$REASON" ]]; then
           ARGS+=(--reason "$REASON")
         fi

--- a/tools/app_registry/DEPLOY.md
+++ b/tools/app_registry/DEPLOY.md
@@ -47,6 +47,7 @@ every call returns `Unauthenticated`.
 | `app-registry-promoter-dev` | Promote to `dev` (via `promote.yml`) | Same shape, realm role `app-registry-promoter-dev` | **now** — needed before `promote.yml` can run against `dev` |
 | `app-registry-promoter-stage` | Promote to `stage` (via `promote.yml`) | Same shape, realm role `app-registry-promoter-stage` | **now** — needed before `promote.yml` can run against `stage` |
 | `app-registry-promoter-prod` | Promote to `prod` (via `promote.yml`) | Same shape, realm role `app-registry-promoter-prod` | **now** — needed before `promote.yml` can run against `prod` |
+| `app-registry-worker` | The writeback worker's own calls back into the API (`GetEnvironmentState`) | Confidential, **Service accounts roles** only, audience mapper → `app-registry-api`. **No realm role** — those reads only require an authenticated caller | **now, if you run the worker** |
 
 ### Realm roles
 
@@ -61,6 +62,11 @@ app-registry-promoter-stage
 app-registry-promoter-prod
 app-registry-admin
 ```
+
+The `app-registry-worker` client deliberately gets **no** realm role: it only
+reads (`GetEnvironmentState`), and the read RPCs require an authenticated
+caller rather than a specific role. Give it a role only if you later have it
+write.
 
 **Roles are flat — no role implies another.** `app-registry-admin` does *not*
 grant builder. A principal that needs to both record and administer holds both

--- a/tools/app_registry/PLAN.md
+++ b/tools/app_registry/PLAN.md
@@ -43,6 +43,14 @@ still out of scope (see AR-4b below).
 for what it delivered and what is deliberately still missing before any
 domain can be cut over.
 
+**Where deferred work is tracked.** Three places, deliberately:
+[Carry-over items](#carry-over-items) for small cross-cutting gaps that
+belong to no single phase; each phase's own **"Deliberately NOT done"**
+subsection for scope that phase consciously left (AR-5's is the
+cutover itself); and "Explicitly out of scope" at the end of this document
+for things no phase will do. If you are picking this up cold, read those
+three before starting anything.
+
 ### AR-3d — CLI + `promote.yml` — done
 
 - `app-registry promote`/`rollback`/`status`/`history`/`diff` filled in
@@ -176,10 +184,12 @@ the `manual` tag excludes the new target from wildcard expansion.
   **Resolved by AR-2d** — see `postgres_integration_test.go`. The SCD2
   `promotion` table's partial unique index is still untested; it doesn't
   exist until AR-3's migration `002` lands (see AR-2d's scope note above).
-- **Auth is unimplemented.** Handlers check no claims; the Tiltfile runs
-  `GRPC_AUTH_MODE=none`. Fine for AR-2 (recording, CI service account), **not**
-  fine for AR-3, whose entire point is that a build credential cannot promote to
-  prod. Settle OIDC config before AR-3.
+- **Auth is unimplemented.** ~~Handlers check no claims; the Tiltfile runs
+  `GRPC_AUTH_MODE=none`.~~ **Resolved by AR-3a** — role model in
+  `server/auth`, enforced on every RPC. Note `GRPC_AUTH_MODE` still
+  *defaults* to `none`, in which the server grants every caller every role;
+  that is intentional (Tilt and local dev depend on it) and is the
+  deployer's responsibility to override. See DEPLOY.md §3.
 - **Transaction-abort hazard for AR-3.** A failed statement aborts the
   surrounding Postgres transaction, so any error-message or logging code that
   queries afterwards silently degrades. This bit `RecordArtifact` once already;
@@ -188,6 +198,23 @@ the `manual` tag excludes the new target from wildcard expansion.
   only thing currently exercising the pgx layer.
 - `list-apps --format json` prints `deploy_unit` as an integer. Cosmetic; no CI
   path reads it.
+- **`promotion_event.temporal_workflow_id` / `temporal_run_id` are never
+  stamped back** (AR-4b). `003_promotion.up.sql`'s schema comment anticipates
+  them, and `WritebackOutbox.EventID` exists precisely so the worker can do
+  it, but nothing writes them — so an operator cannot jump from an audit row
+  to its Temporal workflow history. Needs an `event_id`-keyed update path
+  from the worker.
+- **Temporal `WorkflowIDReusePolicy` is left at the SDK default** (AR-4b),
+  reasoned about in `worker/outbox/drain.go`'s comments but never
+  independently stress-tested. Relevant because workflow id = promotion id,
+  so reuse semantics decide what happens when a promotion is retried.
+- **`--format table` is unimplemented across the whole CLI** — every command
+  falls back to JSON with a `# table format not implemented yet` notice
+  (`cli/cmd/client.go`, `cli/cmd/util.go`). Pre-existing, cosmetic, but the
+  flag is advertised.
+- **No admin/web UI.** Deferred as non-critical for launch. PLAN.md's
+  out-of-scope list notes the CLI is kept thin specifically so a UI can be
+  added without reimplementing rules server-side.
 
 ## Sequencing rationale
 

--- a/tools/app_registry/cli/README.md
+++ b/tools/app_registry/cli/README.md
@@ -30,9 +30,9 @@ app-registry artifacts record ... --idempotency-key K          # CI
 app-registry builds record ... --idempotency-key K             # CI
 
 app-registry promote <domain-name> <version> --env prod --reason "..."
-                     [--allow-override] [--dry-run] [--idempotency-key K]
+                     [--kind image|chart] [--allow-override] [--dry-run] [--idempotency-key K]
 app-registry rollback <domain-name> --env prod --reason "..."
-                     [--dry-run] [--idempotency-key K]
+                     [--kind image|chart] [--dry-run] [--idempotency-key K]
 app-registry status <env> [--domain D] [--at <RFC3339>]
 app-registry history <domain-name> [--env E]
 app-registry diff <env-a> <env-b>
@@ -45,6 +45,13 @@ promote?" — it filters by the derived promotability described in
 [`../ARCHITECTURE.md`](../ARCHITECTURE.md#promotability).
 
 ### `promote` / `rollback`
+
+Both identify the artifact/target by `owner_full_name` + `kind` (+ `version`
+for `promote`). `--kind` defaults to `image` (the common case — most owners
+are images, not charts) but must be set explicitly to `chart` when promoting
+or rolling back a chart. There is no `unspecified` default: the server
+rejects an unset/invalid kind rather than guessing, since guessing wrong
+could promote or roll back the wrong artifact silently.
 
 `--idempotency-key` is optional on both: if omitted, the CLI generates a UUID
 (`promoteIdempotencyKey` in `promote.go`), matching ARCHITECTURE.md

--- a/tools/app_registry/cli/cmd/promote.go
+++ b/tools/app_registry/cli/cmd/promote.go
@@ -25,16 +25,21 @@ func promoteIdempotencyKey(key string) string {
 }
 
 func newPromoteCmd() *cobra.Command {
-	var env, reason string
+	var env, reason, kind string
 	var allowOverride, dryRun bool
 	c := &cobra.Command{
 		Use:   "promote <domain-name> <version>",
 		Short: "Promote an artifact to an environment",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			k, err := parseArtifactKind(kind)
+			if err != nil {
+				return err
+			}
 			req := &pb.PromoteRequest{
 				EnvironmentKey: env,
 				OwnerFullName:  args[0],
+				Kind:           k,
 				Version:        args[1],
 				Reason:         reason,
 				AllowOverride:  allowOverride,
@@ -62,6 +67,7 @@ func newPromoteCmd() *cobra.Command {
 	}
 	c.Flags().StringVar(&env, "env", "", "Target environment key, e.g. prod")
 	c.Flags().StringVar(&reason, "reason", "", "Required above dev rank; recorded in the audit log")
+	c.Flags().StringVar(&kind, "kind", "image", "Artifact kind (image|chart); the owner_full_name+version pair is ambiguous without it")
 	c.Flags().BoolVar(&allowOverride, "allow-override", false, "Acknowledge promoting a VIA_CHART artifact directly")
 	c.Flags().BoolVar(&dryRun, "dry-run", false, "Compute the resulting state without writing")
 	c.Flags().StringVar(&idempotencyKeyFlag, "idempotency-key", "", "Client-generated; a UUID is generated if omitted (see ARCHITECTURE.md 'Idempotency')")
@@ -70,17 +76,22 @@ func newPromoteCmd() *cobra.Command {
 }
 
 func newRollbackCmd() *cobra.Command {
-	var env, reason string
+	var env, reason, kind string
 	var dryRun bool
 	c := &cobra.Command{
 		Use:   "rollback <domain-name>",
 		Short: "Re-promote whatever was previously current for this target",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			k, err := parseArtifactKind(kind)
+			if err != nil {
+				return err
+			}
 			return withClient(cmd, func(rc *registryClient) error {
 				resp, err := rc.Promotion.Rollback(cmd.Context(), &pb.RollbackRequest{
 					EnvironmentKey: env,
 					OwnerFullName:  args[0],
+					Kind:           k,
 					Reason:         reason,
 					DryRun:         dryRun,
 					IdempotencyKey: promoteIdempotencyKey(idempotencyKeyFlag),
@@ -97,6 +108,7 @@ func newRollbackCmd() *cobra.Command {
 	}
 	c.Flags().StringVar(&env, "env", "", "Target environment key, e.g. prod")
 	c.Flags().StringVar(&reason, "reason", "", "Required above dev rank; recorded in the audit log")
+	c.Flags().StringVar(&kind, "kind", "image", "Artifact kind (image|chart) of the target being rolled back")
 	c.Flags().BoolVar(&dryRun, "dry-run", false, "Compute the resulting state without writing")
 	c.Flags().StringVar(&idempotencyKeyFlag, "idempotency-key", "", "Client-generated; a UUID is generated if omitted (see ARCHITECTURE.md 'Idempotency')")
 	_ = c.MarkFlagRequired("env")

--- a/tools/app_registry/cli/cmd/promote_test.go
+++ b/tools/app_registry/cli/cmd/promote_test.go
@@ -165,3 +165,65 @@ func TestPromoteIdempotencyKey_PreservesProvided(t *testing.T) {
 		t.Fatalf("got %q, want explicit-key", got)
 	}
 }
+
+// TestParseArtifactKind_PromoteRollbackFlag exercises parseArtifactKind with
+// the exact inputs promote/rollback's --kind flag can carry: the two valid
+// strings, the "image" default those commands register, and an invalid
+// value. This is the regression test for the bug where PromoteRequest and
+// RollbackRequest were built without ever setting Kind, so the server always
+// saw ARTIFACT_KIND_UNSPECIFIED and every promotion/rollback failed lookup
+// -- see promoteArtifactLookup / Rollback in
+// server/handlers/promotion.go.
+func TestParseArtifactKind_PromoteRollbackFlag(t *testing.T) {
+	tests := []struct {
+		in      string
+		want    pb.ArtifactKind
+		wantErr bool
+	}{
+		{in: "image", want: pb.ArtifactKind_ARTIFACT_KIND_IMAGE},
+		{in: "chart", want: pb.ArtifactKind_ARTIFACT_KIND_CHART},
+		{in: "bogus", wantErr: true},
+		{in: "", wantErr: true},
+	}
+	for _, tt := range tests {
+		got, err := parseArtifactKind(tt.in)
+		if tt.wantErr {
+			if err == nil {
+				t.Errorf("parseArtifactKind(%q): expected error, got nil (kind=%v)", tt.in, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("parseArtifactKind(%q): unexpected error: %v", tt.in, err)
+			continue
+		}
+		if got != tt.want {
+			t.Errorf("parseArtifactKind(%q) = %v, want %v", tt.in, got, tt.want)
+		}
+	}
+}
+
+// TestNewPromoteCmd_DefaultKindFlagIsImage locks in the --kind default
+// (image, the common case) so a future change to the flag registration is
+// caught here rather than only discovered against a live server.
+func TestNewPromoteCmd_DefaultKindFlagIsImage(t *testing.T) {
+	c := newPromoteCmd()
+	f := c.Flags().Lookup("kind")
+	if f == nil {
+		t.Fatal("expected promote to register a --kind flag")
+	}
+	if f.DefValue != "image" {
+		t.Errorf("--kind default = %q, want %q", f.DefValue, "image")
+	}
+}
+
+func TestNewRollbackCmd_DefaultKindFlagIsImage(t *testing.T) {
+	c := newRollbackCmd()
+	f := c.Flags().Lookup("kind")
+	if f == nil {
+		t.Fatal("expected rollback to register a --kind flag")
+	}
+	if f.DefValue != "image" {
+		t.Errorf("--kind default = %q, want %q", f.DefValue, "image")
+	}
+}


### PR DESCRIPTION
Stacked on #515 (AR-6b). Fixes a bug that made the promote path unusable.

## The bug

`promote.go` built `PromoteRequest` **without ever setting `Kind`**, so the server's `promoteArtifactLookup` saw `ARTIFACT_KIND_UNSPECIFIED` and rejected the lookup with `InvalidArgument: kind is required when identifying by owner_full_name`.

`rollback` was worse: `promotion.go:227` requires `kind` unconditionally with no fallback, so **every CLI rollback was 100% broken**.

This is why AR-4b's end-to-end testing had to be driven through `grpcurl` — the CLI simply could not promote.

**Reproduced before fixing:** the pre-fix binary was built via `git stash` and run against real Postgres + a migrated `app-registry-api`, producing exactly that error. Then fixed, then re-run green. A fix verified only by a new passing test would not have proven the bug was ever real.

## Fix

`--kind` (accepting `image`/`chart`) on both `promote` and `rollback`, reusing the existing `parseArtifactKind` helper that `artifacts record`/`list` already use — same strings, same error shape.

**Defaults to `image` rather than being required.** `promote.yml` had no kind-equivalent input, so making it required would have broken every existing invocation. The failure mode of a wrong default is safe: the server validates kind against real data, so a mis-kinded call fails the lookup rather than promoting the wrong artifact.

## Closing the `promote.yml` gap

The agent documented "promote.yml has no `kind` input" as a known limitation, since it was told not to touch workflows. I closed it instead — leaving CI unable to promote charts would be a real hole in the deploy path. `promote.yml` gains a `kind` choice input (`image`/`chart`, default `image`), passed through `env:` to both steps, consistent with the injection-safe pattern already established there. The DEPLOY.md caveat is removed since it no longer applies.

## Also: the worker's Keycloak client was undocumented

Relevant now that CI is going `oidc`. `app-registry-worker` authenticates via `GRPC_AUTH_*` and calls `GetEnvironmentState`, but **DEPLOY.md's client table listed no worker client** — follow that doc, flip the server to `oidc`, and the worker breaks. Added, with the note that it deliberately gets **no realm role**: the read RPCs require an authenticated caller, not a specific role.

## Verification

Real wire path, not just unit tests — this bug got past a green build precisely because nothing exercised the wire. Postgres 16 + migrations + `app-registry-api` + the built CLI: `promote` succeeded, `status` showed it, a second promote then `rollback` correctly restored the earlier version, and `--kind bogus` was rejected client-side.

At the top of the full stack: **17/17 tests pass**, `bazel build //...` green across 2547 actions. `promote.yml` re-validated as YAML with both steps confirmed to carry `KIND` and pass `--kind`.

## Checked and clean

Every `pb.*Request{...}` construction in `cli/cmd/` was audited for the same "proto field never set" class of bug. Only `promote.go` was affected. There are also **no `TODO`/`FIXME` markers anywhere** in the registry's Go or SQL.