### PR TITLE
fix: reconcile apps/charts in App Registry before recording builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,6 +203,35 @@ jobs:
           fi
         fi
 
+    # Registers/updates every release_app and helm_chart manifest as an
+    # app/chart row in the App Registry, once per release run, before any
+    # per-app "Record build and artifact" step needs to resolve one by
+    # owner_full_name. See tools/app_registry/README.md's recording sequence
+    # diagram: ReconcileApps precedes RecordBuild/RecordArtifact. Without
+    # this, RecordArtifact's owner lookup fails for any app/chart never
+    # reconciled -- surfacing as a bare "invalid argument" from
+    # resolveOwner in server/handlers/artifact.go, since an unresolved owner
+    # is indistinguishable, at that layer, from a genuinely malformed
+    # request.
+    #
+    # Best-effort like the recording steps below: continue-on-error so a
+    # registry outage never fails a release.
+    - name: Reconcile apps/charts in App Registry
+      if: ${{ github.event.inputs.dry_run == 'false' && vars.APP_REGISTRY_CICD_OPT_IN == 'true' }}
+      continue-on-error: true
+      timeout-minutes: 5
+      env:
+        APP_REGISTRY_ADDRESS: ${{ vars.APP_REGISTRY_ADDRESS }}
+        GRPC_AUTH_MODE: oidc
+        GRPC_AUTH_TOKEN_URL: ${{ vars.APP_REGISTRY_AUTH_TOKEN_URL }}
+        GRPC_AUTH_CLIENT_ID: app-registry-builder-${{ vars.APP_REGISTRY_BUILDER_ENV || 'dev' }}
+        GRPC_AUTH_CLIENT_SECRET: ${{ secrets.APP_REGISTRY_BUILDER_CLIENT_SECRET }}
+      run: |
+        "$RELEASE_HELPER" manifest-set --git-sha "${{ github.sha }}" > "$RUNNER_TEMP/manifest-set.json"
+        "$APP_REGISTRY_CLI" apps reconcile \
+          --from-plan "$RUNNER_TEMP/manifest-set.json" \
+          --idempotency-key "${{ github.run_id }}-${{ github.run_attempt }}-reconcile"
+
   # Plan which apps need OpenAPI spec builds
   plan-openapi-builds:
     name: Plan OpenAPI Builds


### PR DESCRIPTION
## Summary
- Follow-up to #540 (issue #539). Fixing the gRPC dial hang and client ID let CI finally reach `RecordBuild`/`RecordArtifact`, which surfaced a separate, pre-existing gap: `release.yml` never called `ReconcileApps` to register apps/charts in the registry before recording builds against them.
- `resolveOwner` (`tools/app_registry/server/handlers/artifact.go:145-158`) returns the bare `repository.ErrInvalidArgument` — no message — when `GetAppByFullName`/`GetChartByFullName` can't find the owner. That surfaced in CI as a contentless `rpc error: code = InvalidArgument desc = invalid argument` on every app's `artifacts record` call, since none of them had ever been reconciled into the registry.
- Added a one-time "Reconcile apps/charts in App Registry" step to the `plan-release` job (runs once, before the per-app matrix), piping `release_helper_go manifest-set` into `app-registry apps reconcile` — matching the recording sequence documented in `tools/app_registry/README.md` (`ReconcileApps` precedes `RecordBuild`/`RecordArtifact`).
- Same gating/shape as the existing recording steps: `dry_run == false`, `APP_REGISTRY_CICD_OPT_IN == 'true'`, `continue-on-error: true`, `timeout-minutes: 5`.

## Verification
Reproduced against the real dev App Registry:
1. Confirmed `builds record` was actually succeeding in CI (idempotency replay proved it), narrowing the failure to `artifacts record`.
2. Ran `release_helper_go manifest-set` + `app-registry apps reconcile --from-plan ...` locally against dev — registered all 32 apps / 12 charts.
3. Re-ran the previously-failing `artifacts record` call for `app-registry-cli` — succeeded immediately after reconcile.

## Test plan
- [x] `bazel build //tools/release_helper_go/... //tools/app_registry/cli/...`
- [x] YAML validated
- [x] Manually reproduced root cause and fix against the real dev App Registry (see above)
- [ ] Next real release run completes the recording steps cleanly end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)