### PR TITLE
fix: restrict test container architecture to main branch builds only (#518)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,10 +91,12 @@ jobs:
 
   # Container architecture test - verify cross-compilation works correctly
   # Runs in parallel with test job for faster CI
+  # Only runs on main branch to reduce CI overhead on feature branches
   test-container-arch:
     name: Test Container Architecture
     runs-on: ubuntu-latest
-    
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -349,11 +351,19 @@ jobs:
           exit 1
         fi
         
-        # Container arch test must always pass
-        if [[ "$CONTAINER_ARCH_RESULT" != "success" ]]; then
+        # Container arch test must pass on main, but is skipped on PRs
+        if [[ "$CONTAINER_ARCH_RESULT" != "success" && "$CONTAINER_ARCH_RESULT" != "skipped" ]]; then
           echo "❌ **Overall Status: FAILED**" >> $GITHUB_STEP_SUMMARY
           echo "Container architecture test failed - cross-compilation is broken!" >> $GITHUB_STEP_SUMMARY
           echo "::error::Container architecture test failed"
+          exit 1
+        fi
+
+        # On main branch, container arch test should have run and succeeded
+        if [[ "${{ github.event_name }}" == "push" && "$CONTAINER_ARCH_RESULT" == "skipped" ]]; then
+          echo "❌ **Overall Status: FAILED**" >> $GITHUB_STEP_SUMMARY
+          echo "Container architecture test was skipped on main branch but should have run!" >> $GITHUB_STEP_SUMMARY
+          echo "::error::Container architecture test was unexpectedly skipped"
           exit 1
         fi
         

--- a/docs/CI_CD.md
+++ b/docs/CI_CD.md
@@ -13,14 +13,17 @@ graph TD
     A[Push/PR] --> B[Build Job]
     A --> C[Test Job]
     C --> D{Test Success?}
-    D -->|Yes| E[Container Arch Test]
     D -->|No| F[Pipeline Fails]
-    B --> G{Build Success?}
-    G -->|Yes| H[Plan Docker]
-    G -->|No| F
-    E --> I{Arch Test Success?}
-    I -->|Yes| H
+    D -->|Yes| E{Main Branch?}
+    E -->|Yes| E1[Container Arch Test]
+    E -->|No| E2[Skip Arch Test]
+    E1 --> I{Arch Test Success?}
     I -->|No| F
+    I -->|Yes| H[Plan Docker]
+    E2 --> H
+    B --> G{Build Success?}
+    G -->|Yes| H
+    G -->|No| F
     H --> J{Main Branch?}
     J -->|Yes| K[Docker Job]
     J -->|No| L[Build Summary]
@@ -31,7 +34,8 @@ graph TD
     
     style B fill:#e1f5fe
     style C fill:#e1f5fe
-    style E fill:#f3e5f5
+    style E1 fill:#f3e5f5
+    style E2 fill:#f0f0f0
     style K fill:#fff3e0
     style F fill:#ffebee
     style O fill:#e8f5e8
@@ -56,7 +60,7 @@ Builds all targets to verify compilation (runs in parallel with Test)
 Runs all unit and integration tests
 
 ### Container Arch Test
-Verifies cross-compilation for multi-architecture containers (critical for ARM64 support)
+Verifies cross-compilation for multi-architecture containers (critical for ARM64 support). Runs on main branch builds only to reduce CI overhead on feature branches.
 
 ### Plan Docker
 Determines which apps need Docker images built based on changes


### PR DESCRIPTION
## Summary
Restrict the test-container-arch CI job to run only on main branch pushes, reducing CI overhead on feature branches. The test is critical for verifying cross-compilation, but cross-compilation drift is no longer as much of a concern for pull requests.

## Changes
- Added `if: github.event_name == 'push' && github.ref == 'refs/heads/main'` condition to test-container-arch job
- Updated build-summary job to correctly handle skipped status on PRs
- Updated CI/CD.md documentation and pipeline diagram to reflect the new behavior

## Test Plan
- [ ] CI should pass on pull requests without running the container architecture test
- [ ] CI should still run the container architecture test on main branch pushes
- [ ] Build summary should correctly report status in both cases

🤖 Generated with Claude Code