### PR TITLE
fix: remaining --config=ci download-minimal breakage in promote/helm-chart steps

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -109,9 +109,6 @@ jobs:
         bazel-remote-cache-user: ${{ secrets.BAZEL_REMOTE_CACHE_USER }}
         bazel-remote-cache-password: ${{ secrets.BAZEL_REMOTE_CACHE_PASSWORD }}
 
-    - name: Build app-registry CLI
-      run: bazel build --config=ci //tools/app_registry/cli:app-registry
-
     # Read from *this job's* Environment secrets (scoped by `environment:`
     # above), never from repository secrets. See DEPLOY.md "Where each
     # secret goes" -- each GitHub Environment holds the promoter client
@@ -132,8 +129,6 @@ jobs:
         ALLOW_OVERRIDE: ${{ inputs.allow_override }}
         DRY_RUN: ${{ inputs.dry_run }}
       run: |
-        APP_REGISTRY_CLI="$(bazel info bazel-bin --config=ci)/tools/app_registry/cli/app-registry_/app-registry"
-
         ARGS=(promote "$OWNER_FULL_NAME" "$VERSION" --env "$ENVIRONMENT" --kind "$KIND")
         if [[ -n "$REASON" ]]; then
           ARGS+=(--reason "$REASON")
@@ -145,7 +140,7 @@ jobs:
           ARGS+=(--dry-run)
         fi
 
-        "$APP_REGISTRY_CLI" "${ARGS[@]}"
+        bazel run --config=ci-release //tools/app_registry/cli:app-registry -- "${ARGS[@]}"
 
     - name: Rollback
       if: inputs.action == 'rollback'
@@ -161,8 +156,6 @@ jobs:
         REASON: ${{ inputs.reason }}
         DRY_RUN: ${{ inputs.dry_run }}
       run: |
-        APP_REGISTRY_CLI="$(bazel info bazel-bin --config=ci)/tools/app_registry/cli/app-registry_/app-registry"
-
         ARGS=(rollback "$OWNER_FULL_NAME" --env "$ENVIRONMENT" --kind "$KIND")
         if [[ -n "$REASON" ]]; then
           ARGS+=(--reason "$REASON")
@@ -171,7 +164,7 @@ jobs:
           ARGS+=(--dry-run)
         fi
 
-        "$APP_REGISTRY_CLI" "${ARGS[@]}"
+        bazel run --config=ci-release //tools/app_registry/cli:app-registry -- "${ARGS[@]}"
 
     # No continue-on-error anywhere above: a failed promotion must fail the
     # job loudly, unlike the best-effort recording steps in release.yml.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -778,10 +778,13 @@ jobs:
         # Create output directory for charts
         mkdir -p /tmp/helm-charts
         
-        # Build the release helper binary first (avoids nested Bazel invocations)
+        # Build the release helper binary first (avoids nested Bazel invocations).
+        # ci-release config: builds from source (no remote cache reads, and
+        # --remote_download_toplevel so the binary actually lands on disk --
+        # plain --config=ci sets --remote_download_minimal, see #530).
         echo "Building release helper..."
-        bazel build --config=ci //tools/release_helper_go:release_helper_go
-        RELEASE_HELPER="$(bazel info bazel-bin --config=ci)/tools/release_helper_go/release_helper_go_/release_helper_go"
+        bazel build --config=ci-release //tools/release_helper_go:release_helper_go
+        RELEASE_HELPER="$(bazel info bazel-bin --config=ci-release)/tools/release_helper_go/release_helper_go_/release_helper_go"
         
         # Parse chart list and build each chart with proper versioning
         CHARTS="${{ steps.plan.outputs.charts }}"


### PR DESCRIPTION
## Summary
Follow-up audit after #530/#531 asked "are there more instances of this?" Grepped all of `.github/workflows/*.yml` for `bazel build --config=ci` / `bazel info bazel-bin --config=ci` (plain `ci`, not `ci-release`/`ci-images`) followed by direct binary execution. Found three more live instances, all broken by the same root cause: `build:ci --remote_download_minimal` landed in `.bazelrc` via #444 (2026-08-08) and never materializes `bazel build` outputs to local disk under plain `--config=ci`.

- **`promote.yml` "Promote" step** — resolved `APP_REGISTRY_CLI`'s path via `--config=ci` after a separate build step that used the same broken config. Unlike `release.yml`'s recording steps, there's no `continue-on-error` here — every real promotion would fail loudly with exit 127.
- **`promote.yml` "Rollback" step** — same bug, missed in the first pass (#531 only touched `release.yml`).
- **`release.yml` "Release Helm Charts" job** — pre-dates App Registry entirely (#440), unrelated to it, and not gated behind `APP_REGISTRY_CICD_OPT_IN` — this builds `release_helper_go` and drives every helm chart release. Broken since #444 landed, independent of anything App Registry related.

## Fix
- `promote.yml`: dropped the separate "Build app-registry CLI" step (now dead) and switched both `Promote`/`Rollback` steps to `bazel run --config=ci-release`, matching #531's pattern.
- `release.yml` helm chart step: kept the existing build + `bazel info bazel-bin` structure (not `bazel run`) — the adjacent `release-multiarch` step has a comment that nested Bazel invocations under `bazel run` can deadlock, and `build-helm-chart` likely shells out to Bazel the same way. Just switched `--config=ci` → `--config=ci-release` there, matching the already-correct sibling step at line ~356.

## Test plan
- [ ] Trigger `promote.yml` (dry-run) against `dev` and confirm the Promote step succeeds.
- [ ] Trigger `promote.yml` rollback (dry-run) and confirm the Rollback step succeeds.
- [ ] Re-run a helm chart release and confirm `build-helm-chart` succeeds (binary is found).

🤖 Generated with [Claude Code](https://claude.com/claude-code)