### PR TITLE
fix(release): helm charts silently shipped app images pinned to 'latest'

### DIFF
--- a/tools/release_helper_go/cmd/build_helm.go
+++ b/tools/release_helper_go/cmd/build_helm.go
@@ -63,19 +63,24 @@ func newBuildHelmChartCmd() *cobra.Command {
 			}
 
 			// Resolve app versions
-			appVersions := map[string]string{}
+			allApps, err := ListAllApps(defaultBazel, defaultFS, workspaceRoot)
+			if err != nil {
+				return err
+			}
+			var appVersions map[string]string
 			if useReleasedVersions {
-				allApps, err := ListAllApps(defaultBazel, defaultFS, workspaceRoot)
-				if err != nil {
-					return err
-				}
 				appVersions, err = resolveChartAppVersions(chart, allApps, defaultGit)
 				if err != nil {
 					return err
 				}
 			} else {
+				appVersions = map[string]string{}
 				for _, appName := range chart.Apps {
-					appVersions[appName] = "latest"
+					matched, err := findChartApp(appName, chart.Domain, allApps)
+					if err != nil {
+						return err
+					}
+					appVersions[matched.FullName()] = "latest"
 				}
 			}
 
@@ -170,28 +175,41 @@ func autoIncrementHelmVersion(chartName, bumpType string, git GitRunner) (string
 func resolveChartAppVersions(chart HelmChartMetadata, allApps []AppMetadata, git GitRunner) (map[string]string, error) {
 	versions := map[string]string{}
 	for _, appName := range chart.Apps {
-		// Try to find app in allApps by name and domain
-		var matched *AppMetadata
-		for i := range allApps {
-			a := &allApps[i]
-			if a.Name == appName && a.Domain == chart.Domain {
-				matched = a
-				break
-			}
-			if a.Name == appName {
-				matched = a
-			}
-		}
-		if matched == nil {
-			return nil, fmt.Errorf("app %q not found for chart %q", appName, chart.Name)
+		matched, err := findChartApp(appName, chart.Domain, allApps)
+		if err != nil {
+			return nil, err
 		}
 		ver, err := getLatestAppVersion(matched.Domain, matched.Name, git)
 		if err != nil || ver == "" {
 			return nil, fmt.Errorf("no released version for app %q in domain %q", matched.Name, matched.Domain)
 		}
-		versions[matched.Name] = ver
+		versions[matched.FullName()] = ver
 	}
 	return versions, nil
+}
+
+// findChartApp resolves one of a chart's declared app names to its full
+// AppMetadata, preferring a match within the chart's own domain. The
+// returned metadata's FullName() ("<domain>-<name>") is the key composer.go
+// uses for the values.yaml `apps` map, so callers must key appVersions by
+// FullName() rather than the bare app name for packageChartWithVersion's
+// imageTag lookup to find it.
+func findChartApp(appName, chartDomain string, allApps []AppMetadata) (*AppMetadata, error) {
+	var matched *AppMetadata
+	for i := range allApps {
+		a := &allApps[i]
+		if a.Name == appName && a.Domain == chartDomain {
+			matched = a
+			break
+		}
+		if a.Name == appName {
+			matched = a
+		}
+	}
+	if matched == nil {
+		return nil, fmt.Errorf("app %q not found for chart domain %q", appName, chartDomain)
+	}
+	return matched, nil
 }
 
 func getLatestAppVersion(domain, appName string, git GitRunner) (string, error) {

--- a/tools/release_helper_go/cmd/build_helm.go
+++ b/tools/release_helper_go/cmd/build_helm.go
@@ -269,24 +269,39 @@ func packageChartWithVersion(chartDir, chartName, version, outDir string, appVer
 		}
 	}
 
-	// Update values.yaml imageTag for resolved app versions
+	// Update values.yaml imageTag for resolved app versions. A resolved
+	// version that fails to land in values.yaml is worse than useless — it
+	// silently ships whatever imageTag was baked in at `bazel build` time
+	// (typically "latest"), so every step here fails hard rather than
+	// swallowing the error, unlike the historical version of this code.
 	valuesYaml := filepath.Join(tmpChartDir, "values.yaml")
 	if len(appVersions) > 0 {
-		if data, err := os.ReadFile(valuesYaml); err == nil {
-			var values map[string]interface{}
-			if err := yaml.Unmarshal(data, &values); err == nil {
-				if apps, ok := values["apps"].(map[string]interface{}); ok {
-					for appKey, ver := range appVersions {
-						if appEntry, ok := apps[appKey].(map[string]interface{}); ok {
-							appEntry["imageTag"] = ver
-							fmt.Printf("Updated %s imageTag to %s\n", appKey, ver)
-						}
-					}
-				}
-				if out, err := yaml.Marshal(values); err == nil {
-					_ = os.WriteFile(valuesYaml, out, 0644)
-				}
+		data, err := os.ReadFile(valuesYaml)
+		if err != nil {
+			return "", fmt.Errorf("read values.yaml: %w", err)
+		}
+		var values map[string]interface{}
+		if err := yaml.Unmarshal(data, &values); err != nil {
+			return "", fmt.Errorf("parse values.yaml: %w", err)
+		}
+		apps, ok := values["apps"].(map[string]interface{})
+		if !ok {
+			return "", fmt.Errorf("values.yaml has no \"apps\" map to set imageTag on")
+		}
+		for appKey, ver := range appVersions {
+			appEntry, ok := apps[appKey].(map[string]interface{})
+			if !ok {
+				return "", fmt.Errorf("values.yaml \"apps\" has no entry %q to set imageTag on (chart's apps map may use a different key convention than the resolved app versions)", appKey)
 			}
+			appEntry["imageTag"] = ver
+			fmt.Printf("Updated %s imageTag to %s\n", appKey, ver)
+		}
+		out, err := yaml.Marshal(values)
+		if err != nil {
+			return "", fmt.Errorf("marshal values.yaml: %w", err)
+		}
+		if err := os.WriteFile(valuesYaml, out, 0644); err != nil {
+			return "", fmt.Errorf("write values.yaml: %w", err)
 		}
 	}
 

--- a/tools/release_helper_go/cmd/build_helm_test.go
+++ b/tools/release_helper_go/cmd/build_helm_test.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	appmetapb "github.com/whale-net/everything/tools/appmeta/proto"
@@ -69,5 +72,51 @@ func TestFindChartAppPrefersChartDomain(t *testing.T) {
 	}
 	if matched.Domain != "manmanv2" {
 		t.Errorf("expected match in chart's own domain, got domain %q", matched.Domain)
+	}
+}
+
+// ── packageChartWithVersion's values.yaml imageTag guardrail ───────────────
+//
+// These tests only exercise the appVersions-key-mismatch failure path,
+// which returns before packageChartWithVersion ever shells out to `helm
+// package` — the Bazel go_test target has no `helm` binary as a data
+// dependency, so a success-path test would fail on `helm: executable file
+// not found` rather than testing anything meaningful here.
+
+func TestPackageChartWithVersionErrorsOnKeyMismatch(t *testing.T) {
+	chartDir := t.TempDir()
+	writeFile(t, filepath.Join(chartDir, "Chart.yaml"), "name: control-services\nversion: 0.0.0-dev\n")
+	// values.yaml keyed the way composer.go actually keys it.
+	writeFile(t, filepath.Join(chartDir, "values.yaml"), "apps:\n  manmanv2-event-processor:\n    imageTag: latest\n")
+
+	// A bare app name, as the pre-fix resolveChartAppVersions produced,
+	// must not silently no-op against the domain-prefixed values.yaml key.
+	appVersions := map[string]string{"event-processor": "v0.2.18"}
+
+	_, err := packageChartWithVersion(chartDir, "helm-manmanv2-control-services", "v0.2.18", t.TempDir(), appVersions)
+	if err == nil {
+		t.Fatal("expected error when appVersions key doesn't match values.yaml apps key, got nil")
+	}
+	if !strings.Contains(err.Error(), "event-processor") {
+		t.Errorf("expected error to name the unmatched key, got: %v", err)
+	}
+}
+
+func TestPackageChartWithVersionErrorsOnMissingAppsMap(t *testing.T) {
+	chartDir := t.TempDir()
+	writeFile(t, filepath.Join(chartDir, "Chart.yaml"), "name: control-services\nversion: 0.0.0-dev\n")
+	writeFile(t, filepath.Join(chartDir, "values.yaml"), "global:\n  namespace: manmanv2\n")
+
+	appVersions := map[string]string{"manmanv2-event-processor": "v0.2.18"}
+	_, err := packageChartWithVersion(chartDir, "helm-manmanv2-control-services", "v0.2.18", t.TempDir(), appVersions)
+	if err == nil {
+		t.Fatal("expected error when values.yaml has no apps map, got nil")
+	}
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
 	}
 }

--- a/tools/release_helper_go/cmd/build_helm_test.go
+++ b/tools/release_helper_go/cmd/build_helm_test.go
@@ -1,0 +1,73 @@
+package cmd
+
+import (
+	"testing"
+
+	appmetapb "github.com/whale-net/everything/tools/appmeta/proto"
+)
+
+// ── findChartApp / resolveChartAppVersions ─────────────────────────────────
+
+func testApps() []AppMetadata {
+	return []AppMetadata{
+		{AppManifest: &appmetapb.AppManifest{Name: "control-api", Domain: "manmanv2"}, BazelTarget: "//manmanv2/api:control-api_metadata"},
+		{AppManifest: &appmetapb.AppManifest{Name: "event-processor", Domain: "manmanv2"}, BazelTarget: "//manmanv2/processor:event-processor_metadata"},
+	}
+}
+
+// TestResolveChartAppVersionsKeysByFullName pins the app-versions map to
+// composer.go's values.yaml key convention ("<domain>-<name>", i.e.
+// AppMetadata.FullName()). packageChartWithVersion looks up
+// appVersions[appKey] against the values.yaml "apps" map, which composer.go
+// keys by FullName() — keying by the bare app name here would make every
+// lookup silently miss and leave the chart's baked-in "latest" imageTag in
+// place, which is exactly the bug this test guards against.
+func TestResolveChartAppVersionsKeysByFullName(t *testing.T) {
+	chart := HelmChartMetadata{ChartManifest: &appmetapb.ChartManifest{
+		Name: "helm-manmanv2-control-services", Domain: "manmanv2",
+		Apps: []string{"control-api", "event-processor"},
+	}}
+	git := newFakeGit(
+		fakeGitCall{argsContain: []string{"tag", "--list", "manmanv2-control-api.*"}, output: "manmanv2-control-api.v1.2.3"},
+		fakeGitCall{argsContain: []string{"tag", "--list", "manmanv2-event-processor.*"}, output: "manmanv2-event-processor.v0.2.18"},
+	)
+
+	versions, err := resolveChartAppVersions(chart, testApps(), git)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := map[string]string{
+		"manmanv2-control-api":     "v1.2.3",
+		"manmanv2-event-processor": "v0.2.18",
+	}
+	for key, ver := range want {
+		if got := versions[key]; got != ver {
+			t.Errorf("versions[%q] = %q, want %q (full versions map: %v)", key, got, ver, versions)
+		}
+	}
+	// Bare app names must NOT be used as keys.
+	if _, ok := versions["event-processor"]; ok {
+		t.Errorf("versions must be keyed by FullName(), not bare app name; got bare-name key in %v", versions)
+	}
+}
+
+func TestFindChartAppNotFound(t *testing.T) {
+	if _, err := findChartApp("nonexistent", "manmanv2", testApps()); err == nil {
+		t.Fatal("expected error for unknown app")
+	}
+}
+
+func TestFindChartAppPrefersChartDomain(t *testing.T) {
+	apps := []AppMetadata{
+		{AppManifest: &appmetapb.AppManifest{Name: "worker", Domain: "other"}},
+		{AppManifest: &appmetapb.AppManifest{Name: "worker", Domain: "manmanv2"}},
+	}
+	matched, err := findChartApp("worker", "manmanv2", apps)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if matched.Domain != "manmanv2" {
+		t.Errorf("expected match in chart's own domain, got domain %q", matched.Domain)
+	}
+}


### PR DESCRIPTION
## Summary

Reproduces and fixes the bug reported for `whalenet/manmanv2-control-services`: the chart's `Chart.yaml` version bumps correctly on every release (`v0.2.18` was correctly the latest), but the `manmanv2-event-processor` image the chart references resolved to `ghcr.io/whale-net/manmanv2-event-processor:latest` in the cluster instead of a pinned version — even though a new versioned image had just been published.

**Root cause:** key mismatch between how `resolveChartAppVersions` (in `tools/release_helper_go/cmd/build_helm.go`) keys its resolved app-version map and how `composer.go`'s `generateValuesYaml` keys the chart's `values.yaml` `apps` map.

- `composer.go` keys `values.yaml`'s `apps` map by `"<domain>-<name>"` (`AppMetadata.FullName()`, e.g. `manmanv2-event-processor`) — this convention was added in #216 (Oct 2025).
- `resolveChartAppVersions` keyed its returned map by the bare app name (`event-processor`).
- `packageChartWithVersion` looks up `appVersions[appKey]` against `values.yaml`'s `apps` map to overwrite the baked-in `imageTag`. With the bare-name key, that lookup always missed — silently. No error, just a no-op.

Every chart therefore kept whatever `imageTag` the Bazel-built chart shipped with by default, which is `"latest"` (see `GetImageTag` in `tools/helm/composer.go`, dev builds have no `Version`).

This has been broken since the Go rewrite of `release_helper` (#440, May 2026) — the Python predecessor's composer already used the domain-app key convention, and had its own historical fix for shipping `latest` (#213), but the Go rewrite re-keyed version resolution using the bare name and reintroduced the bug. Confirmed against the failing run: [Release Helm Charts job](https://github.com/whale-net/everything/actions/runs/31409243490/job/93525917682) shows `Auto-determined chart version ... v0.2.18` and a successful package, but **zero** `Updated <app> imageTag to <version>` log lines — meaning the imageTag rewrite silently affected nothing for any app in the chart, not just the event processor.

## Fix

1. Key `resolveChartAppVersions`'s (and the `--use-released=false` fallback path's) returned map by `AppMetadata.FullName()`, matching `composer.go`. Factored the shared app-lookup-by-name into `findChartApp`.
2. Make `packageChartWithVersion`'s `values.yaml` rewrite fail hard (instead of silently swallowing errors) on read/parse/marshal/write failure, a missing `apps` map, or a resolved app version with no matching `values.yaml` entry — this exact silent-failure pattern is how the bug shipped undetected for months.
3. Added regression tests: `TestResolveChartAppVersionsKeysByFullName` (pins the map keys to `FullName()`, fails if bare names are reintroduced — verified it reproduces the original bug when reverted), plus tests covering the new hard-fail paths in `packageChartWithVersion`.

No configuration or cluster changes — this only fixes the release tooling that builds and packages the chart. The next release run of `manmanv2` (or any `release_helm_chart`) will correctly pin `imageTag` to the resolved app versions.

## Test plan
- [x] `bazel test //tools/release_helper_go/... //tools/helm/...` — all pass (one pre-existing, unrelated flaky `TestManifestSet_GitSHAFlagOverridesGit`/`EnumsSerializeAsNames` failure observed on `main` too, timestamp-based, not touched by this change)
- [x] Reverted the fix locally and confirmed `TestResolveChartAppVersionsKeysByFullName` fails with the exact bare-name mismatch, then confirmed it passes with the fix restored
- [ ] Next real `manmanv2` (or any) helm release run should show `Updated <domain>-<app> imageTag to <version>` lines for every app, and the published chart's `values.yaml` should carry the pinned tag — worth eyeballing on the next release