### PR TITLE
feat(app-registry): guard ReconcileApps against stale/out-of-order writes

### DIFF
--- a/.github/actions/app-registry-reconcile/action.yml
+++ b/.github/actions/app-registry-reconcile/action.yml
@@ -43,6 +43,21 @@ runs:
       env:
         GIT_SHA: ${{ inputs.git-sha }}
         IDEMPOTENCY_KEY: ${{ inputs.idempotency-key }}
+      # `manifest-set` resolves AppManifestSet.source_committed_at itself
+      # via `git log -1 --format=%ct "$GIT_SHA"` -- no new flag needed here,
+      # it flows through automatically once release_helper_go supports it
+      # (see tools/app_registry/ARCHITECTURE.md "Reconcile watermark",
+      # issue #545). This resolves fine even though ci.yml's checkout step
+      # for this job uses the default fetch-depth (1): a fetch-depth: 1
+      # checkout of a push event still fetches the full commit object for
+      # github.sha (verified locally -- `git log -1 --format=%ct <sha>`
+      # succeeds against a --depth 1 clone of that sha's tip), just not any
+      # ancestor history, which this call doesn't need. If GIT_SHA is ever
+      # something OTHER than the checked-out tip (e.g. this action is
+      # reused against an arbitrary historical ref), `git log` fails and
+      # manifest-set falls back to source_committed_at = 0 -- see
+      # resolveSourceCommittedAt's doc comment -- rather than failing the
+      # step.
       run: |
         "$RELEASE_HELPER" manifest-set --git-sha "$GIT_SHA" > "$RUNNER_TEMP/manifest-set.json"
         "$APP_REGISTRY_CLI" apps reconcile \

--- a/tools/app_registry/ARCHITECTURE.md
+++ b/tools/app_registry/ARCHITECTURE.md
@@ -73,6 +73,7 @@ erDiagram
 | `idempotency_key` | append-only | Key → prior response, for safe CI retries. |
 | `version_allocation` | append-only | AR-5a. `AllocateVersion`'s reservation ledger — see "Version model" below. |
 | `domain_adoption` | mutable | One row per domain; `stage` ∈ observe/promote/allocate. See "Resolved questions" #3. |
