### PR TITLE
refactor: reusable App Registry CI actions; reconcile on main push, not release

### DIFF
--- a/.github/actions/app-registry-auth/action.yml
+++ b/.github/actions/app-registry-auth/action.yml
@@ -1,0 +1,41 @@
+name: 'App Registry Auth'
+description: >-
+  Exports the APP_REGISTRY_ADDRESS / GRPC_AUTH_* env vars the app-registry
+  CLI reads for OIDC service-account auth (see tools/app_registry/ENV.md).
+  Every step in this repo that calls the App Registry needs the same five
+  vars; this collapses that duplication into one place so a future
+  non-release workflow (e.g. recording builds on every main push, not just
+  tagged releases) can reuse it too instead of re-copying the block.
+
+inputs:
+  address:
+    description: 'app-registry-api address (host:port) -- typically vars.APP_REGISTRY_ADDRESS'
+    required: true
+  token-url:
+    description: 'Keycloak token endpoint -- typically vars.APP_REGISTRY_AUTH_TOKEN_URL'
+    required: true
+  client-id:
+    description: 'Keycloak client id, e.g. app-registry-builder-dev or app-registry-promoter-prod'
+    required: true
+  client-secret:
+    description: 'Keycloak client secret for client-id'
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Export App Registry auth env
+      shell: bash
+      env:
+        ADDRESS: ${{ inputs.address }}
+        TOKEN_URL: ${{ inputs.token-url }}
+        CLIENT_ID: ${{ inputs.client-id }}
+        CLIENT_SECRET: ${{ inputs.client-secret }}
+      run: |
+        {
+          echo "APP_REGISTRY_ADDRESS=$ADDRESS"
+          echo "GRPC_AUTH_MODE=oidc"
+          echo "GRPC_AUTH_TOKEN_URL=$TOKEN_URL"
+          echo "GRPC_AUTH_CLIENT_ID=$CLIENT_ID"
+          echo "GRPC_AUTH_CLIENT_SECRET=$CLIENT_SECRET"
+        } >> "$GITHUB_ENV"

