### PR TITLE
perf(ci): build release_helper_go once per CI run, share via artifact

### DIFF
--- a/.github/actions/download-release-tools/action.yml
+++ b/.github/actions/download-release-tools/action.yml
@@ -1,9 +1,13 @@
 name: 'Download Release Tools'
 description: >-
-  Downloads the release_helper_go / app-registry CLI binaries built once by
-  the build-release-tools job and exports RELEASE_HELPER / APP_REGISTRY_CLI
-  env vars pointing at the executables. Avoids every downstream job
-  rebuilding these tools from source (see PR discussion on #530-#532).
+  Downloads whichever of the release_helper_go / app-registry CLI binaries
+  the calling workflow's build-release-tools job produced, and exports
+  RELEASE_HELPER / APP_REGISTRY_CLI env vars for the ones present. Avoids
+  every downstream job rebuilding these tools from source (see PR discussion
+  on #530-#532, #535). Not every workflow needs both binaries -- e.g. ci.yml
+  only builds release_helper_go -- so this only exports a var for a binary
+  that's actually in the artifact.
+
 branding:
   icon: 'download'
   color: 'green'
@@ -26,7 +30,12 @@ runs:
     - name: Make tools executable and export paths
       shell: bash
       run: |
-        chmod +x "${{ runner.temp }}/release-tools/release_helper_go"
-        chmod +x "${{ runner.temp }}/release-tools/app-registry"
-        echo "RELEASE_HELPER=${{ runner.temp }}/release-tools/release_helper_go" >> "$GITHUB_ENV"
-        echo "APP_REGISTRY_CLI=${{ runner.temp }}/release-tools/app-registry" >> "$GITHUB_ENV"
+        DIR="${{ runner.temp }}/release-tools"
+        if [[ -f "$DIR/release_helper_go" ]]; then
+          chmod +x "$DIR/release_helper_go"
+          echo "RELEASE_HELPER=$DIR/release_helper_go" >> "$GITHUB_ENV"
+        fi
+        if [[ -f "$DIR/app-registry" ]]; then
+          chmod +x "$DIR/app-registry"
+          echo "APP_REGISTRY_CLI=$DIR/app-registry" >> "$GITHUB_ENV"
+        fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,44 @@ on:
     branches: [ main ]
 
 jobs:
+  # Build release_helper_go once and share it via upload-artifact/download-
+  # artifact (see .github/actions/download-release-tools) instead of every
+  # job that needs it -- plan-docker, and every leg of the docker matrix --
+  # rebuilding it from source independently. ci-images (not ci-release):
+  # these are throwaway CI-only Docker builds, never pushed, so there's no
+  # "must not read from a possibly-stale cache" concern the way there is for
+  # release.yml's actual published artifacts -- cache reads are pure upside
+  # here. No `needs:` -- runs in parallel with the test jobs below.
+  build-release-tools:
+    name: Build Release Tools
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Setup Build Environment
+      uses: ./.github/actions/setup-build-env
+      with:
+        cache-suffix: 'release-tools'
+        bazel-remote-cache-url: ${{ secrets.BAZEL_REMOTE_CACHE_URL }}
+        bazel-remote-cache-user: ${{ secrets.BAZEL_REMOTE_CACHE_USER }}
+        bazel-remote-cache-password: ${{ secrets.BAZEL_REMOTE_CACHE_PASSWORD }}
+
+    - name: Build release_helper_go
+      run: |
+        bazel build --config=ci-images //tools/release_helper_go:release_helper_go
+        BAZEL_BIN="$(bazel info bazel-bin --config=ci-images)"
+        mkdir -p /tmp/release-tools
+        cp "$BAZEL_BIN/tools/release_helper_go/release_helper_go_/release_helper_go" /tmp/release-tools/release_helper_go
+        bazel shutdown
+
+    - name: Upload release tools artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: release-tools
+        path: /tmp/release-tools/
+        retention-days: 1
+
   # # Build job - commented out in favor of merged build+test job below
   # # Uncomment and remove build step from test job to restore separate build/test parallelism
   # build:
@@ -199,7 +237,7 @@ jobs:
   plan-docker:
     name: Plan Docker Builds
     runs-on: ubuntu-latest
-    needs: [test, test-container-arch]
+    needs: [test, test-container-arch, build-release-tools]
     outputs:
       matrix: ${{ steps.plan.outputs.matrix }}
       apps: ${{ steps.plan.outputs.apps }}
@@ -208,15 +246,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
-        
-    - name: Setup Build Environment
-      uses: ./.github/actions/setup-build-env
-      with:
-        cache-suffix: 'ci'
-        bazel-remote-cache-url: ${{ secrets.BAZEL_REMOTE_CACHE_URL }}
-        bazel-remote-cache-user: ${{ secrets.BAZEL_REMOTE_CACHE_USER }}
-        bazel-remote-cache-password: ${{ secrets.BAZEL_REMOTE_CACHE_PASSWORD }}
-        
+
+    - name: Download release tools
+      uses: ./.github/actions/download-release-tools
+
     - name: Plan Docker builds using release tool
       id: plan
       env:
@@ -242,7 +275,7 @@ jobs:
         
         # Use release helper to plan the Docker builds
         echo "Planning Docker builds using release tool..."
-        PLAN_OUTPUT=$(bazel run --config=ci //tools/release_helper_go:release_helper_go -- plan \
+        PLAN_OUTPUT=$("$RELEASE_HELPER" plan \
           --event-type "$EVENT_TYPE" \
           --base-commit="$BASE_COMMIT" \
           --format github)
@@ -262,27 +295,24 @@ jobs:
             fi
           fi
         done <<< "$PLAN_OUTPUT"
-        
-        # Shutdown Bazel server to prevent hanging
-        bazel shutdown
 
   # Docker job - builds container images using the release tool (main branch only)
   # Note: Images are built but not pushed to registry. Use the Release workflow for publishing.
   docker:
     name: Build ${{ matrix.domain }}-${{ matrix.app }} Image
     runs-on: ubuntu-latest
-    needs: plan-docker
+    needs: [plan-docker, build-release-tools]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.plan-docker.outputs.apps && needs.plan-docker.outputs.apps != 'null'
     strategy:
       matrix: ${{ fromJson(needs.plan-docker.outputs.matrix) }}
       fail-fast: false
-    
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
-      
+
     - name: Setup Build Environment
       uses: ./.github/actions/setup-build-env
       with:
@@ -291,7 +321,14 @@ jobs:
         bazel-remote-cache-url: ${{ secrets.BAZEL_REMOTE_CACHE_URL }}
         bazel-remote-cache-user: ${{ secrets.BAZEL_REMOTE_CACHE_USER }}
         bazel-remote-cache-password: ${{ secrets.BAZEL_REMOTE_CACHE_PASSWORD }}
-        
+
+    # release_helper_go's `build` subcommand still shells out to Bazel itself
+    # to build the image, so Setup Build Environment above is still needed --
+    # this just fetches the already-built release_helper_go binary instead of
+    # rebuilding it in every matrix leg.
+    - name: Download release tools
+      uses: ./.github/actions/download-release-tools
+
     - name: Build Docker image for ${{ matrix.domain }}-${{ matrix.app }}
       env:
         GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
@@ -301,7 +338,7 @@ jobs:
         # Use full domain-app format to avoid ambiguity
         FULL_APP_NAME="${DOMAIN}-${APP}"
         echo "Building Docker image for $FULL_APP_NAME using release tool..."
-        bazel run --config=ci-images //tools/release_helper_go:release_helper_go -- build "$FULL_APP_NAME"
+        "$RELEASE_HELPER" build "$FULL_APP_NAME"
         
         # Show the built Docker image
         echo "Built Docker image for $FULL_APP_NAME:"


### PR DESCRIPTION
## Summary
Stacked on #535. That PR applied build-once-and-share to `release.yml`; this extends the same pattern to `ci.yml`, which is actually the higher-frequency case -- it runs on every push to `main` (and the `test`/`test-container-arch`/`test-database` jobs run on every PR too), whereas `release.yml` only runs on manual dispatch.

`ci.yml`'s `docker` job matrix rebuilds `release_helper_go` from source on **every matrix leg** (once per app touched by a push to main), and `plan-docker` rebuilds it again separately.

## Change
- New `build-release-tools` job (no `needs:`, runs in parallel with the test jobs) builds `release_helper_go` once under `--config=ci-images` -- not `ci-release`: these are throwaway CI-only Docker builds that never get pushed, so there's no cache-poisoning concern to guard against, and cache reads are pure upside here.
- `plan-docker` and the `docker` matrix job now download the pre-built binary instead of rebuilding; `plan-docker` no longer needs Bazel/Docker setup at all since it never invokes Bazel directly.
- Generalized `.github/actions/download-release-tools` (shared with `release.yml`) to only export `RELEASE_HELPER`/`APP_REGISTRY_CLI` for whichever binaries are actually present in the artifact -- `ci.yml` only ever builds `release_helper_go`, not the App Registry CLI (CI doesn't record anything to the registry).

## Not changed
`promote.yml` -- it makes exactly one CLI call per run, so there's nothing to amortize via build-once-and-share. Already addressed separately (#532/#535) by dropping its build config from `ci-release` to plain `ci`.

## Test plan
- [ ] Push to `main` with app changes and confirm `build-release-tools` runs once, `plan-docker` and every `docker` matrix leg download successfully.
- [ ] Confirm `docker` job's image build still succeeds end to end (`"$RELEASE_HELPER" build "$FULL_APP_NAME"`).
- [ ] Compare `docker` job matrix wall-clock time against a recent main-branch run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)