### PR TITLE
fix: app-registry builder/promoter client id mismatches (#526)

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -5,10 +5,19 @@ name: Promote
 # ARCHITECTURE.md -> "Authorization": the `environment:` declaration on the
 # `promote` job below is the entire security model for this workflow, not a
 # formality. It is what scopes the job to the target GitHub Environment's
-# secrets (so only that environment's `app-registry-promoter-<env>` client
-# secret is readable) and what triggers that environment's required
-# reviewers. A builder credential is never in scope here -- it lives in a
-# repository secret and carries no promoter role regardless.
+# secrets (so only that environment's `APP_REGISTRY_PROMOTER_CLIENT_SECRET`
+# is readable) and what triggers that environment's required reviewers. A
+# builder credential is never in scope here -- it lives in a repository
+# secret and carries no promoter role regardless.
+#
+# `environment` (the GitHub Environment) and `registry_environment` (the
+# Keycloak app-registry-promoter-<key> suffix / App Registry --env) are two
+# separate inputs on purpose: the GitHub Environment name is whatever this
+# repo's Environments happen to be called (e.g. promotion-dev), which need
+# not equal the App Registry's environment key (dev/stage/prod). A caller who
+# mismatches them just fails Keycloak auth -- the wrong client id paired with
+# the right environment's secret does not authenticate -- so decoupling the
+# two does not weaken the security scoping above.
 #
 # Unlike the best-effort AR-2c recording steps in release.yml, the promote
 # step below is NOT continue-on-error: a promotion that silently fails while
@@ -19,7 +28,15 @@ on:
   workflow_dispatch:
     inputs:
       environment:
-        description: 'Target GitHub Environment / App Registry environment key (e.g. dev, stage, prod). Must have a matching GitHub Environment with the app-registry-promoter-<environment> secret configured.'
+        description: 'GitHub Environment this job runs under (controls which APP_REGISTRY_PROMOTER_CLIENT_SECRET and required reviewers apply). May be named anything (e.g. promotion-dev) -- it does not have to match registry_environment.'
+        required: true
+      registry_environment:
+        description: 'App Registry environment key / Keycloak app-registry-promoter-<key> client suffix. Must match a real app-registry-promoter-<key> client regardless of what the GitHub Environment above is named.'
+        type: choice
+        options:
+          - dev
+          - stage
+          - prod
         required: true
       action:
         description: 'promote a specific version, or roll back to whatever was previously current'
@@ -55,11 +72,13 @@ on:
 
 jobs:
   promote:
-    name: ${{ inputs.action }} ${{ inputs.owner_full_name }} -> ${{ inputs.environment }}
+    name: ${{ inputs.action }} ${{ inputs.owner_full_name }} -> ${{ inputs.registry_environment }} (${{ inputs.environment }})
     runs-on: ubuntu-latest
     # This is the security-critical line -- see the header comment above.
     # It scopes the job to the named GitHub Environment's secrets and
-    # required reviewers.
+    # required reviewers. Deliberately the GitHub Environment name, NOT
+    # registry_environment -- the two are allowed to differ (e.g. GitHub
+    # Environment "promotion-dev" vs registry key "dev").
     environment: ${{ inputs.environment }}
     steps:
     # Every `run:` block in this workflow reads inputs through `env:` rather
@@ -95,17 +114,17 @@ jobs:
 
     # Read from *this job's* Environment secrets (scoped by `environment:`
     # above), never from repository secrets. See DEPLOY.md "Where each
-    # secret goes" -- promoter-<env> client secrets live only on the
-    # matching GitHub Environment.
+    # secret goes" -- each GitHub Environment holds the promoter client
+    # secret matching whatever registry_environment its operators pass.
     - name: Promote
       if: inputs.action == 'promote'
       env:
         APP_REGISTRY_ADDRESS: ${{ vars.APP_REGISTRY_ADDRESS }}
         GRPC_AUTH_MODE: oidc
         GRPC_AUTH_TOKEN_URL: ${{ vars.APP_REGISTRY_AUTH_TOKEN_URL }}
-        GRPC_AUTH_CLIENT_ID: app-registry-promoter-${{ inputs.environment }}
+        GRPC_AUTH_CLIENT_ID: app-registry-promoter-${{ inputs.registry_environment }}
         GRPC_AUTH_CLIENT_SECRET: ${{ secrets.APP_REGISTRY_PROMOTER_CLIENT_SECRET }}
-        ENVIRONMENT: ${{ inputs.environment }}
+        ENVIRONMENT: ${{ inputs.registry_environment }}
         OWNER_FULL_NAME: ${{ inputs.owner_full_name }}
         KIND: ${{ inputs.kind }}
         VERSION: ${{ inputs.version }}
@@ -134,9 +153,9 @@ jobs:
         APP_REGISTRY_ADDRESS: ${{ vars.APP_REGISTRY_ADDRESS }}
         GRPC_AUTH_MODE: oidc
         GRPC_AUTH_TOKEN_URL: ${{ vars.APP_REGISTRY_AUTH_TOKEN_URL }}
-        GRPC_AUTH_CLIENT_ID: app-registry-promoter-${{ inputs.environment }}
+        GRPC_AUTH_CLIENT_ID: app-registry-promoter-${{ inputs.registry_environment }}
         GRPC_AUTH_CLIENT_SECRET: ${{ secrets.APP_REGISTRY_PROMOTER_CLIENT_SECRET }}
-        ENVIRONMENT: ${{ inputs.environment }}
+        ENVIRONMENT: ${{ inputs.registry_environment }}
         OWNER_FULL_NAME: ${{ inputs.owner_full_name }}
         KIND: ${{ inputs.kind }}
         REASON: ${{ inputs.reason }}

--- a/tools/app_registry/DEPLOY.md
+++ b/tools/app_registry/DEPLOY.md
@@ -43,6 +43,19 @@ every call returns `Unauthenticated`.
 |---|---|---|---|
 | `app-registry-api` | Names the audience. Never obtains a token. | Client authentication **On**, **all** flows unchecked, no roles | **now** |
 | `app-registry-builder` | CI recording (`ReconcileApps`, `RecordBuild`, `RecordArtifact`) | Confidential, **Service accounts roles** only, realm role `app-registry-builder`, audience mapper → `app-registry-api` | **now** |
+
+> **Do not split `app-registry-builder` per environment.** Unlike the promoter
+> clients below, recording (`RecordBuild`/`RecordArtifact`) has no
+> environment concept — `release.yml` runs it once per release, before any
+> promotion decision exists, against the single `APP_REGISTRY_ADDRESS`. There
+> is exactly one `app-registry-builder` client and one `app-registry-builder`
+> realm role (`server/auth/auth.go`'s `RoleBuilder`); creating
+> `app-registry-builder-dev` / `-prod` variants has no corresponding code path
+> to select between them and will just leave `release.yml`'s
+> `GRPC_AUTH_CLIENT_ID: app-registry-builder` unable to authenticate. If a
+> per-environment split is ever needed here, it requires a code change in
+> this repo (an environment input to the recording steps) first — do not
+> introduce the split Keycloak-side alone.
 | `app-registry-admin` | `EnvironmentRegistry`, `SetAppStatus` | Same shape, realm role `app-registry-admin` | **now** |
 | `app-registry-promoter-dev` | Promote to `dev` (via `promote.yml`) | Same shape, realm role `app-registry-promoter-dev` | **now** — needed before `promote.yml` can run against `dev` |
 | `app-registry-promoter-stage` | Promote to `stage` (via `promote.yml`) | Same shape, realm role `app-registry-promoter-stage` | **now** — needed before `promote.yml` can run against `stage` |
@@ -242,6 +255,19 @@ the run.
 To promote to `prod`: create the `prod` GitHub Environment (§1's client table
 and §4's secret table), configure required reviewers on it, run the workflow
 with `environment: prod`, and approve the run when prompted.
+
+> **The `environment` input name is load-bearing — it must be one string that
+> is simultaneously two things.** `promote.yml` uses `inputs.environment` both
+> as the GitHub Environment to scope secrets/reviewers to (`environment:
+> ${{ inputs.environment }}`) and, via `GRPC_AUTH_CLIENT_ID:
+> app-registry-promoter-${{ inputs.environment }}`, as the suffix that selects
+> the Keycloak promoter client. There is no translation layer between the two.
+> This only works if the GitHub Environment is named *exactly* `dev`, `stage`,
+> or `prod` — matching the `app-registry-promoter-<env>` client names in §1
+> and the `environment` table seeded by AR-3b. Naming a GitHub Environment
+> anything else (e.g. `promotion-dev`) silently breaks the security scoping:
+> the job would either fail to find the right secret, or — if a same-named
+> Keycloak client happens to exist — read the wrong one.
 
 ---
 

--- a/tools/app_registry/DEPLOY.md
+++ b/tools/app_registry/DEPLOY.md
@@ -244,30 +244,36 @@ green job.
 ## 6. Promote via `promote.yml`
 
 `.github/workflows/promote.yml` is a `workflow_dispatch` job with inputs
-`environment`, `action` (`promote`/`rollback`), `owner_full_name`, `version`,
-`reason`, `allow_override`, `dry_run`. Its job declares
-`environment: ${{ inputs.environment }}`, which is what scopes it to that
-GitHub Environment's `APP_REGISTRY_PROMOTER_CLIENT_SECRET` and triggers that
-Environment's required reviewers — see §4's secret table. Unlike the AR-2c
-recording steps it is **not** `continue-on-error`: a failed promotion fails
-the run.
+`environment`, `registry_environment`, `action` (`promote`/`rollback`),
+`owner_full_name`, `version`, `reason`, `allow_override`, `dry_run`. Its job
+declares `environment: ${{ inputs.environment }}`, which is what scopes it to
+that GitHub Environment's `APP_REGISTRY_PROMOTER_CLIENT_SECRET` and triggers
+that Environment's required reviewers — see §4's secret table. Unlike the
+AR-2c recording steps it is **not** `continue-on-error`: a failed promotion
+fails the run.
 
-To promote to `prod`: create the `prod` GitHub Environment (§1's client table
-and §4's secret table), configure required reviewers on it, run the workflow
-with `environment: prod`, and approve the run when prompted.
+`environment` and `registry_environment` are deliberately two separate
+inputs, not one string doing double duty:
 
-> **The `environment` input name is load-bearing — it must be one string that
-> is simultaneously two things.** `promote.yml` uses `inputs.environment` both
-> as the GitHub Environment to scope secrets/reviewers to (`environment:
-> ${{ inputs.environment }}`) and, via `GRPC_AUTH_CLIENT_ID:
-> app-registry-promoter-${{ inputs.environment }}`, as the suffix that selects
-> the Keycloak promoter client. There is no translation layer between the two.
-> This only works if the GitHub Environment is named *exactly* `dev`, `stage`,
-> or `prod` — matching the `app-registry-promoter-<env>` client names in §1
-> and the `environment` table seeded by AR-3b. Naming a GitHub Environment
-> anything else (e.g. `promotion-dev`) silently breaks the security scoping:
-> the job would either fail to find the right secret, or — if a same-named
-> Keycloak client happens to exist — read the wrong one.
+- `environment` is the **GitHub Environment name**, whatever this repo's
+  Environments actually happen to be called (e.g. `promotion-dev`,
+  `promotion-prod`). It only has to match a real GitHub Environment.
+- `registry_environment` is the **App Registry environment key** — it drives
+  both `GRPC_AUTH_CLIENT_ID: app-registry-promoter-${{
+  inputs.registry_environment }}` and the CLI's `--env` flag, and must match
+  one of `dev`/`stage`/`prod` per §1's client table, independent of what the
+  GitHub Environment is named.
+
+Pick both correctly for the target: e.g. `environment: promotion-prod`,
+`registry_environment: prod`. A mismatch (say `registry_environment: dev`
+under `environment: promotion-prod`) doesn't bypass anything — it just fails
+Keycloak authentication, because that GitHub Environment's secret is the
+`prod` client's secret, which does not pair with the `dev` client id.
+
+To promote to `prod`: create the corresponding GitHub Environment (§1's
+client table and §4's secret table), configure required reviewers on it, run
+the workflow with that `environment` and `registry_environment: prod`, and
+approve the run when prompted.
 
 ---
 

--- a/tools/app_registry/ENV.md
+++ b/tools/app_registry/ENV.md
@@ -92,7 +92,7 @@ placement rationale:
 | `vars.APP_REGISTRY_ADDRESS` | Repository variable | `APP_REGISTRY_ADDRESS` | both |
 | `vars.APP_REGISTRY_AUTH_TOKEN_URL` | Repository variable | `GRPC_AUTH_TOKEN_URL` | both |
 | `secrets.APP_REGISTRY_BUILDER_CLIENT_SECRET` | Repository secret | `GRPC_AUTH_CLIENT_SECRET` (`GRPC_AUTH_CLIENT_ID=app-registry-builder`) | `release.yml` recording steps only |
-| `secrets.APP_REGISTRY_PROMOTER_CLIENT_SECRET` | Environment secret, one per `dev`/`stage`/`prod` GitHub Environment | `GRPC_AUTH_CLIENT_SECRET` (`GRPC_AUTH_CLIENT_ID=app-registry-promoter-<environment>`) | `promote.yml` only |
+| `secrets.APP_REGISTRY_PROMOTER_CLIENT_SECRET` | Environment secret, one per GitHub Environment (e.g. `promotion-dev`/`promotion-prod`) | `GRPC_AUTH_CLIENT_SECRET` (`GRPC_AUTH_CLIENT_ID=app-registry-promoter-<registry_environment>`) | `promote.yml` only |
 
 `GRPC_AUTH_MODE=oidc` is hardcoded in both workflows rather than read from a
 variable — the CLI must match whatever the server runs, and the server is

--- a/tools/app_registry/OPERATIONS.md
+++ b/tools/app_registry/OPERATIONS.md
@@ -94,17 +94,20 @@ see [DEPLOY.md §4](DEPLOY.md#4-ci-credentials).
 ### 3. Promote to an environment
 
 **Requires `promote.yml`'s GitHub Environments and Keycloak promoter clients
-to exist — as of this writing they do not, so this step cannot succeed
-outside Tilt.** Once they do:
+to exist.** Once they do:
 
-- GitHub → Actions → `Promote` → **Run workflow**, filling in `environment`,
-  `action` (`promote`/`rollback`), `owner_full_name`
-  (`<domain>-<name>`), `version` (for `promote`), and `reason` (required
-  above `dev`).
-- The job runs under `environment: <the one you chose>`, which is what
-  gates it on that environment's required reviewers and lets it read that
-  environment's `app-registry-promoter-<env>` secret — approve the run when
-  prompted.
+- GitHub → Actions → `Promote` → **Run workflow**, filling in `environment`
+  (the GitHub Environment, e.g. `promotion-dev`), `registry_environment`
+  (the App Registry key it maps to — `dev`/`stage`/`prod`), `action`
+  (`promote`/`rollback`), `owner_full_name` (`<domain>-<name>`), `version`
+  (for `promote`), and `reason` (required above `dev`). These two
+  environment inputs are separate because the GitHub Environment's name
+  need not match the registry key — see [DEPLOY.md
+  §6](DEPLOY.md#6-promote-via-promoteyml).
+- The job runs under `environment: <the GitHub Environment you chose>`,
+  which is what gates it on that environment's required reviewers and lets
+  it read that environment's `app-registry-promoter-<registry_environment>`
+  secret — approve the run when prompted.
 - Prefer `dry_run: true` first against anything above `dev`: it computes the
   resulting state without writing, using the same authorization and
   promotability checks a real promotion would hit.


### PR DESCRIPTION
## Summary
- **Builder client**: `release.yml`'s `GRPC_AUTH_CLIENT_ID: app-registry-builder` is correct as written — `server/auth/auth.go` (`RoleBuilder`) and `ARCHITECTURE.md`'s Authorization table both define exactly one non-split `app-registry-builder` role/client, unlike the per-environment promoter roles. Recording has no environment concept, so it should not be split. `DEPLOY.md` now says this explicitly, so `argok8s` (which created split `app-registry-builder-dev`/`-prod` clients per its `TODO.md`) provisions the single client this repo's code actually expects.
- **Promoter client (the real, currently-live bug)**: `promote.yml` used `inputs.environment` for two jobs at once — the GitHub Environment name (`environment: ${{ inputs.environment }}`, scoping secrets/reviewers) *and* the Keycloak client suffix (`GRPC_AUTH_CLIENT_ID: app-registry-promoter-${{ inputs.environment }}`). This repo's actual GitHub Environments are `promotion-dev`/`promotion-prod` (verified via `gh api repos/whale-net/everything/environments`), not `dev`/`stage`/`prod`, so the derived client id (`app-registry-promoter-promotion-dev`) never matched a real Keycloak client — promotion could never authenticate.

## Changes
- `.github/workflows/promote.yml`: split `environment` into two `workflow_dispatch` inputs — `environment` (the GitHub Environment, any name) and `registry_environment` (`dev`/`stage`/`prod`, drives the Keycloak client suffix and the CLI's `--env`). A mismatch between the two fails Keycloak auth rather than opening any gap (wrong client id + right environment's secret still don't authenticate), so decoupling them doesn't weaken the security scoping the header comment describes.
- `tools/app_registry/DEPLOY.md`: explicit note that `app-registry-builder` must not be split per environment; rewrote §6 to describe the two-input model and how to pick both values for a target environment.
- `tools/app_registry/ENV.md`, `tools/app_registry/OPERATIONS.md`: updated the promoter-secret/workflow-input references to match.

## Testing
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/promote.yml'))"` — valid YAML.
- Docs-only elsewhere.

## Related Issue
Closes #526