### PR TITLE
ci: run CI on pull requests to any base branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,9 @@
 name: CI
 
 on:
+  # No branches filter here: stacked PRs target other feature branches, not
+  # just main, and still need CI to run.
   pull_request:
-    branches: [ main ]
   push:
     branches: [ main ]
 


### PR DESCRIPTION
## Summary
- PR #511 (and the rest of the `ar-3*`/`ar-4*`/`ar-5*`/`ar-6*` stack) target feature branches, not `main`, so no checks run on them.
- The `pull_request` trigger in `.github/workflows/ci.yml` was scoped to `branches: [ main ]`, which only fires when the PR's base is `main`.
- Removed the branch filter on `pull_request` so CI runs regardless of base branch; `push` stays scoped to `main`.

## Test plan
- [ ] Confirm PR #511 (and other stacked PRs) pick up the `Test` check once this merges.