### PR TITLE
fix(app-registry): identify the missing owner in resolveOwner's InvalidArgument

### DIFF
--- a/.github/actions/app-registry-reconcile/action.yml
+++ b/.github/actions/app-registry-reconcile/action.yml
@@ -6,9 +6,9 @@ description: >-
   doesn't know about yet. Must run before any RecordBuild/RecordArtifact
   call that resolves an owner by full name -- see
   tools/app_registry/README.md's recording sequence diagram. Skipping this
-  makes RecordArtifact's owner lookup fail with a bare, contextless
-  InvalidArgument for any never-reconciled app/chart (see issue #539 and
-  its follow-up, #542).
+  makes RecordArtifact's owner lookup fail with an InvalidArgument naming
+  the never-reconciled app/chart (see issue #539, its follow-up #542, and
+  the error-message fix in #548).
 
   Requires RELEASE_HELPER and APP_REGISTRY_CLI env vars already set (see
   .github/actions/download-release-tools).

--- a/tools/app_registry/OPERATIONS.md
+++ b/tools/app_registry/OPERATIONS.md
@@ -75,8 +75,11 @@ To check whether a specific release actually got recorded:
 4. A step that ran, shows a red `X` inline but the **job** is still green —
    this is the silent-failure case. Look for `::warning::` lines (digest
    resolution failed) or a gRPC error (`Unauthenticated`, `Unavailable`,
-   etc.) in the log. The job outcome tells you nothing; only the step log
-   does.
+   `InvalidArgument`, etc.) in the log. An `InvalidArgument` naming an
+   app/chart and asking whether it's been reconciled means the release ran
+   ahead of `ReconcileApps` (see `.github/actions/app-registry-reconcile`,
+   which runs on push to `main` via `ci.yml`) — not a credential or CLI
+   problem. The job outcome tells you nothing; only the step log does.
 
 To confirm from the registry side rather than the log:
 

--- a/tools/app_registry/server/handlers/artifact.go
+++ b/tools/app_registry/server/handlers/artifact.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"errors"
+	"fmt"
 	"regexp"
 	"strings"
 	"time"
@@ -142,17 +143,20 @@ func (s *ArtifactServer) RecordArtifact(ctx context.Context, req *pb.RecordArtif
 // resolveOwner resolves owner_full_name to an app_id or chart_id, depending
 // on kind, wrapping repository.ErrNotFound as ErrInvalidArgument — an
 // unknown owner is a caller mistake, not a "row doesn't exist yet" case.
+// The wrapped message names the owner and hints at the most common cause
+// (see issue #548): a release running ahead of ReconcileApps, which runs on
+// push to main via ci.yml (see .github/actions/app-registry-reconcile).
 func (s *ArtifactServer) resolveOwner(ctx context.Context, r repository.Registry, kind repository.ArtifactKind, ownerFullName string) (string, error) {
 	if kind == repository.ArtifactKindImage {
 		app, err := r.Apps().GetAppByFullName(ctx, ownerFullName)
 		if err != nil {
-			return "", repository.ErrInvalidArgument
+			return "", fmt.Errorf("%w: app %q not found -- has it been reconciled? (ReconcileApps runs on push to main via ci.yml)", repository.ErrInvalidArgument, ownerFullName)
 		}
 		return app.AppID, nil
 	}
 	chart, err := r.Apps().GetChartByFullName(ctx, ownerFullName)
 	if err != nil {
-		return "", repository.ErrInvalidArgument
+		return "", fmt.Errorf("%w: chart %q not found -- has it been reconciled? (ReconcileApps runs on push to main via ci.yml)", repository.ErrInvalidArgument, ownerFullName)
 	}
 	return chart.ChartID, nil
 }
@@ -344,13 +348,13 @@ func (s *ArtifactServer) resolveOwnerAndDomain(ctx context.Context, kind reposit
 	if kind == repository.ArtifactKindImage {
 		app, aerr := s.repo.Apps().GetAppByFullName(ctx, ownerFullName)
 		if aerr != nil {
-			return "", "", status.Errorf(codes.InvalidArgument, "unknown app %q", ownerFullName)
+			return "", "", status.Errorf(codes.InvalidArgument, "app %q not found -- has it been reconciled? (ReconcileApps runs on push to main via ci.yml)", ownerFullName)
 		}
 		return app.Domain, app.AppID, nil
 	}
 	chart, cerr := s.repo.Apps().GetChartByFullName(ctx, ownerFullName)
 	if cerr != nil {
-		return "", "", status.Errorf(codes.InvalidArgument, "unknown chart %q", ownerFullName)
+		return "", "", status.Errorf(codes.InvalidArgument, "chart %q not found -- has it been reconciled? (ReconcileApps runs on push to main via ci.yml)", ownerFullName)
 	}
 	return chart.Domain, chart.ChartID, nil
 }

--- a/tools/app_registry/server/handlers/artifact_test.go
+++ b/tools/app_registry/server/handlers/artifact_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"strings"
 	"testing"
 
 	pb "github.com/whale-net/everything/tools/app_registry/protos"
@@ -141,6 +142,56 @@ func TestRecordArtifact_RejectsChartPinningUnrecordedImage(t *testing.T) {
 	}
 	if status.Code(err) != codes.InvalidArgument {
 		t.Fatalf("expected InvalidArgument, got %v (%v)", status.Code(err), err)
+	}
+	if !strings.Contains(err.Error(), "sha256:neverrecorded") {
+		t.Fatalf("expected error to name the unrecorded digest, got %q", err.Error())
+	}
+}
+
+// TestRecordArtifact_UnknownOwnerNamesTheOwnerAndHintsAtReconcile covers
+// issue #548: resolveOwner used to return the bare repository.ErrInvalidArgument
+// sentinel when the owner_full_name wasn't found, so a caller saw only
+// "invalid argument" with no indication that the app/chart simply hadn't
+// been reconciled yet. The fix must keep the status code InvalidArgument
+// (mapRepoErr's errors.Is mapping must not change) while making the message
+// name the owner and point at reconciliation as the likely cause.
+func TestRecordArtifact_UnknownOwnerNamesTheOwnerAndHintsAtReconcile(t *testing.T) {
+	_, artifactSrv, _ := setup(t)
+	ctx := authedCtx()
+	build := recordBuild(t, artifactSrv, "run-unknown-owner")
+
+	cases := []struct {
+		name          string
+		kind          pb.ArtifactKind
+		ownerFullName string
+	}{
+		{"unknown app", pb.ArtifactKind_ARTIFACT_KIND_IMAGE, "demo-never-reconciled-app"},
+		{"unknown chart", pb.ArtifactKind_ARTIFACT_KIND_CHART, "demo-never-reconciled-chart"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := artifactSrv.RecordArtifact(ctx, &pb.RecordArtifactRequest{
+				BuildId: build.BuildId, Kind: tc.kind,
+				OwnerFullName: tc.ownerFullName, Digest: "sha256:" + tc.name, Version: "v1.0.0",
+				IdempotencyKey: "record-" + tc.name,
+			})
+			if err == nil {
+				t.Fatalf("expected an error for unknown owner %q", tc.ownerFullName)
+			}
+			if status.Code(err) != codes.InvalidArgument {
+				t.Fatalf("expected InvalidArgument, got %v (%v)", status.Code(err), err)
+			}
+			msg := status.Convert(err).Message()
+			if msg == "invalid argument" {
+				t.Fatalf("expected a message naming the owner, got the bare sentinel message %q", msg)
+			}
+			if !strings.Contains(msg, tc.ownerFullName) {
+				t.Fatalf("expected message to contain owner %q, got %q", tc.ownerFullName, msg)
+			}
+			if !strings.Contains(msg, "reconciled") {
+				t.Fatalf("expected message to hint at reconciliation, got %q", msg)
+			}
+		})
 	}
 }
 
