### PR TITLE
fix: bound App Registry gRPC dial and fix builder client ID (#539)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -431,6 +431,11 @@ jobs:
     - name: Record build and artifact in App Registry
       if: ${{ github.event.inputs.dry_run == 'false' && vars.APP_REGISTRY_CICD_OPT_IN == 'true' }}
       continue-on-error: true
+      # Defense in depth against a hung dial (e.g. a misconfigured
+      # APP_REGISTRY_ADDRESS pointed at a TLS-only endpoint without a port --
+      # see issue #539): bound the whole step so a connectivity problem fails
+      # fast instead of blocking the release for hours.
+      timeout-minutes: 5
       env:
         APP: ${{ matrix.app }}
         DOMAIN: ${{ matrix.domain }}
@@ -443,9 +448,15 @@ jobs:
         # once the server runs GRPC_AUTH_MODE=oidc every call here fails
         # Unauthenticated -- silently, because this step is
         # continue-on-error (see DEPLOY.md section 4).
+        #
+        # The real Keycloak clients are environment-scoped
+        # (app-registry-builder-dev / app-registry-builder-prod), not a bare
+        # app-registry-builder -- see issue #539. APP_REGISTRY_BUILDER_ENV is
+        # a repository variable selecting which; only "dev" is wired up in
+        # CI today, hence the fallback.
         GRPC_AUTH_MODE: oidc
         GRPC_AUTH_TOKEN_URL: ${{ vars.APP_REGISTRY_AUTH_TOKEN_URL }}
-        GRPC_AUTH_CLIENT_ID: app-registry-builder
+        GRPC_AUTH_CLIENT_ID: app-registry-builder-${{ vars.APP_REGISTRY_BUILDER_ENV || 'dev' }}
         GRPC_AUTH_CLIENT_SECRET: ${{ secrets.APP_REGISTRY_BUILDER_CLIENT_SECRET }}
       run: |
         FULL_APP_NAME="${DOMAIN}-${APP}"
@@ -958,15 +969,18 @@ jobs:
     - name: Record chart artifacts in App Registry
       if: steps.plan.outputs.charts != '' && github.event.inputs.dry_run == 'false' && vars.APP_REGISTRY_CICD_OPT_IN == 'true'
       continue-on-error: true
+      # See the "Record build and artifact in App Registry" step above -- same
+      # hang risk (issue #539), same fix.
+      timeout-minutes: 5
       env:
         CHARTS: ${{ steps.plan.outputs.charts }}
         APP_REGISTRY_ADDRESS: ${{ vars.APP_REGISTRY_ADDRESS }}
         # See the "Record build and artifact in App Registry" step above --
         # same builder credential, same repository-secret placement, same
-        # reason (DEPLOY.md section 4).
+        # reason (DEPLOY.md section 4), same env-scoped client id.
         GRPC_AUTH_MODE: oidc
         GRPC_AUTH_TOKEN_URL: ${{ vars.APP_REGISTRY_AUTH_TOKEN_URL }}
-        GRPC_AUTH_CLIENT_ID: app-registry-builder
+        GRPC_AUTH_CLIENT_ID: app-registry-builder-${{ vars.APP_REGISTRY_BUILDER_ENV || 'dev' }}
         GRPC_AUTH_CLIENT_SECRET: ${{ secrets.APP_REGISTRY_BUILDER_CLIENT_SECRET }}
       run: |
         IDEMPOTENCY_PREFIX="${{ github.run_id }}-${{ github.run_attempt }}"

--- a/libs/go/grpcclient/client.go
+++ b/libs/go/grpcclient/client.go
@@ -7,13 +7,22 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"strconv"
 	"strings"
+	"time"
 
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 )
+
+// defaultDialTimeout bounds the blocking dial (grpc.WithBlock below) when the
+// caller's context carries no deadline of its own. Without this, a dial that
+// can never succeed -- e.g. a plaintext handshake against a TLS-only
+// endpoint -- retries forever instead of failing fast. Override with
+// GRPC_DIAL_TIMEOUT (seconds).
+const defaultDialTimeout = 10 * time.Second
 
 // Client manages gRPC connections
 type Client struct {
@@ -45,6 +54,7 @@ type TLSConfig struct {
 //   - GRPC_TLS_SKIP_VERIFY=false (optional): Disable certificate verification (insecure, dev only)
 //   - GRPC_CA_CERT_PATH=/path/to/ca.crt (optional): Custom CA certificate
 //   - GRPC_TLS_SERVER_NAME=api.example.com (optional): Server name for certificate verification
+//   - GRPC_DIAL_TIMEOUT=10 (optional): Seconds to wait for the initial dial when ctx has no deadline (default 10)
 func NewClient(ctx context.Context, address string, extraOpts ...grpc.DialOption) (*Client, error) {
 	// Load TLS config from environment
 	var tlsConfig *TLSConfig
@@ -90,6 +100,21 @@ func NewClientWithTLS(ctx context.Context, address string, tlsConfig *TLSConfig,
 	opts = append(opts, grpc.WithStatsHandler(otelgrpc.NewClientHandler()))
 	opts = append(opts, extraOpts...)
 	opts = append(opts, grpc.WithBlock())
+
+	// grpc.WithBlock() above means DialContext blocks until connected or ctx
+	// is done. If the caller didn't already bound ctx, apply a default so a
+	// dial that can never succeed fails fast instead of hanging forever.
+	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+		timeout := defaultDialTimeout
+		if v := os.Getenv("GRPC_DIAL_TIMEOUT"); v != "" {
+			if secs, err := strconv.Atoi(v); err == nil && secs > 0 {
+				timeout = time.Duration(secs) * time.Second
+			}
+		}
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
 
 	conn, err := grpc.DialContext(ctx, address, opts...)
 	if err != nil {

--- a/tools/app_registry/DEPLOY.md
+++ b/tools/app_registry/DEPLOY.md
@@ -42,20 +42,16 @@ every call returns `Unauthenticated`.
 | Client ID | Purpose | Config | Needed |
 |---|---|---|---|
 | `app-registry-api` | Names the audience. Never obtains a token. | Client authentication **On**, **all** flows unchecked, no roles | **now** |
-| `app-registry-builder` | CI recording (`ReconcileApps`, `RecordBuild`, `RecordArtifact`) | Confidential, **Service accounts roles** only, realm role `app-registry-builder`, audience mapper → `app-registry-api` | **now** |
+| `app-registry-builder-dev` / `app-registry-builder-prod` | CI recording (`ReconcileApps`, `RecordBuild`, `RecordArtifact`) | Confidential, **Service accounts roles** only, both assigned the single `app-registry-builder` realm role, audience mapper → `app-registry-api` | **now** |
 
-> **Do not split `app-registry-builder` per environment.** Unlike the promoter
-> clients below, recording (`RecordBuild`/`RecordArtifact`) has no
-> environment concept — `release.yml` runs it once per release, before any
-> promotion decision exists, against the single `APP_REGISTRY_ADDRESS`. There
-> is exactly one `app-registry-builder` client and one `app-registry-builder`
-> realm role (`server/auth/auth.go`'s `RoleBuilder`); creating
-> `app-registry-builder-dev` / `-prod` variants has no corresponding code path
-> to select between them and will just leave `release.yml`'s
-> `GRPC_AUTH_CLIENT_ID: app-registry-builder` unable to authenticate. If a
-> per-environment split is ever needed here, it requires a code change in
-> this repo (an environment input to the recording steps) first — do not
-> introduce the split Keycloak-side alone.
+> **Builder clients are environment-scoped, like the promoter clients below**
+> (issue #539). `release.yml`'s recording steps set
+> `GRPC_AUTH_CLIENT_ID: app-registry-builder-${{ vars.APP_REGISTRY_BUILDER_ENV || 'dev' }}`
+> — `APP_REGISTRY_BUILDER_ENV` is a repository variable selecting which
+> builder identity CI authenticates as. Only `dev` is wired up in CI today
+> (hence the fallback); set the repository variable and provision the
+> matching realm role/client before pointing `APP_REGISTRY_ADDRESS` at a prod
+> registry.
 | `app-registry-admin` | `EnvironmentRegistry`, `SetAppStatus` | Same shape, realm role `app-registry-admin` | **now** |
 | `app-registry-promoter-dev` | Promote to `dev` (via `promote.yml`) | Same shape, realm role `app-registry-promoter-dev` | **now** — needed before `promote.yml` can run against `dev` |
 | `app-registry-promoter-stage` | Promote to `stage` (via `promote.yml`) | Same shape, realm role `app-registry-promoter-stage` | **now** — needed before `promote.yml` can run against `stage` |
@@ -103,7 +99,7 @@ mistakes are both invisible until you look at a decoded token.
 TOKEN=$(curl -s -X POST \
   https://<host>/realms/<realm>/protocol/openid-connect/token \
   -d grant_type=client_credentials \
-  -d client_id=app-registry-builder \
+  -d client_id=app-registry-builder-dev \
   -d client_secret=<secret> | jq -r .access_token)
 
 echo "$TOKEN" | cut -d. -f2 | base64 -d 2>/dev/null | jq '{sub, aud, realm_access}'
@@ -183,7 +179,7 @@ Client-side variables the CLI reads (see [ENV.md](ENV.md)):
 |---|---|
 | `GRPC_AUTH_MODE` | `oidc` — must match the server |
 | `GRPC_AUTH_TOKEN_URL` | `https://<host>/realms/<realm>/protocol/openid-connect/token` |
-| `GRPC_AUTH_CLIENT_ID` | `app-registry-builder` (recording) or `app-registry-promoter-<environment>` (promotion) |
+| `GRPC_AUTH_CLIENT_ID` | `app-registry-builder-<APP_REGISTRY_BUILDER_ENV, default dev>` (recording) or `app-registry-promoter-<environment>` (promotion) |
 | `GRPC_AUTH_CLIENT_SECRET` | that client's secret |
 
 ### Where each secret goes
@@ -213,9 +209,10 @@ Repository *variables* (not secrets):
 
 | Variable | Value |
 |---|---|
-| `APP_REGISTRY_ADDRESS` | the API's ingress host:port |
+| `APP_REGISTRY_ADDRESS` | the API's ingress host:port — **must include the port** (e.g. `dev-app-registry.whalenet.dev:443`); `libs/go/grpcclient`'s TLS auto-detect only fires on `:443` or an `https://` prefix, so a bare hostname dials plaintext against a TLS-only ingress and hangs (issue #539) |
 | `APP_REGISTRY_AUTH_TOKEN_URL` | the Keycloak token endpoint, e.g. `https://<host>/realms/<realm>/protocol/openid-connect/token` — same for every client, so it is a variable, not a secret |
 | `APP_REGISTRY_CICD_OPT_IN` | `true` to enable recording — see below |
+| `APP_REGISTRY_BUILDER_ENV` | which builder client `release.yml` authenticates as: `dev` or `prod`, matching a provisioned `app-registry-builder-<env>` client. Falls back to `dev` when unset — only `dev` is wired up in CI today. |
 
 ---
 

--- a/tools/app_registry/ENV.md
+++ b/tools/app_registry/ENV.md
@@ -91,12 +91,22 @@ placement rationale:
 |---|---|---|---|
 | `vars.APP_REGISTRY_ADDRESS` | Repository variable | `APP_REGISTRY_ADDRESS` | both |
 | `vars.APP_REGISTRY_AUTH_TOKEN_URL` | Repository variable | `GRPC_AUTH_TOKEN_URL` | both |
-| `secrets.APP_REGISTRY_BUILDER_CLIENT_SECRET` | Repository secret | `GRPC_AUTH_CLIENT_SECRET` (`GRPC_AUTH_CLIENT_ID=app-registry-builder`) | `release.yml` recording steps only |
+| `vars.APP_REGISTRY_BUILDER_ENV` | Repository variable | `GRPC_AUTH_CLIENT_ID=app-registry-builder-<value>`, falls back to `dev` when unset | `release.yml` recording steps only |
+| `secrets.APP_REGISTRY_BUILDER_CLIENT_SECRET` | Repository secret | `GRPC_AUTH_CLIENT_SECRET` | `release.yml` recording steps only |
 | `secrets.APP_REGISTRY_PROMOTER_CLIENT_SECRET` | Environment secret, one per GitHub Environment (e.g. `promotion-dev`/`promotion-prod`) | `GRPC_AUTH_CLIENT_SECRET` (`GRPC_AUTH_CLIENT_ID=app-registry-promoter-<registry_environment>`) | `promote.yml` only |
 
 `GRPC_AUTH_MODE=oidc` is hardcoded in both workflows rather than read from a
 variable — the CLI must match whatever the server runs, and the server is
 expected to run `oidc` in every environment these workflows target.
+
+`vars.APP_REGISTRY_ADDRESS` must include the port (e.g.
+`dev-app-registry.whalenet.dev:443`) — `libs/go/grpcclient`'s TLS
+auto-detect (`shouldUseTLS`) only enables TLS when the address contains
+`:443` or starts with `https://`; a bare hostname dials plaintext against a
+TLS-only ingress and fails to connect (see issue #539). The Keycloak
+clients backing the builder credential are environment-scoped
+(`app-registry-builder-dev` / `app-registry-builder-prod`, mirroring the
+promoter clients) — there is no bare `app-registry-builder` client.
 
 ## Temporal (`libs/go/temporal`)
 


### PR DESCRIPTION
## Summary
- Fixes #539: the "Record build and artifact in App Registry" step could hang indefinitely instead of failing fast.
- `libs/go/grpcclient.NewClientWithTLS` dials with `grpc.WithBlock()` and no deadline attached to the context, so a dial that can never succeed (e.g. plaintext handshake against a TLS-only ingress) retries forever. Added a default 10s dial timeout (only applied when the caller's context has no existing deadline), overridable via `GRPC_DIAL_TIMEOUT`. This is a shared-library fix so it also protects other callers (`tools/app_registry/worker`, `manmanv2/ui`) that pass unbounded contexts.
- Added `timeout-minutes: 5` to both App Registry recording steps in `release.yml` as defense in depth.
- `GRPC_AUTH_CLIENT_ID` was hardcoded to `app-registry-builder`, which has no corresponding Keycloak client — the real clients are environment-scoped (`app-registry-builder-dev` / `app-registry-builder-prod`), mirroring the promoter clients. Parameterized via a new `APP_REGISTRY_BUILDER_ENV` repo variable: `app-registry-builder-${{ vars.APP_REGISTRY_BUILDER_ENV || 'dev' }}`, falling back to `dev` since that's the only builder environment currently provisioned in CI.
- Updated `DEPLOY.md` / `ENV.md` to match (including removing the now-stale "do not split app-registry-builder per environment" guidance, which this PR implements).

## Not done here (repo owner action required)
- `APP_REGISTRY_ADDRESS` repo variable still needs `:443` appended (e.g. `dev-app-registry.whalenet.dev:443`) so `shouldUseTLS()` auto-detects TLS. Left to the repo owner — this is shared CI state, not code.
- `APP_REGISTRY_BUILDER_ENV` repo variable should be set to `dev` to match the current environment (the workflow already falls back to `dev` if unset, so this is optional but makes it explicit).

## Test plan
- [x] `bazel build //libs/go/grpcclient/... //tools/app_registry/cli/...`
- [x] `bazel test //libs/go/grpcclient/... //tools/app_registry/cli/...`
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"`
- [ ] Real release run records a build + artifact in the dev App Registry successfully (needs the `APP_REGISTRY_ADDRESS` variable fix above first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)