+| `reconcile_watermark` | singleton, mutable | Migration 006 (issue #545). Exactly one row (`id = 1`), seeded as a sentinel. Guards `Reconcile` against a stale (older-commit) call — see "Reconcile watermark" below. |
 
 ### SCD2 on `promotion`
 
@@ -171,6 +172,117 @@ row-per-domain-on-cutover shape (no row = implicit `observe`); AR-5a adds no
 mechanism to move a domain to `allocate` — that is deliberately still a
 direct `UPDATE domain_adoption` (or a future admin RPC/CLI command, not yet
 built), so the first real cutover is a reviewable, explicit action.
+
+## Reconcile watermark (issue #545)
+
+`Reconcile` performs a FULL replace on every call (see "Design principles"
+#1 and `ReconcileAppsRequest`'s own doc comment): every app/chart is
+upserted `ACTIVE`, anything absent is flagged `MISSING`, unconditionally. As
+of #543 it runs from `ci.yml` on every push to `main`, with only a same-group
+CI concurrency cancel (#546) as a mitigation — which does not cover a
+manually re-run older workflow (fresh queue timing, not the original push's
+chronological position) or an in-flight RPC that outran a cancellation. An
+older call landing after a newer one would silently revert registry state
+(e.g. re-marking `ACTIVE` an app a newer commit correctly flagged `MISSING`)
+with no error and no way to detect it after the fact.
+
+**The guard: a singleton watermark, checked and advanced inside the same
+transaction as the write.** Migration 006 adds `reconcile_watermark`, one
+row recording the most recently *applied* call's ordering metadata.
+`Reconcile` reads it with `SELECT ... FOR UPDATE` (so two concurrent calls
+serialize instead of both reading the same stale watermark), decides
+apply-or-skip, and — only on apply — writes the app/chart diff and advances
+the watermark, all in one transaction (the non-dry-run path already runs
+inside `runIdempotent`'s `WithTx`). The comparison/tie-break logic itself
+lives once, in Go (`repository.ShouldApplyReconcile`), shared by the
+postgres and fake implementations exactly like `DerivePromotability` is —
+not duplicated as SQL in one place and Go in the other.
+
+**Ordering key: `source_committed_at`, not `discovered_at`.**
+`AppManifestSet.discovered_at` (`appmeta.proto`) is the Unix time
+`release_helper_go` ran its `bazel query` sweep — sweep time, not the swept
+commit's position in history. A manually re-run older workflow sweeps at
+re-run time, so `discovered_at` is **not monotonic in commit order** and is
+unsafe to use alone: it is exactly the "re-run an old workflow" case this
+watermark exists to guard against, and a naive `discovered_at`-only
+watermark would sail straight past it. `source_committed_at` (added
+alongside this migration) is the git committer timestamp of `git_sha`
+instead — `release_helper_go`'s `manifest-set` command resolves it via `git
+log -1 --format=%ct <git_sha>` — which *is* monotonic with history for any
+commit reachable from `main`. `discovered_at` is kept as a comparison
+fallback for exactly one reason: backward compatibility with an
+`AppManifestSet` produced by a `release_helper_go` binary that predates this
+field (e.g. still cached on a CI runner mid-rollout of this change), which
+carries `source_committed_at = 0`. `git log` resolution failing (git
+unavailable, sha unresolvable in a shallow clone) also leaves it `0` rather
+than failing the `manifest-set` command — losing the stronger ordering
+guarantee for one call beats breaking manifest discovery entirely.
+
+**Tie-breaking rules** (`ShouldApplyReconcile`, evaluated in this order):
+
+1. No watermark yet (table's sentinel row, `git_sha = ''`): apply. The very
+   first reconcile is always accepted.
+2. `incoming.git_sha == current.git_sha`: apply, unconditionally, regardless
+   of how the timestamps compare. The identical commit reconciled twice
+   (a manual re-run of the same workflow run, or the CLI pointed at the
+   same manifest set again with a fresh idempotency key) is harmless to
+   re-apply — idempotency already covers true RPC-level replays; this
+   covers the same commit arriving via two *different* calls — and clock
+   skew between two sweeps of the same commit must never produce a
+   false-stale rejection.
+3. Incoming's ordering key (`source_committed_at`, falling back to
+   `discovered_at`) strictly older than current's: **skip** (stale).
+4. Otherwise (incoming's key is ≥ current's, and `git_sha` differs):
+   **apply**. The equal-timestamp case is deliberate: two different commits
+   landing in the same wall-clock second (or two manifest sets both falling
+   back to `discovered_at`) must not block a legitimate merge just because
+   they tied.
+
+**A skipped-stale call is a no-op SUCCESS, not an error.** A CI re-run of an
+older commit is doing the *right* thing by declining to revert newer state;
+turning that workflow red would be exactly backwards. But a silent no-op is
+the failure mode this feature exists to eliminate, so
+`ReconcileAppsResponse` carries `skipped_stale` and
+`current_watermark_git_sha`, the handler logs at `Warn` when it happens (see
+`server/handlers/app.go`'s `ReconcileApps`), and the CLI prints a stderr
+banner (mirroring `promote.go`'s already-promoted/dry-run banners) so it is
+visible in a CI log even if nobody inspects the JSON response.
+
+**Idempotency-key interaction.** A skipped-stale response IS stored under
+the request's `idempotency_key`, same as any other successful response —
+deliberately, not an oversight: a retry with the *same* key must replay the
+*same* answer. If the skip weren't stored and the watermark happened to
+change before a retry (e.g. a legitimately newer commit's reconcile lands
+between the two calls), a replay could flip from "skipped" to "applied" for
+what the caller believes is the same request — silently reordering writes
+relative to what actually happened on the wire. Storing it keeps
+`runIdempotent`'s guarantee ("repeated calls with the same key are a no-op
+returning the original result") true here too.
+
+**Dry run never touches the watermark**, in either direction: it neither
+reads it to decide skip-or-apply, nor advances it on completion. Dry run
+already writes nothing (see `ReconcileAppsRequest.dry_run`'s doc comment);
+consulting a mutation guard for a call that cannot mutate would just be
+extra Postgres round trips answering a question nobody asked.
+
+**Why a singleton table, not a per-app/per-row watermark.** `Reconcile` is
+always a full-replace of the complete manifest set, so there is exactly one
+meaningful "most recent complete sweep" to compare against — one global
+watermark suffices. A per-row watermark would have to answer an unasked
+question ("was THIS app's row from a newer sweep than THAT app's row"),
+which cannot happen under a full-replace write model.
+
+**Why the watermark table is seeded with a sentinel row, not left empty.**
+Postgres's `SELECT ... FOR UPDATE` locks only rows it *matches* — against a
+genuinely empty table it locks nothing, so two concurrent "first ever
+reconcile" transactions would both read "no watermark," both proceed to
+apply, and only accidentally serialize at the final write. Migration 006
+seeds exactly one row (`git_sha = ''`, timestamps `0`) so the locking read
+always has something to hold from the very first call onward. This sentinel
+is what "no watermark yet" means operationally — see migration 006's
+comments and `ShouldApplyReconcile`'s doc comment; it is invisible above the
+repository interface, which only ever exposes "is there a watermark or
+not."
 
 ## Promotability
 
@@ -441,6 +553,9 @@ when the opt-in is off, or a registry outage becomes a release outage.
 | Manifest schema | shared `//tools/appmeta/proto` | registry-local manifest messages | Two hand-written Go structs already decode the manifest JSON and had drifted; a third would compound it. |
 | Manifest schema | proto + `protojson` | shared hand-written Go struct | `protojson` reads the existing snake_case JSON unchanged, and `DiscardUnknown: false` turns drift into a test failure. |
 | App/chart registration | `ReconcileApps`, full manifest set, run on push to `main` | a scoped `RegisterApp`/upsert RPC tied to `release.yml`, sending only the apps in that run | Two write paths to the same rows with different invariants. `ReconcileApps` treats its input as the complete truth and flags anything absent as `MISSING` (`api.proto`'s own comment) — a scoped call would either need to skip that check (weakening triage) or would falsely flag every app not in the current release as `MISSING`. It's also unsafe to run at release time at all: `release.yml` can be dispatched against an arbitrary (possibly old) ref, and reconciling an old commit's manifest set would flag every app added since as `MISSING`. Running it on every push to `main` instead means it only ever sees the current, complete tree. See issue #539's follow-up (#542) and DEPLOY.md "CI wiring (AR-3d)". |
+| Reconcile watermark ordering key | `source_committed_at` (git committer timestamp of `git_sha`), fallback to `discovered_at` | `discovered_at` alone | `discovered_at` is sweep time, not commit-history position — a manually re-run older workflow sweeps at re-run time, producing a *newer* `discovered_at` than the newer commit it's racing. That is precisely the headline case issue #545 exists to guard against, so a `discovered_at`-only watermark would not catch it. See "Reconcile watermark" above. |
+| Stale reconcile call | no-op success (`skipped_stale = true`) | `FailedPrecondition` error | A CI re-run of an older commit is doing the *correct* thing by declining to overwrite newer state; failing that workflow run would punish correct behavior and train people to retry (or worse, force-apply) their way past a safety check. A visible response field plus a server-side `Warn` log gives the same "you should know this happened" property as an error without making the workflow red. |
+| Reconcile watermark granularity | one singleton row for the whole registry | a watermark per app/chart row | `Reconcile` is always a full-replace of the complete manifest set (see "Design principles" #1) — there is exactly one meaningful "most recent complete sweep," so a per-row watermark would have to answer a question that cannot arise under this write model ("was this one row from a newer sweep than that one"). |
 
 ## Future: approval gate
 

--- a/tools/app_registry/OPERATIONS.md
+++ b/tools/app_registry/OPERATIONS.md
@@ -81,6 +81,20 @@ To check whether a specific release actually got recorded:
    which runs on push to `main` via `ci.yml`) — not a credential or CLI
    problem. The job outcome tells you nothing; only the step log does.
 
+**"Why didn't my reconcile apply?" (issue #545).** The `reconcile-app-registry`
+job in `ci.yml` runs green but `app-registry apps list`/`get` still shows
+old state. Check the step's log for `reconcile skipped: this manifest set
+(git_sha=...) is stale relative to the current watermark (git_sha=...)` — the
+CLI prints this to stderr, and the server logs the same event at `Warn`. This
+means the reconcile watermark rejected the call as older (in commit history,
+via `source_committed_at`) than one already applied — almost always a
+manually re-run workflow for an older commit, or a workflow run whose reconcile
+step got queued behind a later push's. **This is expected, correct behavior,
+not a bug**: applying it would have reverted registry state to match the
+older commit. See [ARCHITECTURE.md "Reconcile watermark"](ARCHITECTURE.md#reconcile-watermark-issue-545)
+for the full mechanism, and re-run `ci.yml` for the commit you actually want
+reflected if that's not what already ran.
+
 To confirm from the registry side rather than the log:
 
 ```bash

--- a/tools/app_registry/cli/cmd/apps.go
+++ b/tools/app_registry/cli/cmd/apps.go
@@ -132,6 +132,18 @@ func newAppsReconcileCmd() *cobra.Command {
 				if err != nil {
 					return err
 				}
+				// Skipped-stale is a no-op SUCCESS (see
+				// ReconcileAppsResponse.skipped_stale's doc comment) so it
+				// must not fail the command, but it must not be silent
+				// either -- a CI log that only shows a green step for a
+				// call that wrote nothing is exactly the failure mode
+				// issue #545 exists to fix. Mirrors promote.go's
+				// already-promoted/dry-run stderr banners.
+				if resp.SkippedStale {
+					fmt.Fprintf(cmd.ErrOrStderr(),
+						"reconcile skipped: this manifest set (git_sha=%q) is stale relative to the current watermark (git_sha=%q); nothing was written\n",
+						manifests.GitSha, resp.CurrentWatermarkGitSha)
+				}
 				return printResponse(resp)
 			})
 		},

--- a/tools/app_registry/migrate/README.md
+++ b/tools/app_registry/migrate/README.md
@@ -34,6 +34,7 @@ ArgoCD sync waves. See `friendly_computing_machine/docs/argocd-integration.md`.
 | `003_promotion` (AR-3c) | `promotion` (SCD2), `promotion_event`, `v_current_promotion` |
 | `004_writeback_outbox` (AR-4b) | `writeback_outbox` |
 | `005_version_allocation` (AR-5a) | `artifact.version_major/minor/patch` + backfill, `artifact_version_order_idx`, `version_allocation` |
+| `006_reconcile_watermark` (issue #545) | `reconcile_watermark` — singleton row guarding `ReconcileApps` against a stale (older-commit) call landing after a newer one |
 
 Split this way so AR-2 needs only `001`, AR-3b adds `002`, AR-3c adds `003`,
 AR-4b adds `004`, and AR-5a adds `005` — each phase ships an independently
@@ -78,6 +79,13 @@ CREATE INDEX artifact_version_order_idx
 -- artifact_version_idx, but on a table that doesn't require a digest/build.
 CREATE UNIQUE INDEX version_allocation_idx ON version_allocation (owner_id, kind, version);
 ```
+
+`reconcile_watermark` (`006`) is seeded with exactly one sentinel row at
+migration time (`id = 1`, `git_sha = ''`, timestamps `0`) rather than left
+empty — `SELECT ... FOR UPDATE` locks only rows it matches, so a genuinely
+empty table gives two concurrent "first ever reconcile" calls nothing to
+serialize against. See the migration's own comments for the full rationale
+and how the sentinel row is distinguished from a "real" watermark.
 
 `domain_adoption` gates the per-domain cutover described in
 [`../ARCHITECTURE.md`](../ARCHITECTURE.md#resolved-questions): one row per

--- a/tools/app_registry/migrate/schema/migrations/006_reconcile_watermark.down.sql
+++ b/tools/app_registry/migrate/schema/migrations/006_reconcile_watermark.down.sql
@@ -1,0 +1,3 @@
+-- Rollback App Registry Reconcile watermark (issue #545)
+
+DROP TABLE IF EXISTS reconcile_watermark;

--- a/tools/app_registry/migrate/schema/migrations/006_reconcile_watermark.up.sql
+++ b/tools/app_registry/migrate/schema/migrations/006_reconcile_watermark.up.sql
@@ -1,0 +1,102 @@
+-- App Registry — Reconcile watermark (issue #545)
+--
+-- ReconcileApps performs a FULL replace on every call: every app/chart is
+-- upserted ACTIVE and anything absent is flagged MISSING, unconditionally.
+-- As of #543 it runs from ci.yml on every push to main, with no ordering
+-- guard beyond a same-group CI concurrency cancel (#546, a cheap mitigation
+-- that is NOT sufficient on its own -- see that issue's "Caveats"). Without
+-- a server-side guard, an OLDER commit's reconcile call landing AFTER a
+-- newer one's (a manually re-run workflow, or an in-flight RPC that outran
+-- a cancellation) silently reverts registry state -- e.g. re-marking ACTIVE
+-- an app a newer commit correctly flagged MISSING -- with no error and no
+-- way to detect it after the fact.
+--
+-- This migration adds a singleton watermark row recording the most
+-- recently APPLIED reconcile call's ordering metadata. Reconcile() compares
+-- every incoming call against it (inside the same transaction as the
+-- upserts, via SELECT ... FOR UPDATE, so concurrent callers serialize
+-- rather than both reading a stale watermark) and no-ops a call whose
+-- ordering key is strictly older -- see ARCHITECTURE.md "Reconcile
+-- watermark" for the full comparison/tie-break rules, which live in Go
+-- (server/repository.ShouldApplyReconcile), not SQL.
+
+-- Why source_committed_at, not discovered_at: AppManifestSet.discovered_at
+-- (appmeta.proto) is the Unix time release_helper_go ran its `bazel query`
+-- sweep, NOT the swept commit's position in history -- a manually re-run
+-- older workflow sweeps at re-run time, so discovered_at is NOT monotonic
+-- in commit order and is unsafe to use alone as an ordering key (the exact
+-- "re-run an old workflow" case this table exists to guard against would
+-- sail straight past a discovered_at-only watermark). source_committed_at
+-- (appmeta.proto field 5, added alongside this migration) is the git
+-- committer timestamp of git_sha instead, which IS monotonic-with-history
+-- for any commit reachable from main. discovered_at is kept as a
+-- comparison fallback for backward compatibility: an AppManifestSet
+-- produced by a release_helper_go binary that predates this field (e.g.
+-- still cached on a CI runner mid-rollout) carries source_committed_at = 0,
+-- and the fallback lets that caller keep working, just without the
+-- stronger ordering guarantee, rather than being rejected outright.
+
+-- Why a singleton table, not a per-app/per-row watermark: ReconcileApps is
+-- always a full-replace of the complete manifest set (ARCHITECTURE.md
+-- "Design principles" #1 and this table's own migration 001 doc comments),
+-- so there is exactly one meaningful "most recent complete sweep" to compare
+-- against -- one global watermark suffices, and a per-row watermark would
+-- have to answer an unasked question ("was THIS app's row from a newer
+-- sweep than THAT app's row"), which cannot happen under a full-replace
+-- write.
+--
+-- Why CHECK (id = 1) rather than a UNIQUE index on a constant expression:
+-- both structurally forbid a second row, but a literal PRIMARY KEY column
+-- gives every query (the FOR UPDATE read, the upsert) a normal, readable
+-- `WHERE id = 1` instead of an expression index most engineers have never
+-- seen. Rejected: no PK at all plus an application-level "SELECT ... LIMIT
+-- 1 FOR UPDATE" -- that still races on the very first INSERT (see below)
+-- and gives Postgres nothing to enforce if application code has a bug.
+CREATE TABLE reconcile_watermark (
+    id                    SMALLINT PRIMARY KEY DEFAULT 1 CHECK (id = 1),
+
+    -- The commit this watermark reflects. Compared directly against an
+    -- incoming call's git_sha as the FIRST tie-break rule (see
+    -- ShouldApplyReconcile): the identical commit reconciled twice --
+    -- e.g. a manual re-run of the SAME workflow run, or the CLI pointed at
+    -- the same manifest set twice with different idempotency keys -- always
+    -- applies regardless of how its timestamps compare, since re-applying
+    -- identical data is harmless and clock skew between two sweeps of the
+    -- same commit must never produce a false-stale rejection.
+    git_sha               TEXT NOT NULL,
+
+    -- The ordering key. 0 alongside an empty git_sha (see below) means "no
+    -- real watermark recorded yet."
+    source_committed_at   BIGINT NOT NULL,
+
+    -- Comparison fallback when a caller's source_committed_at is 0 -- see
+    -- the rationale above. Stored (not just source_committed_at) so a
+    -- future caller with source_committed_at = 0 can still be compared
+    -- against whatever ordering key the CURRENT watermark was itself
+    -- recorded with, including if that too falls back to discovered_at.
+    discovered_at         BIGINT NOT NULL,
+
+    updated_at            TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Seed exactly one sentinel row rather than leaving the table empty.
+-- Postgres's SELECT ... FOR UPDATE locks only rows it MATCHES -- against a
+-- genuinely empty table it matches (and locks) nothing, so two concurrent
+-- "first ever reconcile" transactions would both read "no watermark," both
+-- proceed to apply, and only serialize (accidentally, via the unique
+-- constraint) at the final INSERT -- by which point both had already
+-- written their app/chart upserts unserialized against each other. Seeding
+-- one row up front means the FOR UPDATE read always has something to lock,
+-- so every reconcile call -- including the very first one ever -- is
+-- properly serialized against concurrent callers for the table's entire
+-- lifetime.
+--
+-- This sentinel (empty git_sha, zero timestamps) is what "no watermark yet"
+-- means operationally: ShouldApplyReconcile (server/repository) treats a
+-- watermark row with git_sha = '' exactly like a wholly absent row --
+-- always apply. The distinction between "table has zero rows" and "table
+-- has one sentinel row" is a storage-layer implementation detail entirely
+-- invisible above the SQL in this file; every caller of the repository
+-- interface only ever sees "is there a watermark or not."
+INSERT INTO reconcile_watermark (id, git_sha, source_committed_at, discovered_at)
+VALUES (1, '', 0, 0);

--- a/tools/app_registry/protos/api_messages_app.proto
+++ b/tools/app_registry/protos/api_messages_app.proto
@@ -47,6 +47,21 @@ message ReconcileAppsResponse {
   repeated Chart recovered_charts = 8;
 
   bool dry_run = 9;
+
+  // True when this call was rejected by the reconcile watermark as older
+  // (in commit order) than the most recently applied call, and was
+  // therefore a no-op success -- nothing above was written, every list is
+  // empty. This is deliberately NOT an error: a re-run of an older CI
+  // workflow doing the right thing (declining to revert newer state) must
+  // not turn the workflow red. See ARCHITECTURE.md "Reconcile watermark"
+  // and issue #545. Never set when dry_run is true -- a dry run never
+  // consults or advances the watermark.
+  bool skipped_stale = 10;
+
+  // The git_sha this call lost to, populated only when skipped_stale is
+  // true -- so a caller/log line can say exactly which commit is currently
+  // recorded instead of just "something newer already applied."
+  string current_watermark_git_sha = 11;
 }
 
 // ============================================================================

--- a/tools/app_registry/server/handlers/BUILD.bazel
+++ b/tools/app_registry/server/handlers/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//libs/go/grpcauth",
+        "//libs/go/logging",
         "//libs/go/semver",
         "//tools/app_registry/protos:appregistrypb",
         "//tools/app_registry/server/auth",

--- a/tools/app_registry/server/handlers/app.go
+++ b/tools/app_registry/server/handlers/app.go
@@ -5,7 +5,9 @@ package handlers
 
 import (
 	"context"
+	"log/slog"
 
+	"github.com/whale-net/everything/libs/go/logging"
 	pb "github.com/whale-net/everything/tools/app_registry/protos"
 	"github.com/whale-net/everything/tools/app_registry/server/auth"
 	"github.com/whale-net/everything/tools/app_registry/server/repository"
@@ -25,6 +27,11 @@ func NewAppServer(repo repository.Registry) *AppServer {
 	return &AppServer{repo: repo}
 }
 
+// appLog is this file's logger name, deliberately its own name (not
+// "handlers") so a skipped-stale reconcile is easy to filter for -- see
+// ReconcileApps's use below.
+var appLog = logging.Get("app-registry-handlers")
+
 func (s *AppServer) ReconcileApps(ctx context.Context, req *pb.ReconcileAppsRequest) (*pb.ReconcileAppsResponse, error) {
 	if err := auth.Require(ctx, auth.RoleBuilder); err != nil {
 		return nil, err
@@ -33,12 +40,24 @@ func (s *AppServer) ReconcileApps(ctx context.Context, req *pb.ReconcileAppsRequ
 		return nil, status.Error(codes.InvalidArgument, "manifests is required")
 	}
 
+	// source is the ordering metadata Reconcile checks against the
+	// reconcile watermark -- see ARCHITECTURE.md "Reconcile watermark" and
+	// issue #545. Passed through unconditionally, including on the dry_run
+	// path below: Reconcile itself ignores it entirely when dryRun is true
+	// (see repository.AppRepository.Reconcile's doc comment), so there is
+	// no branch to get wrong here.
+	source := repository.ReconcileSource{
+		GitSHA:            req.Manifests.GitSha,
+		SourceCommittedAt: req.Manifests.SourceCommittedAt,
+		DiscoveredAt:      req.Manifests.DiscoveredAt,
+	}
+
 	// dry_run computes a diff and writes nothing: it never touches the
 	// idempotency store either (there is nothing for a retry to replay
 	// safely — every dry run recomputes against current state, which is the
 	// whole point).
 	if req.DryRun {
-		result, err := s.repo.Apps().Reconcile(ctx, req.Manifests.Apps, req.Manifests.Charts, true)
+		result, err := s.repo.Apps().Reconcile(ctx, req.Manifests.Apps, req.Manifests.Charts, source, true)
 		if err != nil {
 			return nil, mapRepoErr(err)
 		}
@@ -52,9 +71,24 @@ func (s *AppServer) ReconcileApps(ctx context.Context, req *pb.ReconcileAppsRequ
 	resp, _, err := runIdempotent(ctx, s.repo, req.IdempotencyKey, "ReconcileApps",
 		func() proto.Message { return &pb.ReconcileAppsResponse{} },
 		func(ctx context.Context, r repository.Registry) (proto.Message, error) {
-			result, err := r.Apps().Reconcile(ctx, req.Manifests.Apps, req.Manifests.Charts, false)
+			result, err := r.Apps().Reconcile(ctx, req.Manifests.Apps, req.Manifests.Charts, source, false)
 			if err != nil {
 				return nil, err
+			}
+			if result.SkippedStale {
+				// Warn, not Debug/Info: a stale reconcile being skipped is
+				// a no-op SUCCESS (see ReconcileAppsResponse.skipped_stale's
+				// doc comment for why it must not be an error), but a
+				// silent no-op is exactly the failure mode this whole
+				// feature exists to make detectable after the fact. This
+				// only fires when Reconcile actually ran, not on an
+				// idempotency-key replay of a previously stored response.
+				appLog.Warn("reconcile skipped: stale relative to current watermark",
+					slog.String("incoming_git_sha", source.GitSHA),
+					slog.Int64("incoming_source_committed_at", source.SourceCommittedAt),
+					slog.Int64("incoming_discovered_at", source.DiscoveredAt),
+					slog.String("current_watermark_git_sha", result.CurrentWatermarkGitSHA),
+				)
 			}
 			return reconcileResultToPB(result, false), nil
 		},
@@ -67,15 +101,17 @@ func (s *AppServer) ReconcileApps(ctx context.Context, req *pb.ReconcileAppsRequ
 
 func reconcileResultToPB(r *repository.ReconcileResult, dryRun bool) *pb.ReconcileAppsResponse {
 	return &pb.ReconcileAppsResponse{
-		CreatedApps:        appsToPB(r.CreatedApps),
-		UpdatedApps:        appsToPB(r.UpdatedApps),
-		NewlyMissingApps:   appsToPB(r.NewlyMissingApps),
-		RecoveredApps:      appsToPB(r.RecoveredApps),
-		CreatedCharts:      chartsToPB(r.CreatedCharts),
-		UpdatedCharts:      chartsToPB(r.UpdatedCharts),
-		NewlyMissingCharts: chartsToPB(r.NewlyMissingCharts),
-		RecoveredCharts:    chartsToPB(r.RecoveredCharts),
-		DryRun:             dryRun,
+		CreatedApps:            appsToPB(r.CreatedApps),
+		UpdatedApps:            appsToPB(r.UpdatedApps),
+		NewlyMissingApps:       appsToPB(r.NewlyMissingApps),
+		RecoveredApps:          appsToPB(r.RecoveredApps),
+		CreatedCharts:          chartsToPB(r.CreatedCharts),
+		UpdatedCharts:          chartsToPB(r.UpdatedCharts),
+		NewlyMissingCharts:     chartsToPB(r.NewlyMissingCharts),
+		RecoveredCharts:        chartsToPB(r.RecoveredCharts),
+		DryRun:                 dryRun,
+		SkippedStale:           r.SkippedStale,
+		CurrentWatermarkGitSha: r.CurrentWatermarkGitSHA,
 	}
 }
 

--- a/tools/app_registry/server/handlers/app_test.go
+++ b/tools/app_registry/server/handlers/app_test.go
@@ -216,6 +216,160 @@ func TestReconcileApps_ChartComposesApps(t *testing.T) {
 	}
 }
 
+// ============================================================================
+// Reconcile watermark (issue #545) -- fake-backed handler coverage.
+// See postgres_integration_test.go's "Reconcile watermark" section for the
+// same scenarios exercised against real Postgres (real FOR UPDATE locking,
+// real transaction rollback). These fake-backed versions exist so the
+// business logic (repository.ShouldApplyReconcile and its wiring through
+// the handler/repository layers) is covered by the fast unit tier too, not
+// only the manual Postgres tier.
+// ============================================================================
+
+func manifestSetWithSource(gitSha string, sourceCommittedAt, discoveredAt int64, apps []*appmetapb.AppManifest, charts []*appmetapb.ChartManifest) *appmetapb.AppManifestSet {
+	return &appmetapb.AppManifestSet{
+		GitSha: gitSha, SourceCommittedAt: sourceCommittedAt, DiscoveredAt: discoveredAt,
+		Apps: apps, Charts: charts,
+	}
+}
+
+// TestReconcileApps_StaleCallSkippedWithoutError covers the headline
+// scenario from issue #545: an older commit's call lands after a newer
+// one's and must be a no-op SUCCESS (not an error), naming the commit it
+// lost to, and leaving the newer commit's state (including a MISSING flag)
+// untouched.
+func TestReconcileApps_StaleCallSkippedWithoutError(t *testing.T) {
+	ctx := authedCtx()
+	srv := NewAppServer(fake.New())
+
+	first, err := srv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
+		Manifests:      manifestSetWithSource("newer-sha", 2000, 2000, []*appmetapb.AppManifest{oneApp("demo", "svc")}, nil),
+		IdempotencyKey: "wm-1",
+	})
+	if err != nil {
+		t.Fatalf("first reconcile: %v", err)
+	}
+	svcID := first.CreatedApps[0].AppId
+
+	// A newer commit drops "svc" -- correctly MISSING.
+	second, err := srv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
+		Manifests:      manifestSetWithSource("newest-sha", 3000, 3000, nil, nil),
+		IdempotencyKey: "wm-2",
+	})
+	if err != nil {
+		t.Fatalf("second reconcile: %v", err)
+	}
+	if len(second.NewlyMissingApps) != 1 || second.NewlyMissingApps[0].AppId != svcID {
+		t.Fatalf("expected svc newly missing, got %+v", second.NewlyMissingApps)
+	}
+
+	// A STALE call -- an older commit re-running -- must not revert that.
+	stale, err := srv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
+		Manifests:      manifestSetWithSource("older-rerun-sha", 2500, 2500, []*appmetapb.AppManifest{oneApp("demo", "svc")}, nil),
+		IdempotencyKey: "wm-3",
+	})
+	if err != nil {
+		t.Fatalf("stale reconcile must be a no-op SUCCESS, not an error: %v", err)
+	}
+	if !stale.SkippedStale {
+		t.Fatalf("expected SkippedStale=true for an older-commit call, got %+v", stale)
+	}
+	if stale.CurrentWatermarkGitSha != "newest-sha" {
+		t.Fatalf("expected current_watermark_git_sha=newest-sha, got %q", stale.CurrentWatermarkGitSha)
+	}
+	if len(stale.CreatedApps)+len(stale.UpdatedApps)+len(stale.RecoveredApps) != 0 {
+		t.Fatalf("expected an empty result for a skipped-stale call, got %+v", stale)
+	}
+
+	// svc must STILL be MISSING -- the stale call did not revert it.
+	getResp, err := srv.GetApp(ctx, &pb.GetAppRequest{AppId: svcID})
+	if err != nil {
+		t.Fatalf("get app after stale call: %v", err)
+	}
+	if getResp.App.Status != pb.AppStatus_APP_STATUS_MISSING {
+		t.Fatalf("stale call reverted svc's MISSING flag -- now %v", getResp.App.Status)
+	}
+}
+
+// TestReconcileApps_EqualOrderingKeyDifferentGitShaApplies proves the
+// deliberate equal-timestamp tie-break: two different commits at the same
+// ordering key must not block each other.
+func TestReconcileApps_EqualOrderingKeyDifferentGitShaApplies(t *testing.T) {
+	ctx := authedCtx()
+	srv := NewAppServer(fake.New())
+
+	if _, err := srv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
+		Manifests:      manifestSetWithSource("sha-a", 5000, 5000, []*appmetapb.AppManifest{oneApp("demo", "svc")}, nil),
+		IdempotencyKey: "tie-1",
+	}); err != nil {
+		t.Fatalf("first reconcile: %v", err)
+	}
+
+	resp, err := srv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
+		Manifests: manifestSetWithSource("sha-b", 5000, 5000,
+			[]*appmetapb.AppManifest{oneApp("demo", "svc"), oneApp("demo", "svc2")}, nil),
+		IdempotencyKey: "tie-2",
+	})
+	if err != nil {
+		t.Fatalf("tied-timestamp reconcile: %v", err)
+	}
+	if resp.SkippedStale {
+		t.Fatalf("expected an equal-timestamp, different-git_sha call to apply, got SkippedStale=true")
+	}
+	if len(resp.CreatedApps) != 1 || resp.CreatedApps[0].FullName != "demo-svc2" {
+		t.Fatalf("expected svc2 to be newly created, got %+v", resp.CreatedApps)
+	}
+}
+
+// TestReconcileApps_DryRunNeverConsultsOrAdvancesWatermark proves dry_run
+// is unaffected by the watermark in either direction, mirroring
+// postgres_integration_test.go's version of this proof against real
+// Postgres.
+func TestReconcileApps_DryRunNeverConsultsOrAdvancesWatermark(t *testing.T) {
+	ctx := authedCtx()
+	srv := NewAppServer(fake.New())
+
+	if _, err := srv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
+		Manifests:      manifestSetWithSource("real-sha", 999999, 999999, []*appmetapb.AppManifest{oneApp("demo", "svc")}, nil),
+		IdempotencyKey: "dry-wm-1",
+	}); err != nil {
+		t.Fatalf("real reconcile: %v", err)
+	}
+
+	// A dry run carrying a far-older ordering key must still compute a
+	// normal diff -- if it consulted the watermark, this would come back
+	// SkippedStale with an empty diff instead.
+	dryResp, err := srv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
+		Manifests: manifestSetWithSource("dry-run-old-sha", 1, 1,
+			[]*appmetapb.AppManifest{oneApp("demo", "svc"), oneApp("demo", "new-app")}, nil),
+		DryRun: true,
+	})
+	if err != nil {
+		t.Fatalf("dry run reconcile: %v", err)
+	}
+	if dryResp.SkippedStale {
+		t.Fatalf("dry run must never consult the watermark, got SkippedStale=true")
+	}
+	if len(dryResp.CreatedApps) != 1 || dryResp.CreatedApps[0].FullName != "demo-new-app" {
+		t.Fatalf("expected dry run to compute a normal diff (1 created app), got %+v", dryResp.CreatedApps)
+	}
+
+	// And a REAL call carrying that same far-older key must still be
+	// rejected as stale -- proving the dry run above did not advance the
+	// watermark.
+	afterDry, err := srv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
+		Manifests: manifestSetWithSource("dry-run-old-sha", 1, 1,
+			[]*appmetapb.AppManifest{oneApp("demo", "svc"), oneApp("demo", "new-app")}, nil),
+		IdempotencyKey: "dry-wm-2",
+	})
+	if err != nil {
+		t.Fatalf("post-dry-run real reconcile: %v", err)
+	}
+	if !afterDry.SkippedStale {
+		t.Fatalf("expected the same far-older key to still be rejected as stale after the dry run, got SkippedStale=false -- the dry run must have advanced the watermark")
+	}
+}
+
 // TestSetAppStatus_MissingToArchivedSucceeds covers the only transition a
 // human triggers through this RPC: missing -> archived. missing -> active
 // happens automatically via Reconcile's "recovered" path instead.

--- a/tools/app_registry/server/repository/BUILD.bazel
+++ b/tools/app_registry/server/repository/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "models.go",
         "promotability.go",
         "repository.go",
+        "watermark.go",
     ],
     importpath = "github.com/whale-net/everything/tools/app_registry/server/repository",
     visibility = ["//visibility:public"],

--- a/tools/app_registry/server/repository/fake/fake.go
+++ b/tools/app_registry/server/repository/fake/fake.go
@@ -56,6 +56,14 @@ type state struct {
 	// Absent means DomainAdoptionStageObserve -- see
 	// DomainAdoptionRepository.GetStage's doc comment.
 	DomainAdoption map[string]repository.DomainAdoptionStage
+	// Watermark mirrors the singleton reconcile_watermark row (migration
+	// 006). nil means "no watermark yet" -- unlike postgres, the fake has
+	// no seeded-sentinel-row concurrency concern to work around (WithTx
+	// already serializes every call via the outer mutex, see WithTx's doc
+	// comment), so this is a plain nilable pointer rather than a
+	// GitSHA=="" sentinel value. reconcile.go's use of it must still agree
+	// with repository.ShouldApplyReconcile's semantics for nil.
+	Watermark *repository.ReconcileWatermark
 }
 
 func newState() *state {
@@ -165,8 +173,8 @@ func (h txHandle) WithTx(ctx context.Context, fn func(ctx context.Context, reg r
 // AppRepository
 // ============================================================================
 
-func (r *Registry) Reconcile(ctx context.Context, apps []*appmetapb.AppManifest, charts []*appmetapb.ChartManifest, dryRun bool) (*repository.ReconcileResult, error) {
-	return reconcile(r.state, apps, charts, dryRun)
+func (r *Registry) Reconcile(ctx context.Context, apps []*appmetapb.AppManifest, charts []*appmetapb.ChartManifest, source repository.ReconcileSource, dryRun bool) (*repository.ReconcileResult, error) {
+	return reconcile(r.state, apps, charts, source, dryRun)
 }
 
 func (r *Registry) ListApps(ctx context.Context, filter repository.AppListFilter) ([]repository.App, error) {

--- a/tools/app_registry/server/repository/fake/reconcile.go
+++ b/tools/app_registry/server/repository/fake/reconcile.go
@@ -13,7 +13,16 @@ import (
 // AGENTS-2a.md's ReconcileApps scope. It is shared logic the postgres
 // implementation mirrors in SQL — see postgres/app.go's Reconcile for the
 // same state machine expressed as UPDATE/INSERT statements.
-func reconcile(s *state, apps []*appmetapb.AppManifest, charts []*appmetapb.ChartManifest, dryRun bool) (*repository.ReconcileResult, error) {
+//
+// source/watermark handling mirrors postgres/app.go exactly (see its doc
+// comments and ARCHITECTURE.md "Reconcile watermark"): a dry run never
+// reads or writes workState.Watermark at all -- it operates on a throwaway
+// clone the caller discards, and the watermark check would be meaningless
+// against it anyway. A real (non-dry-run) call checks
+// repository.ShouldApplyReconcile before doing any diffing, and advances
+// the watermark only after every write below has been computed
+// successfully.
+func reconcile(s *state, apps []*appmetapb.AppManifest, charts []*appmetapb.ChartManifest, source repository.ReconcileSource, dryRun bool) (*repository.ReconcileResult, error) {
 	workState := s
 	if dryRun {
 		workState = s.clone()
@@ -21,6 +30,14 @@ func reconcile(s *state, apps []*appmetapb.AppManifest, charts []*appmetapb.Char
 
 	now := time.Now().UTC()
 	result := &repository.ReconcileResult{}
+
+	if !dryRun {
+		if !repository.ShouldApplyReconcile(source, workState.Watermark) {
+			result.SkippedStale = true
+			result.CurrentWatermarkGitSHA = workState.Watermark.GitSHA
+			return result, nil
+		}
+	}
 
 	presentAppIDs := map[string]bool{}
 	for _, am := range apps {
@@ -128,6 +145,15 @@ func reconcile(s *state, apps []*appmetapb.AppManifest, charts []*appmetapb.Char
 			c.Status = repository.StatusMissing
 			workState.Charts[id] = c
 			result.NewlyMissingCharts = append(result.NewlyMissingCharts, c)
+		}
+	}
+
+	if !dryRun {
+		workState.Watermark = &repository.ReconcileWatermark{
+			GitSHA:            source.GitSHA,
+			SourceCommittedAt: source.SourceCommittedAt,
+			DiscoveredAt:      source.DiscoveredAt,
+			UpdatedAt:         now,
 		}
 	}
 

--- a/tools/app_registry/server/repository/models.go
+++ b/tools/app_registry/server/repository/models.go
@@ -80,6 +80,16 @@ type ReconcileResult struct {
 	UpdatedCharts      []Chart
 	NewlyMissingCharts []Chart
 	RecoveredCharts    []Chart
+
+	// SkippedStale is true when the reconcile watermark rejected this call
+	// as older (in commit order) than the most recently applied one -- see
+	// watermark.go's ShouldApplyReconcile. A no-op success, not an error:
+	// every slice above is empty, and nothing was written. Always false
+	// when the call was a dry run -- dry runs never consult the watermark.
+	SkippedStale bool
+	// CurrentWatermarkGitSHA is the git_sha this call lost to. Populated
+	// only when SkippedStale is true.
+	CurrentWatermarkGitSHA string
 }
 
 // AppListFilter is ListAppsRequest's filter set, decoupled from the proto.

--- a/tools/app_registry/server/repository/postgres/BUILD.bazel
+++ b/tools/app_registry/server/repository/postgres/BUILD.bazel
@@ -73,6 +73,7 @@ go_test(
         "//tools/app_registry/server/auth",
         "//tools/app_registry/server/handlers",
         "//tools/app_registry/server/repository",
+        "//tools/appmeta/proto:appmetapb",
         "@com_github_jackc_pgx_v5//pgconn",
         "@com_github_jackc_pgx_v5//pgxpool",
         "@com_github_jackc_pgx_v5//stdlib",

--- a/tools/app_registry/server/repository/postgres/app.go
+++ b/tools/app_registry/server/repository/postgres/app.go
@@ -68,9 +68,29 @@ func deployUnitToDB(du appmetapb.DeployUnit) string {
 // Reconcile
 // ============================================================================
 
-func (r *appRepo) Reconcile(ctx context.Context, apps []*appmetapb.AppManifest, charts []*appmetapb.ChartManifest, dryRun bool) (*repository.ReconcileResult, error) {
+func (r *appRepo) Reconcile(ctx context.Context, apps []*appmetapb.AppManifest, charts []*appmetapb.ChartManifest, source repository.ReconcileSource, dryRun bool) (*repository.ReconcileResult, error) {
 	now := time.Now().UTC()
 	result := &repository.ReconcileResult{}
+
+	// Watermark check -- see ARCHITECTURE.md "Reconcile watermark" and
+	// watermark.go's ShouldApplyReconcile. A dry run never consults or
+	// advances the watermark: it writes nothing, so there is nothing to
+	// guard. `SELECT ... FOR UPDATE` locks the singleton row for the
+	// remainder of this transaction, so a second concurrent Reconcile call
+	// blocks here until this one commits or rolls back -- that is what
+	// makes two racing callers serialize instead of both reading the same
+	// stale watermark.
+	if !dryRun {
+		current, err := r.getReconcileWatermark(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("reconcile: read watermark: %w", err)
+		}
+		if !repository.ShouldApplyReconcile(source, current) {
+			result.SkippedStale = true
+			result.CurrentWatermarkGitSHA = current.GitSHA
+			return result, nil
+		}
+	}
 
 	presentAppIDs := map[string]bool{}
 	appIDByKey := map[string]string{} // "domain|name" -> app_id, for chart resolution
@@ -258,7 +278,52 @@ func (r *appRepo) Reconcile(ctx context.Context, apps []*appmetapb.AppManifest, 
 		result.NewlyMissingCharts = append(result.NewlyMissingCharts, c)
 	}
 
+	if !dryRun {
+		if err := r.advanceReconcileWatermark(ctx, source, now); err != nil {
+			return nil, fmt.Errorf("reconcile: advance watermark: %w", err)
+		}
+	}
+
 	return result, nil
+}
+
+// getReconcileWatermark reads and locks the singleton reconcile_watermark
+// row (migration 006) with FOR UPDATE, so the read-compare-write sequence
+// in Reconcile is atomic with respect to a concurrent caller doing the
+// same. Returns nil only if the row is somehow absent -- migration 006
+// seeds exactly one row and nothing in this package ever deletes it, so
+// this is a defensive fallback, not the expected "no watermark yet" signal;
+// that signal is GitSHA == "" on a real row -- see
+// repository.ShouldApplyReconcile's doc comment.
+func (r *appRepo) getReconcileWatermark(ctx context.Context) (*repository.ReconcileWatermark, error) {
+	row := r.ex.QueryRow(ctx, `
+		SELECT git_sha, source_committed_at, discovered_at, updated_at
+		FROM reconcile_watermark WHERE id = 1 FOR UPDATE`)
+	var w repository.ReconcileWatermark
+	if err := row.Scan(&w.GitSHA, &w.SourceCommittedAt, &w.DiscoveredAt, &w.UpdatedAt); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &w, nil
+}
+
+// advanceReconcileWatermark overwrites the singleton row with source's
+// ordering metadata. Always an UPDATE in practice (migration 006 seeds the
+// row), but written as an upsert so this stays correct even if the seed row
+// were ever missing.
+func (r *appRepo) advanceReconcileWatermark(ctx context.Context, source repository.ReconcileSource, now time.Time) error {
+	_, err := r.ex.Exec(ctx, `
+		INSERT INTO reconcile_watermark (id, git_sha, source_committed_at, discovered_at, updated_at)
+		VALUES (1, $1, $2, $3, $4)
+		ON CONFLICT (id) DO UPDATE SET
+			git_sha = EXCLUDED.git_sha,
+			source_committed_at = EXCLUDED.source_committed_at,
+			discovered_at = EXCLUDED.discovered_at,
+			updated_at = EXCLUDED.updated_at`,
+		source.GitSHA, source.SourceCommittedAt, source.DiscoveredAt, now)
+	return err
 }
 
 // setChartApps rebuilds chart_app for chartID from scratch.

--- a/tools/app_registry/server/repository/postgres/postgres_integration_test.go
+++ b/tools/app_registry/server/repository/postgres/postgres_integration_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/whale-net/everything/tools/app_registry/server/repository"
 
 	pb "github.com/whale-net/everything/tools/app_registry/protos"
+	appmetapb "github.com/whale-net/everything/tools/appmeta/proto"
 )
 
 // authedCtx returns a context carrying a principal holding every app-registry
@@ -1244,5 +1245,380 @@ func TestMigration004BackfillsVersionColumns(t *testing.T) {
 	}
 	if g := fetch("sha256:backfill-garbage"); g != (got{0, 0, 0}) {
 		t.Fatalf("expected an unparseable legacy version to backfill to the documented 0/0/0 sentinel, got %+v", g)
+	}
+}
+
+// ============================================================================
+// Reconcile watermark (issue #545)
+// ============================================================================
+//
+// These tests exercise exactly what server/repository/fake's reconcile
+// watermark logic cannot: the real migration 006 schema (the seeded
+// sentinel row, the CHECK(id=1) singleton guard), and — most importantly —
+// that SELECT ... FOR UPDATE against the real `reconcile_watermark` row
+// actually serializes two concurrent Reconcile transactions rather than
+// both reading the same stale watermark. See ARCHITECTURE.md "Reconcile
+// watermark" for the full comparison/tie-break rules asserted here.
+
+// reconcileManifests builds an AppManifestSet carrying the ordering
+// metadata Reconcile checks against reconcile_watermark directly, so each
+// test can control git_sha/source_committed_at/discovered_at precisely
+// rather than going through release_helper_go.
+func reconcileManifests(gitSha string, sourceCommittedAt, discoveredAt int64, apps []*appmetapb.AppManifest, charts []*appmetapb.ChartManifest) *appmetapb.AppManifestSet {
+	return &appmetapb.AppManifestSet{
+		GitSha:            gitSha,
+		SourceCommittedAt: sourceCommittedAt,
+		DiscoveredAt:      discoveredAt,
+		Apps:              apps,
+		Charts:            charts,
+	}
+}
+
+func oneAppManifest(domain, name string) *appmetapb.AppManifest {
+	return &appmetapb.AppManifest{
+		Domain: domain, Name: name, Description: "d", Language: "go", AppType: "worker",
+		DeployUnit: appmetapb.DeployUnit_DEPLOY_UNIT_IMAGE,
+	}
+}
+
+// watermarkRow reads the singleton reconcile_watermark row directly via
+// SQL, bypassing the repository layer, so assertions are against ground
+// truth rather than re-testing the same code path they're meant to verify.
+func watermarkRow(t *testing.T, pool *pgxpool.Pool) (gitSha string, sourceCommittedAt, discoveredAt int64) {
+	t.Helper()
+	if err := pool.QueryRow(context.Background(),
+		`SELECT git_sha, source_committed_at, discovered_at FROM reconcile_watermark WHERE id = 1`,
+	).Scan(&gitSha, &sourceCommittedAt, &discoveredAt); err != nil {
+		t.Fatalf("read reconcile_watermark: %v", err)
+	}
+	return gitSha, sourceCommittedAt, discoveredAt
+}
+
+func appStatus(t *testing.T, pool *pgxpool.Pool, appID string) string {
+	t.Helper()
+	var status string
+	if err := pool.QueryRow(context.Background(), `SELECT status FROM app WHERE app_id = $1`, appID).Scan(&status); err != nil {
+		t.Fatalf("read app status for %s: %v", appID, err)
+	}
+	return status
+}
+
+// TestMigration006SeedsSentinelWatermarkRow proves migration 006's seed:
+// exactly one row, the documented sentinel (empty git_sha, zero
+// timestamps) -- see that migration's comments for why a seeded sentinel,
+// not a genuinely empty table, is what "no watermark yet" means at the SQL
+// layer.
+func TestMigration006SeedsSentinelWatermarkRow(t *testing.T) {
+	_, pool := newTestRegistry(t)
+
+	var rowCount int
+	if err := pool.QueryRow(context.Background(), `SELECT count(*) FROM reconcile_watermark`).Scan(&rowCount); err != nil {
+		t.Fatalf("count reconcile_watermark rows: %v", err)
+	}
+	if rowCount != 1 {
+		t.Fatalf("expected exactly 1 seeded row, found %d", rowCount)
+	}
+
+	gitSha, sourceCommittedAt, discoveredAt := watermarkRow(t, pool)
+	if gitSha != "" || sourceCommittedAt != 0 || discoveredAt != 0 {
+		t.Fatalf("expected the documented sentinel (empty git_sha, zero timestamps), got git_sha=%q source_committed_at=%d discovered_at=%d",
+			gitSha, sourceCommittedAt, discoveredAt)
+	}
+}
+
+// TestReconcileWatermark_FirstCallAppliesAgainstEmptyWatermark proves the
+// "empty table (sentinel row) means accept the first call" guarantee, and
+// that a successful apply advances the watermark to the incoming call's
+// ordering metadata.
+func TestReconcileWatermark_FirstCallAppliesAgainstEmptyWatermark(t *testing.T) {
+	reg, pool := newTestRegistry(t)
+	ctx := authedCtx()
+	srv := handlers.NewAppServer(reg)
+
+	resp, err := srv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
+		Manifests:      reconcileManifests("sha-1", 1000, 1100, []*appmetapb.AppManifest{oneAppManifest("acme", "widget")}, nil),
+		IdempotencyKey: "watermark-first-1",
+	})
+	if err != nil {
+		t.Fatalf("reconcile against empty watermark: %v", err)
+	}
+	if resp.SkippedStale {
+		t.Fatalf("expected the first-ever reconcile to apply, got SkippedStale=true")
+	}
+	if len(resp.CreatedApps) != 1 {
+		t.Fatalf("expected 1 created app, got %+v", resp.CreatedApps)
+	}
+
+	gitSha, sourceCommittedAt, discoveredAt := watermarkRow(t, pool)
+	if gitSha != "sha-1" || sourceCommittedAt != 1000 || discoveredAt != 1100 {
+		t.Fatalf("expected watermark to advance to (sha-1, 1000, 1100), got (%q, %d, %d)", gitSha, sourceCommittedAt, discoveredAt)
+	}
+}
+
+// TestReconcileWatermark_StaleCallSkippedAndMutatesNothing is the headline
+// scenario from issue #545: an older commit's reconcile call lands AFTER a
+// newer one's, which had correctly flagged an app MISSING. It proves three
+// things a fake-backed test can assert too, but which matter most against
+// real Postgres because they hinge on the transaction actually rolling
+// back cleanly: (1) the call is a no-op success (SkippedStale=true, not an
+// error), (2) it names the commit it lost to, and (3) NOTHING was
+// written -- most importantly, the MISSING flag the newer call set survives
+// completely untouched, proving the stale call didn't revert it.
+func TestReconcileWatermark_StaleCallSkippedAndMutatesNothing(t *testing.T) {
+	reg, pool := newTestRegistry(t)
+	ctx := authedCtx()
+	srv := handlers.NewAppServer(reg)
+
+	// 1. An early commit reconciles two apps.
+	first, err := srv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
+		Manifests: reconcileManifests("newer-sha", 2000, 2000,
+			[]*appmetapb.AppManifest{oneAppManifest("acme", "widget"), oneAppManifest("acme", "gadget")}, nil),
+		IdempotencyKey: "stale-1",
+	})
+	if err != nil {
+		t.Fatalf("first reconcile: %v", err)
+	}
+	if len(first.CreatedApps) != 2 {
+		t.Fatalf("expected 2 created apps, got %+v", first.CreatedApps)
+	}
+	widgetID, gadgetID := first.CreatedApps[0].AppId, first.CreatedApps[1].AppId
+
+	// 2. A LATER, newer commit correctly drops "gadget" -- it's flagged
+	// MISSING, exactly as ARCHITECTURE.md's triage lifecycle says it should
+	// be.
+	second, err := srv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
+		Manifests: reconcileManifests("newest-sha", 3000, 3000,
+			[]*appmetapb.AppManifest{oneAppManifest("acme", "widget")}, nil),
+		IdempotencyKey: "stale-2",
+	})
+	if err != nil {
+		t.Fatalf("second (newer) reconcile: %v", err)
+	}
+	if len(second.NewlyMissingApps) != 1 || second.NewlyMissingApps[0].AppId != gadgetID {
+		t.Fatalf("expected gadget (%s) newly missing, got %+v", gadgetID, second.NewlyMissingApps)
+	}
+
+	beforeGadgetStatus := appStatus(t, pool, gadgetID)
+	beforeWidgetStatus := appStatus(t, pool, widgetID)
+	if beforeGadgetStatus != "missing" {
+		t.Fatalf("expected gadget to be MISSING before the stale call, got %q", beforeGadgetStatus)
+	}
+	beforeGitSha, beforeSCA, beforeDA := watermarkRow(t, pool)
+
+	// 3. A STALE call: an older commit (source_committed_at between the
+	// first and second) re-runs -- e.g. a manually re-run older CI
+	// workflow, issue #545's headline case. If applied, this would re-mark
+	// "gadget" ACTIVE, silently reverting the second call's correct MISSING
+	// flag.
+	stale, err := srv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
+		Manifests: reconcileManifests("older-rerun-sha", 2500, 2500,
+			[]*appmetapb.AppManifest{oneAppManifest("acme", "widget"), oneAppManifest("acme", "gadget")}, nil),
+		IdempotencyKey: "stale-3",
+	})
+	if err != nil {
+		t.Fatalf("stale reconcile call: %v", err)
+	}
+	if !stale.SkippedStale {
+		t.Fatalf("expected the older call to be skipped as stale, got %+v", stale)
+	}
+	if stale.CurrentWatermarkGitSha != "newest-sha" {
+		t.Fatalf("expected current_watermark_git_sha to name the commit it lost to (newest-sha), got %q", stale.CurrentWatermarkGitSha)
+	}
+	if n := len(stale.CreatedApps) + len(stale.UpdatedApps) + len(stale.NewlyMissingApps) + len(stale.RecoveredApps) +
+		len(stale.CreatedCharts) + len(stale.UpdatedCharts) + len(stale.NewlyMissingCharts) + len(stale.RecoveredCharts); n != 0 {
+		t.Fatalf("expected a completely empty result for a skipped-stale call, got %+v", stale)
+	}
+
+	// Prove nothing was mutated: gadget is STILL MISSING (the stale call
+	// did not revert it to ACTIVE), widget is untouched, and the watermark
+	// did not move.
+	if got := appStatus(t, pool, gadgetID); got != "missing" {
+		t.Fatalf("stale call reverted gadget's MISSING flag -- now %q; this is exactly the bug issue #545 exists to prevent", got)
+	}
+	if got := appStatus(t, pool, gadgetID); got != beforeGadgetStatus {
+		t.Fatalf("stale call mutated gadget's status: was %q, now %q", beforeGadgetStatus, got)
+	}
+	if got := appStatus(t, pool, widgetID); got != beforeWidgetStatus {
+		t.Fatalf("stale call mutated widget's status: was %q, now %q", beforeWidgetStatus, got)
+	}
+	gotGitSha, gotSCA, gotDA := watermarkRow(t, pool)
+	if gotGitSha != beforeGitSha || gotSCA != beforeSCA || gotDA != beforeDA {
+		t.Fatalf("stale call advanced the watermark: was (%q,%d,%d), now (%q,%d,%d)",
+			beforeGitSha, beforeSCA, beforeDA, gotGitSha, gotSCA, gotDA)
+	}
+}
+
+// TestReconcileWatermark_EqualOrderingKeyDifferentGitShaApplies proves the
+// deliberate equal-timestamp tie-break: two different commits landing with
+// the same source_committed_at (a same-second merge, or two calls both
+// falling back to discovered_at) must not block each other.
+func TestReconcileWatermark_EqualOrderingKeyDifferentGitShaApplies(t *testing.T) {
+	reg, pool := newTestRegistry(t)
+	ctx := authedCtx()
+	srv := handlers.NewAppServer(reg)
+
+	if _, err := srv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
+		Manifests:      reconcileManifests("sha-a", 5000, 5000, []*appmetapb.AppManifest{oneAppManifest("acme", "widget")}, nil),
+		IdempotencyKey: "tie-1",
+	}); err != nil {
+		t.Fatalf("first reconcile: %v", err)
+	}
+
+	resp, err := srv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
+		Manifests: reconcileManifests("sha-b", 5000, 5000,
+			[]*appmetapb.AppManifest{oneAppManifest("acme", "widget"), oneAppManifest("acme", "gadget")}, nil),
+		IdempotencyKey: "tie-2",
+	})
+	if err != nil {
+		t.Fatalf("tied-timestamp reconcile: %v", err)
+	}
+	if resp.SkippedStale {
+		t.Fatalf("expected an equal-timestamp, different-git_sha call to apply, got SkippedStale=true")
+	}
+	if len(resp.CreatedApps) != 1 || resp.CreatedApps[0].FullName != "acme-gadget" {
+		t.Fatalf("expected gadget to be newly created, got %+v", resp.CreatedApps)
+	}
+
+	gitSha, sourceCommittedAt, _ := watermarkRow(t, pool)
+	if gitSha != "sha-b" || sourceCommittedAt != 5000 {
+		t.Fatalf("expected watermark to advance to (sha-b, 5000), got (%q, %d)", gitSha, sourceCommittedAt)
+	}
+}
+
+// TestReconcileWatermark_IdenticalGitShaAppliesRegardlessOfTimestamp proves
+// tie-break rule 2: the identical commit reconciled twice always applies,
+// even with an older ordering key the second time (clock skew between two
+// sweeps of the same commit must never produce a false-stale rejection).
+func TestReconcileWatermark_IdenticalGitShaAppliesRegardlessOfTimestamp(t *testing.T) {
+	reg, pool := newTestRegistry(t)
+	ctx := authedCtx()
+	srv := handlers.NewAppServer(reg)
+
+	if _, err := srv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
+		Manifests:      reconcileManifests("same-sha", 9000, 9000, []*appmetapb.AppManifest{oneAppManifest("acme", "widget")}, nil),
+		IdempotencyKey: "same-1",
+	}); err != nil {
+		t.Fatalf("first reconcile: %v", err)
+	}
+
+	resp, err := srv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
+		Manifests: reconcileManifests("same-sha", 1000, 1000, // older than 9000
+			[]*appmetapb.AppManifest{oneAppManifest("acme", "widget"), oneAppManifest("acme", "gadget")}, nil),
+		IdempotencyKey: "same-2",
+	})
+	if err != nil {
+		t.Fatalf("identical-git_sha reconcile: %v", err)
+	}
+	if resp.SkippedStale {
+		t.Fatalf("expected an identical git_sha call to apply regardless of its (older) timestamp, got SkippedStale=true")
+	}
+	if len(resp.CreatedApps) != 1 || resp.CreatedApps[0].FullName != "acme-gadget" {
+		t.Fatalf("expected gadget to be newly created, got %+v", resp.CreatedApps)
+	}
+
+	gitSha, sourceCommittedAt, _ := watermarkRow(t, pool)
+	if gitSha != "same-sha" || sourceCommittedAt != 1000 {
+		t.Fatalf("expected watermark to be refreshed to (same-sha, 1000), got (%q, %d)", gitSha, sourceCommittedAt)
+	}
+}
+
+// TestReconcileWatermark_DryRunNeverConsultsOrAdvancesWatermark proves dry
+// run is unaffected by the watermark in EITHER direction: a dry run
+// carrying an ordering key far older than the current watermark still
+// computes a normal diff (proving the watermark is never consulted to
+// decide skip-or-apply), and the watermark row is byte-for-byte unchanged
+// afterward (proving it's never advanced either).
+func TestReconcileWatermark_DryRunNeverConsultsOrAdvancesWatermark(t *testing.T) {
+	reg, pool := newTestRegistry(t)
+	ctx := authedCtx()
+	srv := handlers.NewAppServer(reg)
+
+	if _, err := srv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
+		Manifests:      reconcileManifests("real-sha", 999999, 999999, []*appmetapb.AppManifest{oneAppManifest("acme", "widget")}, nil),
+		IdempotencyKey: "dry-1",
+	}); err != nil {
+		t.Fatalf("real reconcile: %v", err)
+	}
+	beforeGitSha, beforeSCA, beforeDA := watermarkRow(t, pool)
+
+	resp, err := srv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
+		Manifests: reconcileManifests("dry-run-old-sha", 1, 1,
+			[]*appmetapb.AppManifest{oneAppManifest("acme", "widget"), oneAppManifest("acme", "new-app")}, nil),
+		DryRun: true,
+	})
+	if err != nil {
+		t.Fatalf("dry run reconcile: %v", err)
+	}
+	if resp.SkippedStale {
+		t.Fatalf("dry run must never consult the watermark, so it must never report SkippedStale; got true despite carrying a far-older ordering key")
+	}
+	if len(resp.CreatedApps) != 1 || resp.CreatedApps[0].FullName != "acme-new-app" {
+		t.Fatalf("expected dry run to compute a normal diff (1 created app), got %+v", resp.CreatedApps)
+	}
+
+	gotGitSha, gotSCA, gotDA := watermarkRow(t, pool)
+	if gotGitSha != beforeGitSha || gotSCA != beforeSCA || gotDA != beforeDA {
+		t.Fatalf("dry run advanced the watermark: was (%q,%d,%d), now (%q,%d,%d)",
+			beforeGitSha, beforeSCA, beforeDA, gotGitSha, gotSCA, gotDA)
+	}
+
+	var count int
+	if err := pool.QueryRow(context.Background(), `SELECT count(*) FROM app WHERE domain = 'acme' AND name = 'new-app'`).Scan(&count); err != nil {
+		t.Fatalf("count app rows: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("dry run must write nothing; found %d 'new-app' rows", count)
+	}
+}
+
+// TestReconcileWatermark_ConcurrentCallsSerializeOnTheLockedRow drives two
+// real concurrent Reconcile calls -- a lower ordering key and a higher
+// one -- through separate goroutines and asserts the final watermark is
+// always the HIGHER key, regardless of which goroutine's transaction
+// happened to start first. Without the SELECT ... FOR UPDATE lock on
+// reconcile_watermark, both transactions could read "no watermark yet"
+// concurrently and both apply, racing on which one's final INSERT ... ON
+// CONFLICT DO UPDATE commits last -- which could non-deterministically
+// leave the LOWER key as the final watermark. That would be exactly the
+// kind of unserialized race issue #545 exists to close, so this test
+// would flake/fail on an unlucky interleaving if the locking read were
+// ever removed or weakened.
+func TestReconcileWatermark_ConcurrentCallsSerializeOnTheLockedRow(t *testing.T) {
+	reg, pool := newTestRegistry(t)
+	ctx := authedCtx()
+	srv := handlers.NewAppServer(reg)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	errs := make([]error, 2)
+
+	go func() {
+		defer wg.Done()
+		_, err := srv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
+			Manifests:      reconcileManifests("low-sha", 100, 100, []*appmetapb.AppManifest{oneAppManifest("acme", "widget")}, nil),
+			IdempotencyKey: "race-low",
+		})
+		errs[0] = err
+	}()
+	go func() {
+		defer wg.Done()
+		_, err := srv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
+			Manifests:      reconcileManifests("high-sha", 200, 200, []*appmetapb.AppManifest{oneAppManifest("acme", "widget")}, nil),
+			IdempotencyKey: "race-high",
+		})
+		errs[1] = err
+	}()
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("goroutine %d: %v", i, err)
+		}
+	}
+
+	gitSha, sourceCommittedAt, _ := watermarkRow(t, pool)
+	if gitSha != "high-sha" || sourceCommittedAt != 200 {
+		t.Fatalf("expected the higher ordering key (high-sha, 200) to win regardless of goroutine scheduling, got (%q, %d) -- this means the two concurrent Reconcile calls were NOT properly serialized by the watermark's locking read",
+			gitSha, sourceCommittedAt)
 	}
 }

--- a/tools/app_registry/server/repository/repository.go
+++ b/tools/app_registry/server/repository/repository.go
@@ -44,7 +44,21 @@ type AppRepository interface {
 	// chart.apps entries are resolved to app_ids and the call fails with
 	// ErrInvalidArgument if any name is unknown. dryRun computes the result
 	// without writing.
-	Reconcile(ctx context.Context, apps []*appmetapb.AppManifest, charts []*appmetapb.ChartManifest, dryRun bool) (*ReconcileResult, error)
+	//
+	// source carries the ordering metadata (git_sha / source_committed_at /
+	// discovered_at) this call is checked against the reconcile watermark
+	// with -- see ARCHITECTURE.md "Reconcile watermark", watermark.go's
+	// ShouldApplyReconcile, and issue #545. When dryRun is true, source is
+	// ignored entirely: a dry run must never consult or advance the
+	// watermark. When dryRun is false and the watermark rejects source as
+	// stale, Reconcile returns a result with SkippedStale set and writes
+	// nothing -- a no-op success, not an error (a re-run of an older CI
+	// workflow correctly declining to revert newer state must not fail).
+	// Implementations MUST perform the watermark read (locking, e.g.
+	// `SELECT ... FOR UPDATE`) and the apply-or-skip decision inside the
+	// SAME transaction as the app/chart writes, so two concurrent Reconcile
+	// calls serialize rather than both reading a stale watermark.
+	Reconcile(ctx context.Context, apps []*appmetapb.AppManifest, charts []*appmetapb.ChartManifest, source ReconcileSource, dryRun bool) (*ReconcileResult, error)
 
 	ListApps(ctx context.Context, filter AppListFilter) ([]App, error)
 	GetAppByID(ctx context.Context, appID string) (*App, error)

--- a/tools/app_registry/server/repository/watermark.go
+++ b/tools/app_registry/server/repository/watermark.go
@@ -1,0 +1,75 @@
+package repository
+
+import "time"
+
+// ReconcileWatermark is the state of the singleton reconcile_watermark row
+// (migration 006) at the instant it was read -- see ARCHITECTURE.md
+// "Reconcile watermark" and issue #545. A GitSHA of "" is the sentinel value
+// the migration seeds the row with and means the SAME thing a caller sees
+// as "there is no watermark yet" -- see ShouldApplyReconcile.
+type ReconcileWatermark struct {
+	GitSHA            string
+	SourceCommittedAt int64
+	DiscoveredAt      int64
+	UpdatedAt         time.Time
+}
+
+// ReconcileSource is the ordering metadata one ReconcileApps call carries,
+// sourced directly from AppManifestSet.git_sha / source_committed_at /
+// discovered_at (appmeta.proto). Passed to AppRepository.Reconcile so the
+// watermark comparison lives next to the write it guards, inside the same
+// transaction.
+type ReconcileSource struct {
+	GitSHA            string
+	SourceCommittedAt int64
+	DiscoveredAt      int64
+}
+
+// effectiveOrderingKey is source_committed_at when populated (nonzero),
+// falling back to discovered_at otherwise. See appmeta.proto's doc comment
+// on source_committed_at for why discovered_at (sweep time) is not a valid
+// ordering key on its own, and why the fallback exists anyway: backward
+// compatibility with an AppManifestSet produced by a release_helper_go
+// binary that predates the field.
+func effectiveOrderingKey(sourceCommittedAt, discoveredAt int64) int64 {
+	if sourceCommittedAt != 0 {
+		return sourceCommittedAt
+	}
+	return discoveredAt
+}
+
+// ShouldApplyReconcile implements the watermark comparison and tie-break
+// rules from ARCHITECTURE.md "Reconcile watermark":
+//
+//   - No watermark yet (current == nil, or current.GitSHA == "" -- the
+//     sentinel row migration 006 seeds, indistinguishable to callers from a
+//     wholly absent row): apply. The very first reconcile is always
+//     accepted.
+//   - incoming.GitSHA == current.GitSHA: apply, unconditionally. The
+//     identical commit reconciled twice (a manual re-run of the same
+//     workflow run, or the CLI pointed at the same manifest set again with
+//     a fresh idempotency key) is harmless to re-apply -- idempotency
+//     already covers true RPC-level replays, this covers the same commit
+//     arriving via two different calls -- and clock skew between two
+//     sweeps of the SAME commit must never produce a false-stale rejection.
+//   - Otherwise, compare effectiveOrderingKey(incoming) against
+//     effectiveOrderingKey(current). Strictly older: skip (stale). Equal or
+//     newer: apply. The equal case is deliberate, not an edge case being
+//     waved through -- two different commits landing in the same
+//     wall-clock second (or two manifest sets both falling back to
+//     discovered_at) must not block a legitimate merge just because they
+//     tied.
+//
+// This is shared, not duplicated, by every AppRepository implementation
+// (postgres and fake) — see promotability.go's DerivePromotability for the
+// same pattern and rationale.
+func ShouldApplyReconcile(incoming ReconcileSource, current *ReconcileWatermark) bool {
+	if current == nil || current.GitSHA == "" {
+		return true
+	}
+	if incoming.GitSHA == current.GitSHA {
+		return true
+	}
+	return effectiveOrderingKey(incoming.SourceCommittedAt, incoming.DiscoveredAt) >=
+		effectiveOrderingKey(current.SourceCommittedAt, current.DiscoveredAt)
+}

--- a/tools/appmeta/proto/appmeta.proto
+++ b/tools/appmeta/proto/appmeta.proto
@@ -129,6 +129,26 @@ message AppManifestSet {
   // Commit the sweep was taken at.
   string git_sha = 3;
 
-  // Unix timestamp of the sweep.
+  // Unix timestamp of the sweep (i.e. when release_helper_go ran `bazel
+  // query`) -- NOT the commit's position in history. A manually re-run older
+  // CI workflow sweeps at re-run time, so this value is NOT monotonic in
+  // commit order and must not be used to order reconcile calls -- see
+  // source_committed_at below, and issue #545.
   int64 discovered_at = 4;
+
+  // Committer timestamp (Unix seconds) of the commit at git_sha, e.g. `git
+  // log -1 --format=%ct <git_sha>`. This -- not discovered_at -- is the
+  // ordering key the app registry's Reconcile watermark uses to detect a
+  // stale (older-commit) call landing after a newer one: unlike
+  // discovered_at, it reflects the commit's real position in history
+  // regardless of when or how many times it was swept. See
+  // tools/app_registry/ARCHITECTURE.md "Reconcile watermark" and issue #545.
+  //
+  // Zero means "not resolved" -- release_helper_go leaves this unset rather
+  // than failing the manifest-set command when git is unavailable or git_sha
+  // can't be resolved to a commit (e.g. a shallow clone missing the object).
+  // The registry falls back to discovered_at when this is zero, which also
+  // keeps an AppManifestSet produced by a release_helper_go binary that
+  // predates this field working unmodified.
+  int64 source_committed_at = 5;
 }

--- a/tools/release_helper_go/cmd/manifest_set.go
+++ b/tools/release_helper_go/cmd/manifest_set.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -56,8 +57,9 @@ callers must not filter it before sending.`,
 			}
 
 			set := &appmetapb.AppManifestSet{
-				GitSha:       sha,
-				DiscoveredAt: time.Now().Unix(),
+				GitSha:            sha,
+				DiscoveredAt:      time.Now().Unix(),
+				SourceCommittedAt: resolveSourceCommittedAt(defaultGit, sha),
 			}
 			for i := range apps {
 				set.Apps = append(set.Apps, apps[i].AppManifest)
@@ -77,4 +79,26 @@ callers must not filter it before sending.`,
 
 	cmd.Flags().StringVar(&gitSHA, "git-sha", "", "Commit SHA to record (default: git rev-parse HEAD)")
 	return cmd
+}
+
+// resolveSourceCommittedAt returns the git committer timestamp (Unix
+// seconds) of sha, for AppManifestSet.source_committed_at -- the app
+// registry's reconcile-watermark ordering key (see appmeta.proto's doc
+// comment on that field and issue #545). Unlike git_sha resolution above,
+// a failure here does NOT fail the command: this field is a correctness
+// improvement over discovered_at, not a hard requirement, and the server
+// falls back to discovered_at when it's 0 (e.g. git unavailable, or sha
+// unresolvable -- a shallow clone missing the commit object). Losing the
+// stronger ordering guarantee for one call is far better than breaking
+// manifest-set entirely.
+func resolveSourceCommittedAt(git GitRunner, sha string) int64 {
+	out, err := git.Run("log", "-1", "--format=%ct", sha)
+	if err != nil {
+		return 0
+	}
+	v, err := strconv.ParseInt(strings.TrimSpace(out), 10, 64)
+	if err != nil {
+		return 0
+	}
+	return v
 }

--- a/tools/release_helper_go/cmd/manifest_set_test.go
+++ b/tools/release_helper_go/cmd/manifest_set_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -40,6 +41,37 @@ func buildFakeAppAndChartInfra(apps []fakeApp, charts []fakeHelmChart) *fakeBaze
 	)
 }
 
+// containsJSONField reports whether stdout contains a `"key": "value"` pair,
+// tolerating protojson's deliberately-randomized whitespace after the colon
+// (google.golang.org/protobuf/internal/detrand: seeded from a hash of the
+// compiled test binary itself, specifically to stop code from depending on
+// exact byte-for-byte formatting — it flips between one and two spaces
+// across different builds of the SAME source, so asserting a literal
+// `":  "` is a latent bug regardless of what it's checking). Matches only a
+// string-typed value; see containsJSONNumberField for numeric/bare values.
+func containsJSONField(t *testing.T, stdout, key, value string) bool {
+	t.Helper()
+	pattern := `"` + regexp.QuoteMeta(key) + `":\s*"` + regexp.QuoteMeta(value) + `"`
+	matched, err := regexp.MatchString(pattern, stdout)
+	if err != nil {
+		t.Fatalf("bad regexp %q: %v", pattern, err)
+	}
+	return matched
+}
+
+// containsJSONNumberField is containsJSONField for a bare (unquoted)
+// numeric value, e.g. an enum serialized as its wire integer instead of its
+// name.
+func containsJSONNumberField(t *testing.T, stdout, key, value string) bool {
+	t.Helper()
+	pattern := `"` + regexp.QuoteMeta(key) + `":\s*` + regexp.QuoteMeta(value) + `\D`
+	matched, err := regexp.MatchString(pattern, stdout)
+	if err != nil {
+		t.Fatalf("bad regexp %q: %v", pattern, err)
+	}
+	return matched
+}
+
 func TestManifestSet_ContainsAppsAndCharts(t *testing.T) {
 	apps := []fakeApp{
 		{pkg: "demo/hello_go", targetSuffix: "hello-go_metadata", name: "hello-go", domain: "demo"},
@@ -56,13 +88,13 @@ func TestManifestSet_ContainsAppsAndCharts(t *testing.T) {
 					if err != nil {
 						t.Fatalf("unexpected error: %v", err)
 					}
-					if !strings.Contains(stdout, `"name":  "hello-go"`) {
+					if !containsJSONField(t, stdout, "name", "hello-go") {
 						t.Errorf("expected app in output, got: %s", stdout)
 					}
-					if !strings.Contains(stdout, `"name":  "helm-manmanv2-control-services"`) {
+					if !containsJSONField(t, stdout, "name", "helm-manmanv2-control-services") {
 						t.Errorf("expected chart in output, got: %s", stdout)
 					}
-					if !strings.Contains(stdout, `"gitSha":  "deadbeefcafe"`) {
+					if !containsJSONField(t, stdout, "gitSha", "deadbeefcafe") {
 						t.Errorf("expected gitSha from git rev-parse HEAD, got: %s", stdout)
 					}
 					if !strings.Contains(stdout, `"discoveredAt"`) {
@@ -96,11 +128,71 @@ func TestManifestSet_EnumsSerializeAsNames(t *testing.T) {
 					if err != nil {
 						t.Fatalf("unexpected error: %v", err)
 					}
-					if !strings.Contains(stdout, `"deployUnit":  "DEPLOY_UNIT_IMAGE"`) {
+					if !containsJSONField(t, stdout, "deployUnit", "DEPLOY_UNIT_IMAGE") {
 						t.Errorf("expected deployUnit to serialize as its enum name, got: %s", stdout)
 					}
-					if strings.Contains(stdout, `"deployUnit":  2`) {
+					if containsJSONNumberField(t, stdout, "deployUnit", "2") {
 						t.Errorf("deployUnit serialized as an integer, not a name: %s", stdout)
+					}
+				})
+			})
+		})
+	})
+}
+
+// TestManifestSet_SourceCommittedAtFromGitLog covers the happy path: `git
+// log -1 --format=%ct <sha>` succeeds and its value lands on
+// source_committed_at, the app registry's reconcile-watermark ordering key
+// (see appmeta.proto and issue #545).
+func TestManifestSet_SourceCommittedAtFromGitLog(t *testing.T) {
+	bazel := buildFakeAppAndChartInfra(nil, nil)
+	git := newFakeGit(
+		fakeGitCall{argsContain: []string{"rev-parse", "HEAD"}, output: "deadbeefcafe"},
+		fakeGitCall{argsContain: []string{"log", "-1", "--format=%ct", "deadbeefcafe"}, output: "1700000000\n"},
+	)
+
+	withFS(newFakeFS(), func() {
+		withBazel(bazel, func() {
+			withGit(git, func() {
+				withWorkspace(fakeWorkspaceRoot, func() {
+					stdout, _, err := runTest([]string{"manifest-set"})
+					if err != nil {
+						t.Fatalf("unexpected error: %v", err)
+					}
+					if !containsJSONField(t, stdout, "sourceCommittedAt", "1700000000") {
+						t.Errorf("expected sourceCommittedAt from git log, got: %s", stdout)
+					}
+				})
+			})
+		})
+	})
+}
+
+// TestManifestSet_SourceCommittedAtFallsBackToZeroOnGitFailure covers the
+// "git isn't available or the sha can't be resolved" case from issue #545:
+// the command must NOT fail, and source_committed_at must be left at its
+// zero value so the server falls back to discovered_at (see
+// appmeta.proto's doc comment on source_committed_at). protojson omits a
+// zero-valued scalar field entirely by default (no EmitUnpopulated), so the
+// expected shape is simply "the field is absent," not "the field is 0".
+func TestManifestSet_SourceCommittedAtFallsBackToZeroOnGitFailure(t *testing.T) {
+	bazel := buildFakeAppAndChartInfra(nil, nil)
+	git := newFakeGit(
+		fakeGitCall{argsContain: []string{"rev-parse", "HEAD"}, output: "deadbeefcafe"},
+		// No "log" call registered -- fakeGitRunner.Run returns an error,
+		// which resolveSourceCommittedAt must swallow.
+	)
+
+	withFS(newFakeFS(), func() {
+		withBazel(bazel, func() {
+			withGit(git, func() {
+				withWorkspace(fakeWorkspaceRoot, func() {
+					stdout, _, err := runTest([]string{"manifest-set"})
+					if err != nil {
+						t.Fatalf("expected manifest-set to succeed despite git log failing, got: %v", err)
+					}
+					if strings.Contains(stdout, `"sourceCommittedAt"`) {
+						t.Errorf("expected sourceCommittedAt to be omitted (zero value) when git log fails, got: %s", stdout)
 					}
 				})
 			})
@@ -122,7 +214,7 @@ func TestManifestSet_GitSHAFlagOverridesGit(t *testing.T) {
 					if err != nil {
 						t.Fatalf("unexpected error: %v", err)
 					}
-					if !strings.Contains(stdout, `"gitSha":  "explicit-sha"`) {
+					if !containsJSONField(t, stdout, "gitSha", "explicit-sha") {
 						t.Errorf("expected explicit --git-sha to be used, got: %s", stdout)
 					}
 				})


### PR DESCRIPTION
## What

Adds a server-side monotonic ordering guard to `ReconcileApps`, so an older
reconcile call landing after a newer one can no longer silently revert
registry state.

- **New migration `006_reconcile_watermark`** — a singleton watermark table
  (`CHECK (id = 1)`) holding the ordering key, `git_sha`, `discovered_at`
  and `updated_at`.
- **`AppRepository.Reconcile` gained a `ReconcileSource{GitSHA,
  SourceCommittedAt, DiscoveredAt}` parameter.** The Postgres implementation
  reads and locks the watermark (`SELECT … FOR UPDATE`) inside the
  transaction the non-dry-run path already runs in, decides apply-vs-skip,
  and only on apply writes the diff and advances the watermark — atomically.
- **New `AppManifestSet.source_committed_at`** (proto field 5), the git
  committer timestamp of `git_sha`, resolved by `release_helper_go
  manifest-set` via `git log -1 --format=%ct <sha>`.
- **`ReconcileAppsResponse.skipped_stale` + `current_watermark_git_sha`**,
  logged server-side at `Warn` and surfaced by the CLI as a stderr banner.

## Why

`Reconcile()` wrote unconditionally: every app/chart row's `status` and
`last_seen_at` was overwritten on every call with no comparison against
stored state. Since #543, it runs from `ci.yml` on every push to `main`, and
`app`/`chart` are not SCD2 — so a stale write clobbers current state with no
error, no log, and no way to tell afterwards. #546 (a CI `concurrency` group)
is a partial mitigation only; this is the actual fix.

Closes #545

## Design notes / guesses

Called out because these were decided without asking.

### 1. The ordering key is `source_committed_at`, not `discovered_at`

The issue proposes comparing the incoming `discovered_at`. **As populated
today that field cannot work as an ordering key:**
`tools/release_helper_go/cmd/manifest_set.go` sets it to
`time.Now().Unix()` — the *sweep* time on the runner, not the commit's
position in history. A manually re-run older workflow (the issue's headline
case) therefore sweeps *now* and carries a strictly *newer* `discovered_at`,
sailing straight past a naive watermark.

So this PR adds `source_committed_at` and keys the watermark on it, falling
back to `discovered_at` when it is `0`. Zero is the deliberate outcome when
git is unavailable or the sha can't be resolved (shallow clone) — that
degrades to today's behaviour rather than failing the release helper.

### 2. The watermark table is seeded with a sentinel row, not left empty

Deliberate deviation from the obvious "empty table means no watermark yet."
`SELECT … FOR UPDATE` locks only rows it *matches*, so against an empty
table it locks nothing — two concurrent first-ever reconciles would both
read "no watermark" and race unserialized. The migration therefore seeds one
row (`git_sha = ''`, timestamps `0`). The sentinel is invisible above the SQL
layer: `repository.ShouldApplyReconcile` treats `GitSHA == ""` exactly like a
nil watermark.

### 3. A stale call is a no-op **success**, not an error

A CI re-run of an older commit must not turn the workflow red for correctly
declining to clobber newer state. It is reported rather than silent:
`skipped_stale` in the response, a `Warn` server log, and a CLI banner.

### 4. Tie-breaking rules

Evaluated in this order:

1. No watermark → **apply**.
2. Identical `git_sha` → **apply** regardless of timestamps. Re-applying the
   same manifest set is harmless, and this makes the guard immune to clock
   skew on a re-run of the *same* commit.
3. Ordering key strictly older than the watermark → **skip**.
4. Otherwise (equal or newer) → **apply**. Equal-timestamp ties favour
   applying, so two merges landing in the same second don't block each other.

### 5. Idempotency-key interaction

A skipped-stale response **is** stored under the idempotency key, like any
other success. A retry with the same key must replay the same answer rather
than potentially flipping from skipped to applied because the watermark moved
between the two calls.

### 6. Dry run is untouched

It writes nothing, so it neither consults nor advances the watermark. There
is a test for this.

## Test evidence

| Command | Result |
|---|---|
| `bazel test //tools/app_registry/... //tools/release_helper_go/... //tools/appmeta/...` | **PASS** — 9/9 targets |
| `bazel test //...` (whole repo) | **PASS** — 89/89 |
| `bazel test //tools/app_registry/server/repository/postgres:postgres_integration_test` | **PASS** — real Postgres in Docker, ~35 tests |

Seven new real-Postgres integration tests: first call with no watermark
applies; a strictly-older call is skipped and provably mutates nothing
(including that a `MISSING` flag set by the newer call survives);
equal-timestamp/different-sha applies; identical-sha applies; dry run leaves
the watermark untouched; concurrent calls serialize (the higher sha wins
regardless of goroutine scheduling); the sentinel seed behaves as "no
watermark". Plus fake-backed handler tests in `server/handlers/app_test.go`.

### Incidental fix

`tools/release_helper_go/cmd/manifest_set_test.go` had a latent pre-existing
bug: protojson's `internal/detrand` randomizes whitespace *per compiled
binary* specifically to discourage exact-format dependence, and three tests
asserted a literal double space. Changing the binary flipped it to a single
space and they failed. Replaced with whitespace-tolerant assertions.

## Stack

Layer 2 of 3:

1. #551 — #548, contextual owner-not-found message
2. **this PR** — #545, server-side monotonic reconcile guard
3. #547 — release-vs-reconcile gap: decision + stop swallowing the error

🤖 Generated with [Claude Code](https://claude.com/claude-code)
