### PR TITLE
ci: serialize app-registry reconcile with a concurrency group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,17 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-release-tools
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    # Serializes reconcile runs so an older main push's ReconcileApps call
+    # gets cancelled instead of racing a newer one. This job only runs on
+    # push-to-main (see `if:` above), so a constant group -- not one keyed
+    # on ref/workflow -- is what serializes across runs, matching intent.
+    # Partial mitigation only: a manually re-run older workflow run gets
+    # fresh queue timing (not the original push's chronological position),
+    # and an RPC already in flight when cancellation lands still completes.
+    # The real fix is a server-side monotonic ordering guard -- see #545.
+    concurrency:
+      group: app-registry-reconcile
+      cancel-in-progress: true
     steps:
     - name: Checkout code
       uses: actions/checkout@v4


### PR DESCRIPTION
## What changed

Adds a job-level `concurrency:` block to `reconcile-app-registry` in `.github/workflows/ci.yml`:

```yaml
concurrency:
  group: app-registry-reconcile
  cancel-in-progress: true
```

## Why

The job has no `concurrency:` group, so two `main` pushes close together can produce overlapping `ReconcileApps` calls that aren't guaranteed to land in commit order. This groups runs so a newer push's run cancels an older, still-in-progress one — reducing (not eliminating) the common case of two fast successive merges to `main`.

## This is NOT sufficient by itself

Per #546's own caveats, this is a cheap CI-level mitigation only:

- A manually re-run older workflow run gets fresh queue timing at re-run time, not the original push's chronological position, so it isn't caught by this.
- If an in-flight RPC has already left the runner before a cancellation takes effect, the write still lands.

The real fix is a server-side monotonic ordering guard on `ReconcileApps`/`Reconcile()` — tracked in #545. This PR is only the ~5-line CI mitigation called out as worth doing independently.

## Judgement calls

- **Group name is a constant (`app-registry-reconcile`), not keyed on ref/workflow.** The job's `if:` already restricts it to `github.event_name == 'push' && github.ref == 'refs/heads/main'`, so it only ever runs in one context — a constant group is exactly what serializes across those runs, matching the issue's suggested fix.
- **Checked for group-name collisions**: `release.yml` has a workflow-level `concurrency: { group: release, cancel-in-progress: false }` (workflow_dispatch only, distinct name, no overlap). `promote.yml` has no `concurrency:` block. No conflicts.
- Added a YAML comment above the block spelling out the partial-mitigation caveats and pointing at #545, so the limitation is visible in the workflow file itself, not just in this PR description.

## Verification

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` parses cleanly.
- `git diff` is an 11-line addition only — no other changes to the file.

Closes #546

🤖 Generated with [Claude Code](https://claude.com/claude-code)