### PR TITLE
fix: App Registry recording steps never download built binaries under --config=ci

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -424,8 +424,8 @@ jobs:
         fi
 
         echo "Building app-registry CLI..."
-        bazel build --config=ci //tools/app_registry/cli:app-registry
-        APP_REGISTRY_CLI="$(bazel info bazel-bin --config=ci)/tools/app_registry/cli/app-registry_/app-registry"
+        bazel build --config=ci-release //tools/app_registry/cli:app-registry
+        APP_REGISTRY_CLI="$(bazel info bazel-bin --config=ci-release)/tools/app_registry/cli/app-registry_/app-registry"
 
         IDEMPOTENCY_PREFIX="${{ github.run_id }}-${{ github.run_attempt }}"
 
@@ -935,9 +935,9 @@ jobs:
         GRPC_AUTH_CLIENT_SECRET: ${{ secrets.APP_REGISTRY_BUILDER_CLIENT_SECRET }}
       run: |
         echo "Building release helper and app-registry CLI..."
-        bazel build --config=ci //tools/release_helper_go:release_helper_go //tools/app_registry/cli:app-registry
-        RELEASE_HELPER="$(bazel info bazel-bin --config=ci)/tools/release_helper_go/release_helper_go_/release_helper_go"
-        APP_REGISTRY_CLI="$(bazel info bazel-bin --config=ci)/tools/app_registry/cli/app-registry_/app-registry"
+        bazel build --config=ci-release //tools/release_helper_go:release_helper_go //tools/app_registry/cli:app-registry
+        RELEASE_HELPER="$(bazel info bazel-bin --config=ci-release)/tools/release_helper_go/release_helper_go_/release_helper_go"
+        APP_REGISTRY_CLI="$(bazel info bazel-bin --config=ci-release)/tools/app_registry/cli/app-registry_/app-registry"
 
         IDEMPOTENCY_PREFIX="${{ github.run_id }}-${{ github.run_attempt }}"
 


### PR DESCRIPTION
## Summary
- `run` #31343291283 (first release with `APP_REGISTRY_CICD_OPT_IN=true`, releasing `app-registry-cli`) showed a green job with a silently failed "Record build and artifact in App Registry" step: `exit code 127`, `No such file or directory` on the just-built binary.
- Root cause: plain `--config=ci` sets `--remote_download_minimal` (`.bazelrc` line 34), so `bazel build` never materializes outputs on local disk — only kept in the remote cache. `--config=ci-release` (already used elsewhere in this file, e.g. `RELEASE_HELPER`) layers `--remote_download_toplevel` on top of `ci`, which does fetch the binary.
- Both the image-artifact recording step and the chart-artifact recording step built with `--config=ci` and then exec'd the binary path directly, hitting the same bug.

## Fix
Switch both `bazel build` / `bazel info bazel-bin` invocations in the two App Registry recording steps from `--config=ci` to `--config=ci-release`, matching the working pattern already used for `release_helper_go` in the same workflow.

## Test plan
- [ ] Re-run `Release` for `app-registry-cli` with `APP_REGISTRY_CICD_OPT_IN=true` and confirm the "Record build and artifact in App Registry" step succeeds (`✅ Recorded ...`) instead of failing silently.
- [ ] Confirm `app-registry artifacts get app-registry-cli --version <version>` returns the recorded artifact afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)