@@ -330,6 +381,34 @@ func TestAllocateVersion_ValidationErrors(t *testing.T) {
 				t.Fatalf("expected InvalidArgument, got %v", err)
 			}
 		})
+	}
+}
+
+// TestAllocateVersion_UnknownOwnerNamesTheOwnerAndHintsAtReconcile covers
+// resolveOwnerAndDomain (artifact.go), the AllocateVersion sibling of
+// resolveOwner fixed for issue #548: an unknown owner must still map to
+// InvalidArgument, but the message must name the owner and hint that it may
+// simply not have been reconciled yet, not just say "unknown app ...".
+func TestAllocateVersion_UnknownOwnerNamesTheOwnerAndHintsAtReconcile(t *testing.T) {
+	_, artifactSrv := setupAllocate(t)
+	ctx := authedCtx()
+
+	_, err := artifactSrv.AllocateVersion(ctx, &pb.AllocateVersionRequest{
+		Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE, OwnerFullName: "demo-never-reconciled-app",
+		Increment: "patch", IdempotencyKey: "allocate-unknown-owner",
+	})
+	if err == nil {
+		t.Fatal("expected an error for an unknown owner")
+	}
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("expected InvalidArgument, got %v (%v)", status.Code(err), err)
+	}
+	msg := status.Convert(err).Message()
+	if !strings.Contains(msg, "demo-never-reconciled-app") {
+		t.Fatalf("expected message to contain owner name, got %q", msg)
+	}
+	if !strings.Contains(msg, "reconciled") {
+		t.Fatalf("expected message to hint at reconciliation, got %q", msg)
 	}
 }
 

--- a/tools/app_registry/server/repository/fake/fake.go
+++ b/tools/app_registry/server/repository/fake/fake.go
@@ -446,7 +446,8 @@ func (r *Registry) findImageByDigest(digest string) (*repository.Artifact, error
 			return &a, nil
 		}
 	}