--- a/.github/actions/app-registry-reconcile/action.yml
+++ b/.github/actions/app-registry-reconcile/action.yml
@@ -1,0 +1,50 @@
+name: 'App Registry: Reconcile Apps/Charts'
+description: >-
+  Discovers every release_app/helm_chart manifest via `release_helper_go
+  manifest-set` and reconciles it into the App Registry via
+  `app-registry apps reconcile`, registering any app/chart the registry
+  doesn't know about yet. Must run before any RecordBuild/RecordArtifact
+  call that resolves an owner by full name -- see
+  tools/app_registry/README.md's recording sequence diagram. Skipping this
+  makes RecordArtifact's owner lookup fail with a bare, contextless
+  InvalidArgument for any never-reconciled app/chart (see issue #539 and
+  its follow-up, #542).
+
+  Requires RELEASE_HELPER and APP_REGISTRY_CLI env vars already set (see
+  .github/actions/download-release-tools).
+
+inputs:
+  address:
+    required: true
+  token-url:
+    required: true
+  client-id:
+    required: true
+  client-secret:
+    required: true
+  git-sha:
+    description: 'Commit SHA to record on the manifest set -- typically github.sha'
+    required: true
+  idempotency-key:
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - uses: ./.github/actions/app-registry-auth
+      with:
+        address: ${{ inputs.address }}
+        token-url: ${{ inputs.token-url }}
+        client-id: ${{ inputs.client-id }}
+        client-secret: ${{ inputs.client-secret }}
+
+    - name: Reconcile apps/charts
+      shell: bash
+      env:
+        GIT_SHA: ${{ inputs.git-sha }}
+        IDEMPOTENCY_KEY: ${{ inputs.idempotency-key }}
+      run: |
+        "$RELEASE_HELPER" manifest-set --git-sha "$GIT_SHA" > "$RUNNER_TEMP/manifest-set.json"
+        "$APP_REGISTRY_CLI" apps reconcile \
+          --from-plan "$RUNNER_TEMP/manifest-set.json" \
+          --idempotency-key "$IDEMPOTENCY_KEY"

--- a/.github/actions/app-registry-record-build/action.yml
+++ b/.github/actions/app-registry-record-build/action.yml
@@ -1,0 +1,69 @@
+name: 'App Registry: Record Build'
+description: >-
+  Records (or idempotently replays) the Build row for one CI run via
+  `app-registry builds record`. One Build row represents one workflow run,
+  not one app -- callers that pass the same idempotency-key (workflow run
+  id + attempt) safely collapse onto the same row and get the same
+  build-id back, which is how release.yml's per-app matrix jobs all attach
+  their artifacts to a single build.
+
+  Requires APP_REGISTRY_CLI env var already set (see
+  .github/actions/download-release-tools).
+
+inputs:
+  address:
+    required: true
+  token-url:
+    required: true
+  client-id:
+    required: true
+  client-secret:
+    required: true
+  git-sha:
+    required: true
+  git-ref:
+    required: true
+  workflow-run-id:
+    required: true
+  workflow-attempt:
+    required: true
+  actor:
+    required: true
+  idempotency-key:
+    required: true
+
+outputs:
+  build-id:
+    description: 'The recorded (or replayed) build_id'
+    value: ${{ steps.record.outputs.build-id }}
+
+runs:
+  using: composite
+  steps:
+    - uses: ./.github/actions/app-registry-auth
+      with:
+        address: ${{ inputs.address }}
+        token-url: ${{ inputs.token-url }}
+        client-id: ${{ inputs.client-id }}
+        client-secret: ${{ inputs.client-secret }}
+
+    - name: Record build
+      id: record
+      shell: bash
+      env:
+        GIT_SHA: ${{ inputs.git-sha }}
+        GIT_REF: ${{ inputs.git-ref }}
+        WORKFLOW_RUN_ID: ${{ inputs.workflow-run-id }}
+        WORKFLOW_ATTEMPT: ${{ inputs.workflow-attempt }}
+        ACTOR: ${{ inputs.actor }}
+        IDEMPOTENCY_KEY: ${{ inputs.idempotency-key }}
+      run: |
+        BUILD_JSON=$("$APP_REGISTRY_CLI" builds record \
+          --git-sha "$GIT_SHA" \
+          --git-ref "$GIT_REF" \
+          --workflow-run-id "$WORKFLOW_RUN_ID" \
+          --workflow-attempt "$WORKFLOW_ATTEMPT" \
+          --actor "$ACTOR" \
+          --idempotency-key "$IDEMPOTENCY_KEY")
+        BUILD_ID=$(echo "$BUILD_JSON" | jq -r '.build.buildId')
+        echo "build-id=$BUILD_ID" >> "$GITHUB_OUTPUT"

--- a/.github/actions/app-registry-record-image/action.yml
+++ b/.github/actions/app-registry-record-image/action.yml
@@ -1,0 +1,69 @@
+name: 'App Registry: Record Image Artifact'
+description: >-
+  Resolves a pushed image tag's digest via `docker buildx imagetools
+  inspect` and records it as an Artifact via `app-registry artifacts
+  record`. Skips (does not fail) if the digest can't be resolved yet,
+  matching release.yml's existing best-effort recording behavior.
+
+  Requires APP_REGISTRY_CLI env var already set (see
+  .github/actions/download-release-tools), and registry auth already
+  configured (e.g. docker/login-action) for repository.
+
+inputs:
+  address:
+    required: true
+  token-url:
+    required: true
+  client-id:
+    required: true
+  client-secret:
+    required: true
+  build-id:
+    required: true
+  owner-full-name:
+    description: '<domain>-<name>, e.g. manmanv2-host-manager'
+    required: true
+  repository:
+    description: 'Full image repository, e.g. ghcr.io/whale-net/manmanv2-host-manager'
+    required: true
+  version:
+    required: true
+  idempotency-key:
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - uses: ./.github/actions/app-registry-auth
+      with:
+        address: ${{ inputs.address }}
+        token-url: ${{ inputs.token-url }}
+        client-id: ${{ inputs.client-id }}
+        client-secret: ${{ inputs.client-secret }}
+
+    - name: Resolve digest and record artifact
+      shell: bash
+      env:
+        BUILD_ID: ${{ inputs.build-id }}
+        OWNER: ${{ inputs.owner-full-name }}
+        REPOSITORY: ${{ inputs.repository }}
+        VERSION: ${{ inputs.version }}
+        IDEMPOTENCY_KEY: ${{ inputs.idempotency-key }}
+      run: |
+        echo "Resolving digest for ${REPOSITORY}:${VERSION}..."
+        DIGEST=$(docker buildx imagetools inspect "${REPOSITORY}:${VERSION}" | awk '/^Digest:/ {print $2; exit}')
+        if [[ -z "$DIGEST" ]]; then
+          echo "::warning::Could not resolve digest for ${REPOSITORY}:${VERSION}; skipping App Registry recording"
+          exit 0
+        fi
+
+        "$APP_REGISTRY_CLI" artifacts record \
+          --build-id "$BUILD_ID" \
+          --kind image \
+          --owner "$OWNER" \
+          --repository "$REPOSITORY" \
+          --version "$VERSION" \
+          --digest "$DIGEST" \
+          --idempotency-key "$IDEMPOTENCY_KEY"
+
+        echo "✅ Recorded ${OWNER} ${VERSION} (${DIGEST}) in App Registry"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,12 +8,13 @@ on:
     branches: [ main ]
 
 jobs:
-  # Build release_helper_go once and share it via upload-artifact/download-
-  # artifact (see .github/actions/download-release-tools) instead of every
-  # job that needs it -- plan-docker, and every leg of the docker matrix --
-  # rebuilding it from source independently. ci-images (not ci-release):
-  # these are throwaway CI-only Docker builds, never pushed, so there's no
-  # "must not read from a possibly-stale cache" concern the way there is for
+  # Build release_helper_go (and, for the main-only reconcile job below, the
+  # app-registry CLI) once and share via upload-artifact/download-artifact
+  # (see .github/actions/download-release-tools) instead of every job that
+  # needs one -- plan-docker, every leg of the docker matrix, reconcile --
+  # rebuilding from source independently. ci-images (not ci-release): these
+  # are throwaway CI-only Docker builds, never pushed, so there's no "must
+  # not read from a possibly-stale cache" concern the way there is for
   # release.yml's actual published artifacts -- cache reads are pure upside
   # here. No `needs:` -- runs in parallel with the test jobs below.
   build-release-tools:
@@ -31,12 +32,15 @@ jobs:
         bazel-remote-cache-user: ${{ secrets.BAZEL_REMOTE_CACHE_USER }}
         bazel-remote-cache-password: ${{ secrets.BAZEL_REMOTE_CACHE_PASSWORD }}
 
-    - name: Build release_helper_go
+    - name: Build release_helper_go and app-registry CLI
       run: |
-        bazel build --config=ci-images //tools/release_helper_go:release_helper_go
+        bazel build --config=ci-images \
+          //tools/release_helper_go:release_helper_go \
+          //tools/app_registry/cli:app-registry
         BAZEL_BIN="$(bazel info bazel-bin --config=ci-images)"
         mkdir -p /tmp/release-tools
         cp "$BAZEL_BIN/tools/release_helper_go/release_helper_go_/release_helper_go" /tmp/release-tools/release_helper_go
+        cp "$BAZEL_BIN/tools/app_registry/cli/app-registry_/app-registry" /tmp/release-tools/app-registry
         bazel shutdown
 
     - name: Upload release tools artifact
@@ -45,6 +49,39 @@ jobs:
         name: release-tools
         path: /tmp/release-tools/
         retention-days: 1
+
+  # Registers/updates every release_app and helm_chart manifest as an
+  # app/chart row in the App Registry. Runs on every push to main only
+  # (never on pull_request, never from release.yml) so it always reconciles
+  # against the current, complete tree -- see ARCHITECTURE.md "Rejected
+  # alternatives" and DEPLOY.md "CI wiring (AR-3d)" for why this can't
+  # safely live in release.yml, which may be dispatched against an
+  # arbitrary, possibly older ref. Best-effort: continue-on-error so a
+  # registry outage never fails main CI.
+  reconcile-app-registry:
+    name: Reconcile apps/charts in App Registry
+    runs-on: ubuntu-latest
+    needs: build-release-tools
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Download release tools
+      uses: ./.github/actions/download-release-tools
+
+    - name: Reconcile apps/charts in App Registry
+      if: ${{ vars.APP_REGISTRY_CICD_OPT_IN == 'true' }}
+      continue-on-error: true
+      timeout-minutes: 5
+      uses: ./.github/actions/app-registry-reconcile
+      with:
+        address: ${{ vars.APP_REGISTRY_ADDRESS }}
+        token-url: ${{ vars.APP_REGISTRY_AUTH_TOKEN_URL }}
+        client-id: app-registry-builder-${{ vars.APP_REGISTRY_BUILDER_ENV || 'dev' }}
+        client-secret: ${{ secrets.APP_REGISTRY_BUILDER_CLIENT_SECRET }}
+        git-sha: ${{ github.sha }}
+        idempotency-key: ${{ github.run_id }}-${{ github.run_attempt }}-reconcile
 
   # # Build job - commented out in favor of merged build+test job below
   # # Uncomment and remove build step from test job to restore separate build/test parallelism

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -113,14 +113,18 @@ jobs:
     # above), never from repository secrets. See DEPLOY.md "Where each
     # secret goes" -- each GitHub Environment holds the promoter client
     # secret matching whatever registry_environment its operators pass.
+    - name: App Registry Auth
+      if: inputs.action == 'promote'
+      uses: ./.github/actions/app-registry-auth
+      with:
+        address: ${{ vars.APP_REGISTRY_ADDRESS }}
+        token-url: ${{ vars.APP_REGISTRY_AUTH_TOKEN_URL }}
+        client-id: app-registry-promoter-${{ inputs.registry_environment }}
+        client-secret: ${{ secrets.APP_REGISTRY_PROMOTER_CLIENT_SECRET }}
+
     - name: Promote
       if: inputs.action == 'promote'
       env:
-        APP_REGISTRY_ADDRESS: ${{ vars.APP_REGISTRY_ADDRESS }}
-        GRPC_AUTH_MODE: oidc
-        GRPC_AUTH_TOKEN_URL: ${{ vars.APP_REGISTRY_AUTH_TOKEN_URL }}
-        GRPC_AUTH_CLIENT_ID: app-registry-promoter-${{ inputs.registry_environment }}
-        GRPC_AUTH_CLIENT_SECRET: ${{ secrets.APP_REGISTRY_PROMOTER_CLIENT_SECRET }}
         ENVIRONMENT: ${{ inputs.registry_environment }}
         OWNER_FULL_NAME: ${{ inputs.owner_full_name }}
         KIND: ${{ inputs.kind }}
@@ -142,14 +146,18 @@ jobs:
 
         bazel run --config=ci //tools/app_registry/cli:app-registry -- "${ARGS[@]}"
 
+    - name: App Registry Auth
+      if: inputs.action == 'rollback'
+      uses: ./.github/actions/app-registry-auth
+      with:
+        address: ${{ vars.APP_REGISTRY_ADDRESS }}
+        token-url: ${{ vars.APP_REGISTRY_AUTH_TOKEN_URL }}
+        client-id: app-registry-promoter-${{ inputs.registry_environment }}
+        client-secret: ${{ secrets.APP_REGISTRY_PROMOTER_CLIENT_SECRET }}
+
     - name: Rollback
       if: inputs.action == 'rollback'
       env:
-        APP_REGISTRY_ADDRESS: ${{ vars.APP_REGISTRY_ADDRESS }}
-        GRPC_AUTH_MODE: oidc
-        GRPC_AUTH_TOKEN_URL: ${{ vars.APP_REGISTRY_AUTH_TOKEN_URL }}
-        GRPC_AUTH_CLIENT_ID: app-registry-promoter-${{ inputs.registry_environment }}
-        GRPC_AUTH_CLIENT_SECRET: ${{ secrets.APP_REGISTRY_PROMOTER_CLIENT_SECRET }}
         ENVIRONMENT: ${{ inputs.registry_environment }}
         OWNER_FULL_NAME: ${{ inputs.owner_full_name }}
         KIND: ${{ inputs.kind }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,34 +203,16 @@ jobs:
           fi
         fi
 
-    # Registers/updates every release_app and helm_chart manifest as an
-    # app/chart row in the App Registry, once per release run, before any
-    # per-app "Record build and artifact" step needs to resolve one by
-    # owner_full_name. See tools/app_registry/README.md's recording sequence
-    # diagram: ReconcileApps precedes RecordBuild/RecordArtifact. Without
-    # this, RecordArtifact's owner lookup fails for any app/chart never
-    # reconciled -- surfacing as a bare "invalid argument" from
-    # resolveOwner in server/handlers/artifact.go, since an unresolved owner
-    # is indistinguishable, at that layer, from a genuinely malformed
-    # request.
-    #
-    # Best-effort like the recording steps below: continue-on-error so a
-    # registry outage never fails a release.
-    - name: Reconcile apps/charts in App Registry
-      if: ${{ github.event.inputs.dry_run == 'false' && vars.APP_REGISTRY_CICD_OPT_IN == 'true' }}
-      continue-on-error: true
-      timeout-minutes: 5
-      env:
-        APP_REGISTRY_ADDRESS: ${{ vars.APP_REGISTRY_ADDRESS }}
-        GRPC_AUTH_MODE: oidc
-        GRPC_AUTH_TOKEN_URL: ${{ vars.APP_REGISTRY_AUTH_TOKEN_URL }}
-        GRPC_AUTH_CLIENT_ID: app-registry-builder-${{ vars.APP_REGISTRY_BUILDER_ENV || 'dev' }}
-        GRPC_AUTH_CLIENT_SECRET: ${{ secrets.APP_REGISTRY_BUILDER_CLIENT_SECRET }}
-      run: |
-        "$RELEASE_HELPER" manifest-set --git-sha "${{ github.sha }}" > "$RUNNER_TEMP/manifest-set.json"
-        "$APP_REGISTRY_CLI" apps reconcile \
-          --from-plan "$RUNNER_TEMP/manifest-set.json" \
-          --idempotency-key "${{ github.run_id }}-${{ github.run_attempt }}-reconcile"
+    # App/chart registration (ReconcileApps) deliberately does NOT run here.
+    # It requires the complete, current manifest set -- anything absent from
+    # what it's given gets flagged MISSING (api.proto's own comment) -- and
+    # this workflow can be dispatched against an arbitrary, possibly old ref
+    # (a hotfix release from an old tag, say). Reconciling that ref's
+    # manifest set would falsely flag every app added since as MISSING.
+    # Reconcile instead runs on every push to main (ci.yml's
+    # "Reconcile apps/charts in App Registry" job), so it only ever sees the
+    # current, complete tree. See ARCHITECTURE.md "Rejected alternatives"
+    # and DEPLOY.md "CI wiring (AR-3d)".
 
   # Plan which apps need OpenAPI spec builds
   plan-openapi-builds:
@@ -457,19 +439,18 @@ jobs:
     # the variable unset (the default), this step is skipped entirely and CI
     # makes no registry calls. continue-on-error so a registry outage never
     # fails a release.
-    - name: Record build and artifact in App Registry
+    - name: Record build in App Registry
       if: ${{ github.event.inputs.dry_run == 'false' && vars.APP_REGISTRY_CICD_OPT_IN == 'true' }}
+      id: app-registry-build
       continue-on-error: true
       # Defense in depth against a hung dial (e.g. a misconfigured
       # APP_REGISTRY_ADDRESS pointed at a TLS-only endpoint without a port --
       # see issue #539): bound the whole step so a connectivity problem fails
       # fast instead of blocking the release for hours.
       timeout-minutes: 5
-      env:
-        APP: ${{ matrix.app }}
-        DOMAIN: ${{ matrix.domain }}
-        VERSION: ${{ matrix.version || needs.plan-release.outputs.version }}
-        APP_REGISTRY_ADDRESS: ${{ vars.APP_REGISTRY_ADDRESS }}
+      uses: ./.github/actions/app-registry-record-build
+      with:
+        address: ${{ vars.APP_REGISTRY_ADDRESS }}
         # Builder credential -- repository secret, deliberately never an
         # Environment secret (see DEPLOY.md "Where each secret goes"): this
         # identity can record builds/artifacts but carries no promoter role,
@@ -483,42 +464,31 @@ jobs:
         # app-registry-builder -- see issue #539. APP_REGISTRY_BUILDER_ENV is
         # a repository variable selecting which; only "dev" is wired up in
         # CI today, hence the fallback.
-        GRPC_AUTH_MODE: oidc
-        GRPC_AUTH_TOKEN_URL: ${{ vars.APP_REGISTRY_AUTH_TOKEN_URL }}
-        GRPC_AUTH_CLIENT_ID: app-registry-builder-${{ vars.APP_REGISTRY_BUILDER_ENV || 'dev' }}
-        GRPC_AUTH_CLIENT_SECRET: ${{ secrets.APP_REGISTRY_BUILDER_CLIENT_SECRET }}
-      run: |
-        FULL_APP_NAME="${DOMAIN}-${APP}"
-        REPOSITORY="ghcr.io/${{ github.repository_owner }}/${FULL_APP_NAME}"
+        token-url: ${{ vars.APP_REGISTRY_AUTH_TOKEN_URL }}
+        client-id: app-registry-builder-${{ vars.APP_REGISTRY_BUILDER_ENV || 'dev' }}
+        client-secret: ${{ secrets.APP_REGISTRY_BUILDER_CLIENT_SECRET }}
+        git-sha: ${{ github.sha }}
+        git-ref: ${{ github.ref }}
+        workflow-run-id: ${{ github.run_id }}
+        workflow-attempt: ${{ github.run_attempt }}
+        actor: ${{ github.actor }}
+        idempotency-key: ${{ github.run_id }}-${{ github.run_attempt }}
 
-        echo "Resolving digest for ${REPOSITORY}:${VERSION}..."
-        DIGEST=$(docker buildx imagetools inspect "${REPOSITORY}:${VERSION}" | awk '/^Digest:/ {print $2; exit}')
-        if [[ -z "$DIGEST" ]]; then
-          echo "::warning::Could not resolve digest for ${REPOSITORY}:${VERSION}; skipping App Registry recording"
-          exit 0
-        fi
-
-        IDEMPOTENCY_PREFIX="${{ github.run_id }}-${{ github.run_attempt }}"
-
-        BUILD_JSON=$("$APP_REGISTRY_CLI" builds record \
-          --git-sha "${{ github.sha }}" \
-          --git-ref "${{ github.ref }}" \
-          --workflow-run-id "${{ github.run_id }}" \
-          --workflow-attempt "${{ github.run_attempt }}" \
-          --actor "${{ github.actor }}" \
-          --idempotency-key "$IDEMPOTENCY_PREFIX")
-        BUILD_ID=$(echo "$BUILD_JSON" | jq -r '.build.buildId')
-
-        "$APP_REGISTRY_CLI" artifacts record \
-          --build-id "$BUILD_ID" \
-          --kind image \
-          --owner "$FULL_APP_NAME" \
-          --repository "$REPOSITORY" \
-          --version "$VERSION" \
-          --digest "$DIGEST" \
-          --idempotency-key "${IDEMPOTENCY_PREFIX}-${FULL_APP_NAME}-image"
-
-        echo "✅ Recorded ${FULL_APP_NAME} ${VERSION} (${DIGEST}) in App Registry"
+    - name: Record image artifact in App Registry
+      if: ${{ github.event.inputs.dry_run == 'false' && vars.APP_REGISTRY_CICD_OPT_IN == 'true' && steps.app-registry-build.outputs.build-id != '' }}
+      continue-on-error: true
+      timeout-minutes: 5
+      uses: ./.github/actions/app-registry-record-image
+      with:
+        address: ${{ vars.APP_REGISTRY_ADDRESS }}
+        token-url: ${{ vars.APP_REGISTRY_AUTH_TOKEN_URL }}
+        client-id: app-registry-builder-${{ vars.APP_REGISTRY_BUILDER_ENV || 'dev' }}
+        client-secret: ${{ secrets.APP_REGISTRY_BUILDER_CLIENT_SECRET }}
+        build-id: ${{ steps.app-registry-build.outputs.build-id }}
+        owner-full-name: ${{ matrix.domain }}-${{ matrix.app }}
+        repository: ghcr.io/${{ github.repository_owner }}/${{ matrix.domain }}-${{ matrix.app }}
+        version: ${{ matrix.version || needs.plan-release.outputs.version }}
+        idempotency-key: ${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.domain }}-${{ matrix.app }}-image
 
     - name: Generate release notes for app
       if: ${{ github.event.inputs.dry_run == 'false' }}
@@ -995,33 +965,48 @@ jobs:
     # the chart have been pushed — see ARCHITECTURE.md "Chart -> image
     # lockfile" for why that resolution can't happen inside the hermetic
     # Bazel action that composes the chart.
-    - name: Record chart artifacts in App Registry
+    - name: Record chart build in App Registry
       if: steps.plan.outputs.charts != '' && github.event.inputs.dry_run == 'false' && vars.APP_REGISTRY_CICD_OPT_IN == 'true'
+      id: app-registry-build
       continue-on-error: true
-      # See the "Record build and artifact in App Registry" step above -- same
-      # hang risk (issue #539), same fix.
+      # See the "Record build in App Registry" step above -- same hang risk
+      # (issue #539), same fix.
+      timeout-minutes: 5
+      uses: ./.github/actions/app-registry-record-build
+      with:
+        address: ${{ vars.APP_REGISTRY_ADDRESS }}
+        # See the "Record build in App Registry" step above -- same builder
+        # credential, same repository-secret placement, same reason
+        # (DEPLOY.md section 4), same env-scoped client id.
+        token-url: ${{ vars.APP_REGISTRY_AUTH_TOKEN_URL }}
+        client-id: app-registry-builder-${{ vars.APP_REGISTRY_BUILDER_ENV || 'dev' }}
+        client-secret: ${{ secrets.APP_REGISTRY_BUILDER_CLIENT_SECRET }}
+        git-sha: ${{ github.sha }}
+        git-ref: ${{ github.ref }}
+        workflow-run-id: ${{ github.run_id }}
+        workflow-attempt: ${{ github.run_attempt }}
+        actor: ${{ github.actor }}
+        idempotency-key: ${{ github.run_id }}-${{ github.run_attempt }}
+
+    - name: Record chart artifacts in App Registry
+      if: steps.plan.outputs.charts != '' && github.event.inputs.dry_run == 'false' && vars.APP_REGISTRY_CICD_OPT_IN == 'true' && steps.app-registry-build.outputs.build-id != ''
+      continue-on-error: true
+      # See the "Record build in App Registry" step above -- same hang risk
+      # (issue #539), same fix.
       timeout-minutes: 5
       env:
         CHARTS: ${{ steps.plan.outputs.charts }}
         APP_REGISTRY_ADDRESS: ${{ vars.APP_REGISTRY_ADDRESS }}
-        # See the "Record build and artifact in App Registry" step above --
-        # same builder credential, same repository-secret placement, same
-        # reason (DEPLOY.md section 4), same env-scoped client id.
+        # See the "Record build in App Registry" step above -- same builder
+        # credential, same repository-secret placement, same reason
+        # (DEPLOY.md section 4), same env-scoped client id.
         GRPC_AUTH_MODE: oidc
         GRPC_AUTH_TOKEN_URL: ${{ vars.APP_REGISTRY_AUTH_TOKEN_URL }}
         GRPC_AUTH_CLIENT_ID: app-registry-builder-${{ vars.APP_REGISTRY_BUILDER_ENV || 'dev' }}
         GRPC_AUTH_CLIENT_SECRET: ${{ secrets.APP_REGISTRY_BUILDER_CLIENT_SECRET }}
+        BUILD_ID: ${{ steps.app-registry-build.outputs.build-id }}
       run: |
         IDEMPOTENCY_PREFIX="${{ github.run_id }}-${{ github.run_attempt }}"
-
-        BUILD_JSON=$("$APP_REGISTRY_CLI" builds record \
-          --git-sha "${{ github.sha }}" \
-          --git-ref "${{ github.ref }}" \
-          --workflow-run-id "${{ github.run_id }}" \
-          --workflow-attempt "${{ github.run_attempt }}" \
-          --actor "${{ github.actor }}" \
-          --idempotency-key "$IDEMPOTENCY_PREFIX")
-        BUILD_ID=$(echo "$BUILD_JSON" | jq -r '.build.buildId')
 
         IFS=' ' read -ra CHART_ARRAY <<< "$CHARTS"
         for CHART in "${CHART_ARRAY[@]}"; do

--- a/tools/app_registry/ARCHITECTURE.md
+++ b/tools/app_registry/ARCHITECTURE.md
@@ -440,6 +440,7 @@ when the opt-in is off, or a registry outage becomes a release outage.
 | Version source of truth | registry (AR-5), tags retained | tags only | A unique constraint beats `git tag --sort` plus a CI concurrency group for concurrent allocation. |
 | Manifest schema | shared `//tools/appmeta/proto` | registry-local manifest messages | Two hand-written Go structs already decode the manifest JSON and had drifted; a third would compound it. |
 | Manifest schema | proto + `protojson` | shared hand-written Go struct | `protojson` reads the existing snake_case JSON unchanged, and `DiscardUnknown: false` turns drift into a test failure. |
+| App/chart registration | `ReconcileApps`, full manifest set, run on push to `main` | a scoped `RegisterApp`/upsert RPC tied to `release.yml`, sending only the apps in that run | Two write paths to the same rows with different invariants. `ReconcileApps` treats its input as the complete truth and flags anything absent as `MISSING` (`api.proto`'s own comment) — a scoped call would either need to skip that check (weakening triage) or would falsely flag every app not in the current release as `MISSING`. It's also unsafe to run at release time at all: `release.yml` can be dispatched against an arbitrary (possibly old) ref, and reconciling an old commit's manifest set would flag every app added since as `MISSING`. Running it on every push to `main` instead means it only ever sees the current, complete tree. See issue #539's follow-up (#542) and DEPLOY.md "CI wiring (AR-3d)". |
 
 ## Future: approval gate
 

--- a/tools/app_registry/DEPLOY.md
+++ b/tools/app_registry/DEPLOY.md
@@ -173,6 +173,32 @@ manifest, deliberately.
 > `promote.yml` (§5 below) exists as of AR-3d too, reading each environment's
 > promoter secret the same way.
 
+These five env vars, and the reconcile/record-build/record-artifact call
+shapes themselves, are duplicated across `release.yml`, `ci.yml`, and
+`promote.yml`. Rather than keep them in sync by hand, they're wired through
+composite actions in `.github/actions/`:
+
+| Action | Wraps |
+|---|---|
+| `app-registry-auth` | Exports the five `APP_REGISTRY_ADDRESS`/`GRPC_AUTH_*` vars from typed inputs. Used directly by `promote.yml`; used internally by the other three below. |
+| `app-registry-reconcile` | `release_helper_go manifest-set` piped into `app-registry apps reconcile`. |
+| `app-registry-record-build` | `app-registry builds record`, outputting `build-id`. |
+| `app-registry-record-image` | Digest resolution (`docker buildx imagetools inspect`) + `app-registry artifacts record --kind image`. |
+
+Any future workflow that needs to record into the App Registry should call
+these instead of re-copying the `env:` block or the bash.
+
+**`app-registry-reconcile` runs from `ci.yml`, not `release.yml`.** It's a
+`build-release-tools` → `reconcile-app-registry` job pair gated
+`if: github.event_name == 'push' && github.ref == 'refs/heads/main'`, so it
+only ever fires once per merge to `main`, against that merge's exact tree.
+It deliberately does **not** run as part of a release: `release.yml` is a
+`workflow_dispatch` that can target any ref, including an old tag for a
+hotfix, and `ReconcileApps` treats whatever manifest set it's given as the
+complete truth -- reconciling an old commit would flag every app added
+since as `MISSING`. See ARCHITECTURE.md "Rejected alternatives" for the
+scoped-registration alternative this ruled out.
+
 Client-side variables the CLI reads (see [ENV.md](ENV.md)):
 
 | Variable | Value |
@@ -189,7 +215,7 @@ promoting. Getting it wrong defeats the entire credential model.
 
 | Secret | Location | Why |
 |---|---|---|
-| builder client secret (`APP_REGISTRY_BUILDER_CLIENT_SECRET`) | **Repository** secret | Every release job needs it; it grants recording only — wired into `release.yml`'s two recording steps |
+| builder client secret (`APP_REGISTRY_BUILDER_CLIENT_SECRET`) | **Repository** secret | Every release job needs it; it grants recording only — wired into `release.yml`'s reconcile/build/artifact recording steps, each a call to one of the `.github/actions/app-registry-*` composite actions (see below) |
 | `app-registry-promoter-prod` secret (`APP_REGISTRY_PROMOTER_CLIENT_SECRET`) | **Environment** secret on the `prod` GitHub Environment | Only a job declaring `environment: prod` can read it, and that declaration triggers the environment's required reviewers — `promote.yml` declares `environment: ${{ inputs.environment }}` for exactly this reason |
 | `app-registry-promoter-stage` / `-dev` (`APP_REGISTRY_PROMOTER_CLIENT_SECRET`) | Environment secret on the matching Environment, same secret name, different Environment | Same, per environment — the Environment scoping is what selects the right client, not the secret name |
 | admin client secret | Not in GitHub | Human-operated; keep it out of CI entirely |

--- a/tools/app_registry/README.md
+++ b/tools/app_registry/README.md
@@ -53,19 +53,36 @@ promote, rather than every image ever pushed.
 
 ## Flows
 
+### Reconcile (CI, every push to `main`, decoupled from release)
+
+`ReconcileApps` needs the complete, current manifest set -- anything absent
+from what it's given gets flagged `MISSING` -- so it runs from `ci.yml` on
+every push to `main`, never from `release.yml`, which can be dispatched
+against an arbitrary (possibly older) ref. See ARCHITECTURE.md "Rejected
+alternatives" for why a release-scoped registration call was ruled out.
+
+```mermaid
+sequenceDiagram
+    participant GHA as GitHub Actions (ci.yml, push to main)
+    participant RH as release_helper_go
+    participant REG as app-registry-api
+    participant DB as Postgres
+
+    GHA->>RH: manifest-set (bazel query release_app/helm_chart_metadata)
+    RH-->>GHA: full AppManifestSet
+    GHA->>REG: ReconcileApps(manifests, git_sha)
+    REG->>DB: upsert apps/charts, flag absent as MISSING
+    Note over GHA,REG: best-effort — a registry failure warns,<br/>it does not fail CI
+```
+
 ### Recording (CI, additive and non-blocking)
 
 ```mermaid
 sequenceDiagram
     participant GHA as GitHub Actions
-    participant RH as release_helper_go
     participant REG as app-registry-api
-    participant DB as Postgres
     participant GHCR as GHCR / Helm OCI
 
-    GHA->>RH: plan (bazel query release_app)
-    RH->>REG: ReconcileApps(manifests, git_sha)
-    REG->>DB: upsert apps/charts, flag absent as MISSING
     GHA->>REG: RecordBuild(git_sha, run_id, attempt)
     GHA->>GHCR: push image
     GHCR-->>GHA: digest
@@ -75,6 +92,9 @@ sequenceDiagram
     Note over GHA,REG: best-effort — a registry failure warns,<br/>it does not fail the release
     GHA->>GHA: git tag (still authoritative until AR-5)
 ```
+
+Recording assumes the app/chart being recorded was already reconciled by a
+prior push to `main` — see "Reconcile" above.
 
 ### Promotion and writeback
 


### PR DESCRIPTION
## Summary
- Extracts the duplicated App Registry auth env block and reconcile/record-build/record-artifact call shapes (duplicated across `release.yml` twice and `promote.yml`) into composite actions: `app-registry-auth`, `app-registry-reconcile`, `app-registry-record-build`, `app-registry-record-image`. Any future workflow that needs to talk to the registry (e.g. a build-on-main path) reuses these instead of re-copying bash.
- Moves the `ReconcileApps` call out of `release.yml` entirely and into a new `reconcile-app-registry` job in `ci.yml`, gated to `push` on `main` only.

## Why move reconcile off release.yml
`ReconcileApps` treats whatever manifest set it's given as the complete truth — anything absent from it gets flagged `MISSING` (`api.proto`'s own comment). `release.yml` is a `workflow_dispatch` that can be run against an arbitrary ref, including an old tag for a hotfix. Reconciling at release time against a stale commit would falsely flag every app added since that commit as `MISSING` — a real correctness hazard (triage noise, and a path to accidentally archiving a still-active app, per `ARCHITECTURE.md`'s MISSING/ARCHIVED lifecycle).

Running reconcile on every push to `main` instead means it only ever sees the current, complete tree, decoupled from *when* something happens to get released. `ci.yml`'s `build-release-tools` job now also builds the `app-registry` CLI (previously only `release_helper_go`) so the new job has what it needs.

Also documented the alternative we discussed and rejected — a release-scoped register/upsert RPC that would only touch apps in that run — in `ARCHITECTURE.md`'s "Rejected alternatives" table: it would require either a second write path with different invariants, or (if just a filtered `ReconcileApps` call) would falsely flag every un-released app as `MISSING`.

## Test plan
- [x] `bazel build //tools/release_helper_go/... //tools/app_registry/cli/...`
- [x] YAML validated for all touched workflows/actions
- [ ] Next push to `main` runs `reconcile-app-registry` cleanly
- [ ] Next release run no longer includes a reconcile step and still records builds/artifacts successfully (relies on the prior push's reconcile having already run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)