-	return nil, repository.ErrInvalidArgument
+	// Mirrors postgres/artifact.go's RecordArtifact chart-links error.
+	return nil, fmt.Errorf("%w: chart pins unrecorded image digest %s", repository.ErrInvalidArgument, digest)
 }
 
 func (r *Registry) ListArtifacts(ctx context.Context, filter repository.ArtifactListFilter) ([]repository.Artifact, error) {
@@ -514,7 +515,8 @@ func (r *Registry) ResolveArtifact(ctx context.Context, lookup repository.Artifa
 		return nil, nil, nil, err
 	}
 	if a.Kind != repository.ArtifactKindChart {
-		return nil, nil, nil, repository.ErrInvalidArgument
+		// Mirrors postgres/artifact.go's ResolveArtifact.
+		return nil, nil, nil, fmt.Errorf("%w: artifact %s is not a chart", repository.ErrInvalidArgument, a.ArtifactID)
 	}
 	cp := *a
 	cp.Promotability = r.derivePromotability(cp)


### PR DESCRIPTION
## What

`resolveOwner` in `server/handlers/artifact.go` returned the bare
`repository.ErrInvalidArgument` sentinel when `GetAppByFullName`/
`GetChartByFullName` couldn't find `owner_full_name`, so callers saw
`InvalidArgument desc = invalid argument` — indistinguishable from a
genuinely malformed request. Fixed it (and its `AllocateVersion` sibling,
`resolveOwnerAndDomain`) to name the owner and hint that `ReconcileApps`
(runs on push to `main` via `ci.yml`) may not have caught up yet.

While auditing the handler/repository layer for other bare, message-less
domain-sentinel returns in the same family, found two in the fake
repository (`server/repository/fake/fake.go`, which backs the handler unit
tests) whose postgres counterparts already had good messages:
`findImageByDigest` and `ResolveArtifact`'s "not a chart" case. Brought
those in line for consistency.

Updated `.github/actions/app-registry-reconcile/action.yml`'s description
and `tools/app_registry/OPERATIONS.md`'s silent-recording-failure section,
both of which described/assumed the old bare error.

## Why

This was the direct cause of a multi-hour debugging session (#542/#547).
The generic message gave no signal that the real problem was "this
app/chart isn't registered in the registry yet," and this is now a live,
recurring operational scenario per #547 — a release running ahead of
`main`'s reconcile hits this path regularly.

Closes #548

## Test evidence

```
bazel test //tools/app_registry/...
```

7/7 test targets PASS: `cli/cmd:cmd_test`, `server:api_lib_test`,
`server/auth:auth_test`, `server/handlers:handlers_test`,
`server/repository/postgres:postgres_test`, `worker/outbox:outbox_test`,
`worker/writeback:writeback_test`.

New/updated tests in `server/handlers/artifact_test.go`:

- `TestRecordArtifact_UnknownOwnerNamesTheOwnerAndHintsAtReconcile` —
  unknown image/chart owner asserts the status code stays `InvalidArgument`
  **and** the message contains the owner's full name and the word
  "reconciled" (not the bare `"invalid argument"` string).
- `TestAllocateVersion_UnknownOwnerNamesTheOwnerAndHintsAtReconcile` —
  same assertions via `AllocateVersion`/`resolveOwnerAndDomain`.
- `TestRecordArtifact_RejectsChartPinningUnrecordedImage` extended to
  assert the unrecorded digest appears in the error message.

`postgres_integration_test` (real-Postgres, `//go:build integration`,
tagged `external`) is untouched by this change — no `postgres/*.go`
behavior changed, only `fake.go` message text.

## Design notes

Called out because these were guesses made without asking:

- **Hint wording** — "not found — has it been reconciled? (ReconcileApps
  runs on push to main via ci.yml)". Close to the issue's suggested fix but
  not copy-pasted verbatim.
- **Slightly wider scope than the literal issue.** Also fixed
  `resolveOwnerAndDomain` (already had the owner name, just missing the
  reconcile hint) and two fake-repository bare returns, on the theory that
  this PR is "make owner/identity resolution failures self-describing" and
  these are message-only, same-family, low-risk changes.
- **Deliberately left alone:** the fake/postgres `findArtifact`
  default-case bare `ErrInvalidArgument`. It is unreachable defensive code
  (the handler validates before ever calling it), not an owner-resolution
  path, so touching it would be scope creep for no operational benefit.

## Stack

Bottom of a 3-PR stack:

1. **this PR** — #548, contextual owner-not-found message
2. #545 — server-side monotonic reconcile ordering guard
3. #547 — release-vs-reconcile gap: decision + stop swallowing the error

🤖 Generated with [Claude Code](https://claude.com/claude-code)
