### PR TITLE
docs(app-registry): AR-7 release lifecycle design + plan (#558)

### DIFF
--- a/tools/app_registry/ARCHITECTURE.md
+++ b/tools/app_registry/ARCHITECTURE.md
@@ -75,6 +75,12 @@ erDiagram
 | `domain_adoption` | mutable | One row per domain; `stage` ∈ observe/promote/allocate. See "Resolved questions" #3. |
 | `reconcile_watermark` | singleton, mutable | Migration 006 (issue #545). Exactly one row (`id = 1`), seeded as a sentinel. Guards `Reconcile` against a stale (older-commit) call — see "Reconcile watermark" below. |
 
+**Planned (AR-7, issue #558; none of this is built):** `artifact` gains
+`state`/`provenance` with nullable `digest`/`build_id`, absorbing
+`version_allocation`, which is dropped; `app`/`chart` shed their mutable
+metadata to new append-only `app_manifest`/`chart_manifest` snapshot tables and
+a `v_current_app` view. See "Release lifecycle (issue #558)" below.
+
 ### SCD2 on `promotion`
 
 Follows the repo-wide convention in `AGENTS.md` exactly:
@@ -286,6 +292,12 @@ not."
 
 ## Release-vs-reconcile gap (issue #547)
 
+> **Superseded in design, still true as-built.** Issue #558 rejects "accept
+> the gap" as the end state — see "Release lifecycle (issue #558)" below,
+> which closes it by splitting identity assertion from the absence sweep.
+> Everything in this section describes what is deployed today and stays
+> accurate until AR-7c ships.
+
 `ReconcileApps` runs only from `ci.yml` on push to `main` (#543); `release.yml`
 is a `workflow_dispatch` a human triggers, often immediately after merging —
 this is normal usage, not an edge case. That decoupling opens a window: a
@@ -372,6 +384,264 @@ ref" cannot self-heal the way "release right after merging to `main`" can.
 No machinery is planned for this; it is accepted as part of the same
 tradeoff above, not a separate gap to close.
 
+## Release lifecycle (issue #558)
+
+**Status: designed, not built.** Delivery is PLAN.md's AR-7 (AR-7a … AR-7e).
+Nothing in this section is deployed; every table/column/RPC named here is
+proposed. It supersedes "Release-vs-reconcile gap (issue #547)" above, and
+changes what "Availability and bootstrap" below promises — both are
+cross-referenced where that happens.
+
+### The problem: four cross-run orderings, three of them unenforced
+
+A release run and a `main`-push reconcile are separate CI runs with no
+ordering between them. Four orderings must hold for the registry to be
+correct; only one is actually enforced.
+
+| # | Required ordering | Enforced by | Failure |
+|---|---|---|---|
+| 1 | reconcile of commit `C` **before** `RecordArtifact` for an app introduced in `C` | nothing — accepted gap (#547) | exit 3, artifact never recorded and **never backfilled**; that build can never be promoted |
+| 2 | newer reconcile **after** older reconcile | `reconcile_watermark` (#545) + CI concurrency (#546) | solved |
+| 3 | `RecordArtifact(IMAGE, digest D)` **before** any chart pinning `D` | hard server-side reject (`postgres/artifact.go`, "chart pins unrecorded image digest") | chart artifact not recorded |
+| 4 | app rows exist **before** a chart manifest referencing them resolves | `resolveChartApps` fails the **entire** reconcile | repo-wide identity registration wedged, inside a green `main` CI job |
+
+Ordering 3 is the expensive one, because charts pin digests resolved from
+**GHCR by tag** (`docker buildx imagetools inspect ${IMG_REPO}:${IMG_VERSION}`
+in `release.yml`), not from the current run's outputs — so any chart-only
+release pins images published by earlier runs. One image that never got
+recorded (it hit ordering 1, or recording was `continue-on-error` during a
+registry blip) therefore breaks **every future chart release containing that
+app**, permanently: re-running the chart release doesn't fix it (the digest is
+still unrecorded), and reconcile doesn't fix it (reconcile writes identity,
+never artifacts). It only clears when that app is rebuilt and recorded again.
+
+Ordering 4 is the quiet one: one chart manifest naming a removed app, or an
+ambiguous bare app name across two domains, rolls back the whole transaction,
+so the watermark never advances and no app registers at all — while the job
+stays green because the step is `continue-on-error`.
+
+### The principle that resolves it
+
+**The registry is the source of truth for the pipeline. GHCR and the chart
+repository remain the source of truth for artifacts.** Those are different
+claims and keeping them apart is what makes the rest coherent:
+
+- Nothing reads the registry to find out whether an image *exists* — the push
+  is what makes it exist, and the digest the push returned is what gets
+  recorded. A `published` row is proof-of-existence *at the instant it was
+  written*, and deliberately not a live existence check (an image deleted from
+  GHCR afterwards leaves a row that lies; a periodic verifier is a possible
+  later addition, not a guarantee offered now).
+- Because the artifacts themselves survive independently, a registry that is
+  lost, restored from backup, or wrong can be repaired out of band. That path
+  is disaster recovery ("shit is fucked"), not routine maintenance — see
+  "Adoption and disaster recovery" below.
+
+### Artifact lifecycle: `allocated → publishing → published`
+
+The registry stops learning about an artifact *after* the fact. It records the
+intent to publish **before** the push, and completes the record after.
+
+| State | Written by | version | build_id | digest |
+|---|---|---|---|---|
+| `allocated` | `AllocateVersion` (AR-5) | ✓ | — | — |
+| `publishing` | release run, immediately **before** the GHCR/chart push | ✓ | ✓ | — |
+| `published` | release run, after the push, carrying the digest the push returned | ✓ | ✓ | ✓ |
+| `failed` | release run on error, or the reaper on timeout | ✓ | ✓ | — |
+
+**This removes a table rather than adding one.** `version_allocation` exists
+only because `artifact.digest`/`build_id` are `NOT NULL` and allocation
+happens before a build — i.e. it already *is* the `allocated` state, stored
+elsewhere. Migration 007 makes those two columns nullable, adds `state`, folds
+`version_allocation` rows into `artifact`, and drops it. `UNIQUE (owner_id,
+kind, version)` then spans every state, which is strictly stronger than
+today's two-table arrangement: it is the allocation collision guard, and
+"next version" collapses from a max across two tables into one query.
+`artifact_digest_idx` becomes `UNIQUE ... WHERE digest IS NOT NULL`.
+
+Legal transitions, enforced server-side; anything else is `FailedPrecondition`:
+
+- `∅ → allocated` (`AllocateVersion`), `∅ → publishing` (`BeginPublish`
+  without a prior allocation — the pre-cutover path, see below),
+  `allocated → publishing` (`BeginPublish`), `publishing → published`
+  (`RecordArtifact`), `publishing → failed` (`FailPublish`, or the reaper),
+  `failed → publishing` (a later run retrying the same version).
+- `published` is terminal. Re-recording the same digest is an idempotent
+  success; recording a *different* digest for an already-`published` version
+  is rejected — that is a real conflict, not a retry.
+
+**What this buys.** Ordering 3's hard reject stops being a trap: the image row
+exists from `publishing` onward, so a chart failing on "pins an image the
+registry doesn't have" now means the image genuinely was never published,
+which is worth failing on. The registry never reconstructs or infers a record
+it didn't observe (an explicitly rejected alternative — see below).
+
+**The reaper is not optional.** A cancelled workflow leaves a `publishing` row
+forever, and "what is incomplete?" is only a usable recovery query if it does
+not accumulate ghosts. `app-registry-worker` sweeps `publishing` rows older
+than `WRITEBACK`-style configured staleness to `failed` with reason `stale`.
+Ships with AR-7b, not after it.
+
+**Backward compatibility during rollout.** `RecordArtifact` against no
+existing row keeps working, creating the row directly in `published` —
+allowed while a domain is at adoption stage `observe`, rejected at
+`allocate` (where allocation must have happened first). That is what lets CI
+adopt `BeginPublish` per domain instead of in one cutover.
+
+### App identity vs. per-build manifest snapshot
+
+Today `app` carries *mutable metadata* — `deploy_unit`, `image_repository`,
+`bazel_label`, `app_type`, description — and some ref has to author it. Every
+answer to "which ref?" is bad: let any ref write it and it drifts; let only
+`main` write it and releases depend on `main`'s CI (ordering 1). The question
+is removed rather than answered:
+
+- `app` / `chart` become **pure identity**: `(domain, name)`, `status`,
+  first/last-seen provenance. Nothing mutable.
+- The `AppManifest`/`ChartManifest` a run was built from is stored **verbatim**
+  (protojson, `JSONB`) in an append-only `app_manifest` / `chart_manifest`
+  snapshot table, keyed `(owner_id, source_git_sha)` — same commit, same
+  manifest, so writes are naturally idempotent — with `source_committed_at`
+  and whether it came from the `main` sweep or a release run.
+- `artifact.manifest_id` records which snapshot an artifact was built from,
+  and **`artifact.promotability` becomes a stored column** derived from that
+  snapshot at publish time.
+
+Consequences, in order of importance:
+
+1. **A release from any ref writes only facts.** Divergent branch, old tag,
+   unmerged PR — none of them can write mutable state, so there is no drift to
+   bound, observe, or correct, and identity assertion becomes safe from
+   anywhere. This is what closes ordering 1 without the provisional-upsert
+   trade #547 rejected.
+2. **Promotability stops being retroactive.** `RecordArtifact` currently
+   re-reads the owner's *current* `deploy_unit` (`postgres/artifact.go`'s
+   "re-derive promotability against the freshly-read owner deploy_unit"), so
+   editing a `release_app` rule today silently changes the promotability of
+   artifacts published years ago. Deriving from the build's own snapshot is a
+   correctness fix, not a refactor.
+3. **The `main` sweep shrinks to what only it can do**: existence and absence.
+4. **"Value at time T" without SCD2 on `app`.** The per-build snapshot *is*
+   the history, append-only, matching how the rest of this schema works. (This
+   is also why #553's answer — `chart`/`chart_app` are not SCD2 and don't need
+   to be — still holds.)
+
+Cost: reads that want "what does this app look like today" need the newest
+`main` snapshot, via a `v_current_app` view (identity ⋈ latest `main`-sweep
+snapshot), the same pre-joined-view pattern `v_current_promotion` uses.
+`ListApps`/`GetApp` responses are unchanged on the wire.
+
+### `AssertApps` (additive) vs. `ReconcileApps` (absence sweep)
+
+`ReconcileApps` conflates two jobs: assert identity, and assert *absence*.
+Only absence needs a canonical complete tree, and it is identity that releases
+depend on. Split them:
+
+| RPC | Runs from | Writes | Never does |
+|---|---|---|---|
+| `AssertApps` | any ref — `release.yml`, first step of a release | identity rows (`∅→ACTIVE`, `MISSING→ACTIVE` recovered) + manifest snapshots | mark anything `MISSING` |
+| `ReconcileApps` | `main` push only, unchanged watermark | `MISSING` transitions, `chart_app` membership, `main` snapshots | assert identity from a non-canonical ref |
+
+`AssertApps` against an `ARCHIVED` app is **rejected** per item — a human said
+that app is gone for good, and a release resurrecting it silently is worse
+than a red step. `RecordArtifact` against an `ARCHIVED` owner is likewise
+rejected (today it succeeds, which is not intended).
+
+**The sweep becomes partially-applying** (ordering 4): a chart whose apps
+don't resolve is reported as unresolved in `ReconcileAppsResponse` and skipped;
+every other app and chart still applies and the watermark still advances.
+Separately, chart manifests move to **domain-qualified app references**, so
+`resolveChartApps`'s cross-domain ambiguity (`SELECT app_id FROM app WHERE
+name = $1` with more than one match) cannot arise. Both are small, independent
+of everything else here, and fix a failure mode that is silent today — they
+land first (AR-7a).
+
+### The run log: CI orchestrates, the registry records
+
+A release run spans real GHCR pushes, so it cannot be one database
+transaction, and it must not become one: re-pushing eight images because the
+ninth failed is exactly wrong. The saga shape is right, with one boundary held
+firmly — **the registry keeps the saga *log*; it does not *orchestrate* the
+saga.** CI stays the actor that pushes and reports transitions. The moment the
+registry drives steps, design principle 5 ("Record, don't act") breaks and it
+becomes a deployment system. Concretely: no Temporal workflow on the inbound
+path. `writeback_outbox` + Temporal stays what it is — the *outbound* path
+(registry → gitops). Inbound is a state log CI writes to.
+
+**This needs no new tables either.** `build` is already the run aggregate
+(`(workflow_run_id, workflow_attempt)` unique); the artifact rows in
+`allocated`/`publishing`/`published`/`failed` are its children. So:
+
+- "What is incomplete?" = artifacts for this build not in `published`.
+- **Re-running a release job becomes a resume**, not a blind retry: the run log
+  names exactly which children are short of `published`, so the job re-attempts
+  those and then the chart, instead of redoing everything or failing the same
+  way.
+- Exposed as `GetReleaseRun(workflow_run_id[, attempt])` and
+  `app-registry builds status --incomplete` (AR-7d).
+
+**Boundary, stated deliberately:** the registry logs what was *attempted*;
+GitHub logs what was *planned*. A run that dies before reaching an app leaves
+no row for it, and that is visible as a red CI job rather than as registry
+state. Declaring the intended child set up front (a `build_target` table
+written by the plan step) was considered and is **not** in AR-7 — at adoption
+stage `allocate` the allocation step already writes the intent set as
+`allocated` rows, so the gap only exists pre-cutover. See "Open questions".
+
+### Availability, restated per adoption stage
+
+"The registry can be down for hours without blocking a release" and "the
+registry is the source of truth for the pipeline" cannot both hold once
+`publishing` must be written before a push. Rather than add a lever, the
+existing one carries it: `domain_adoption.stage` already means "what is the
+registry authoritative for," so it also means "how critical is it."
+
+| Stage | Recording | Registry outage during a release |
+|---|---|---|
+| `observe` | best-effort, `continue-on-error` | release proceeds; a record may be missing (today's behavior) |
+| `promote` | required — the recording step fails the job | release fails rather than silently skipping a record that later chart releases depend on |
+| `allocate` | release-critical | release cannot proceed; the registry hands out the version number |
+
+At `allocate` the registry is already release-critical whether or not this is
+written down — `AllocateVersion` is in the version path. Per-domain rollback is
+moving the stage back; the global rollback is still
+`APP_REGISTRY_CICD_OPT_IN=false`. This restates, and partially retracts, the
+promise in "Availability and bootstrap" below; that section stays accurate for
+`observe`, which is where every domain is today.
+
+### Adoption and disaster recovery
+
+Charts pin digests resolved from GHCR by tag, so a chart can pin an image
+published before the registry existed, or while the opt-in was off. There is no
+run to resume for those, they will never be in the registry, and under
+"registry is source of truth" the chart correctly — and permanently — fails.
+
+**The way out is an explicit, bounded adoption path** (`AdoptArtifact`, admin
+role only, not the builder credential): record a pre-existing GHCR image or
+chart as `published` with `provenance = 'adopted'` and a required reason.
+`artifact.provenance ∈ ('observed', 'adopted')` makes "which rows did we take
+on faith?" a query rather than an archaeology exercise. It is used lazily —
+when a chart release fails on an unknown pin — not as a bulk backfill, which
+"Resolved questions" #3 still rejects.
+
+The same path is the disaster-recovery path if the registry is lost or
+restored behind: GHCR and the chart repository still hold the artifacts, so
+state is re-adoptable. OPERATIONS.md carries the runbook (AR-7e). The design
+goal is that this is *rare and deliberate*, not a recurring chore — every
+other part of AR-7 exists to keep it that way.
+
+### Rejected alternatives (issue #558)
+
+| Approach | Why rejected |
+|---|---|
+| `AssertApps` upsert alone, keeping `app`'s mutable metadata | Fixes ordering 1 only, and forces the divergent-ref trade (#547) instead of removing it: some ref must author mutable metadata, and every choice of ref is wrong. Moving metadata to per-build snapshots deletes the question. |
+| Infer the missing image artifact from the chart lockfile at chart-record time | Makes the registry *reconstruct* a record it never observed, so "was this published or inferred?" becomes a permanent question on every row. `publishing → published` means the record was always there — less machinery, stronger claim. |
+| One atomic `RecordRelease` RPC (build + assertions + images + charts + links in one transaction) | A release spans real GHCR pushes; it cannot be one database transaction. All-or-nothing would also discard expensive partial progress. The run log gives the same "a re-run is a complete repair" property, as *resume*. |
+| Registry orchestrates the release saga (inbound Temporal workflow) | Breaks "Record, don't act" — the registry would become a deployment system. CI orchestrates; the registry logs. Temporal stays on the outbound writeback path only. |
+| SCD2 on `app` for "what did this app look like at time T" | The append-only per-build manifest snapshot already *is* the history and matches the rest of the schema; SCD2 on identity would add a second history mechanism. Consistent with #553. |
+| A `build_target` table declaring the run's intended children up front | Deferred, not rejected outright — `allocated` rows already carry intent at stage `allocate`. See "Open questions". |
+| Enforce "charts may only pin registry-known images" at chart **compose** time | Deferred (AR-7f). It is the steady state that makes chart builds genuinely hermetic and fails early instead of after every push, but it means no chart can build until every member app has released through the registry once — a real cutover cost that should follow adoption, not precede it. |
+
 ## Promotability
 
 The rule the whole system hangs on. Each app declares its `deploy_unit` in its
@@ -431,6 +701,13 @@ the highest-value part of the recording phase and should not be deferred.
 
 The server rejects a chart artifact that references an image digest it has never
 recorded — a chart may not pin an unknown artifact.
+
+That reject is correct but is a trap today, because charts pin digests
+published by *earlier* runs: one image that never got recorded breaks every
+future chart release containing it, permanently. The artifact lifecycle in
+"Release lifecycle (issue #558)" is what makes the reject safe to keep — the
+image's row exists from `publishing` onward, so failing here means the image
+genuinely was never published.
 
 **This is also the deploy-time idempotency guarantee for a promoted chart's
 app list — see "Resolved questions" #4.** `contains` is a pure function of
@@ -599,6 +876,13 @@ API synchronously**:
 The registry can be down for hours without blocking a release or a deploy. The
 only thing lost is the ability to *make new promotions* during the outage.
 
+> **Scoped to adoption stage `observe` by issue #558.** The claim above holds
+> exactly while a domain's recording is best-effort. At `promote` recording
+> becomes required, and at `allocate` the registry is in the version path and
+> an outage does block that domain's releases — see "Release lifecycle (issue
+> #558)" → "Availability, restated per adoption stage". Every domain is at
+> `observe` today, so nothing here is wrong yet.
+
 ### `APP_REGISTRY_CICD_OPT_IN` — the bootstrap kill switch
 
 "Best-effort" is not enough on its own. The registry is built and released by
@@ -656,6 +940,15 @@ when the opt-in is off, or a registry outage becomes a release outage.
 | Reconcile watermark granularity | one singleton row for the whole registry | a watermark per app/chart row | `Reconcile` is always a full-replace of the complete manifest set (see "Design principles" #1) — there is exactly one meaningful "most recent complete sweep," so a per-row watermark would have to answer a question that cannot arise under this write model ("was this one row from a newer sweep than that one"). |
 | Release-vs-reconcile gap (#547) | accept the gap; make the failure a distinct, actionable annotation instead of silent | a release-time provisional upsert, always superseded by the next real reconcile | Reintroduces a second write path to `app`/`chart`, the exact thing the "App/chart registration" row above already rejected. Unsafe against a `release.yml` ref that diverges from `main` (see "Release-vs-reconcile gap" above): it could write stale metadata that nothing corrects until the next `main` reconcile happens to run. |
 | Release-vs-reconcile gap (#547) | accept the gap; make the failure a distinct, actionable annotation instead of silent | gate `release.yml` on `main`'s reconcile completing first | Avoids a second write path, but every release would block on `main` CI. The repo owner releases immediately after merging as normal practice; this would turn an occasional recording miss into a mandatory wait on every release. |
+
+**Revised by AR-7 (issue #558).** The three rows above about registration and
+the #547 gap rejected a release-time write path *because `app` carries mutable
+metadata that a divergent ref could clobber*. AR-7 removes that premise by
+moving the metadata to per-build manifest snapshots, at which point
+`AssertApps` writes identity and facts only — the objection is answered, not
+overruled. The full-replace/`MISSING` reasoning is untouched: absence still
+belongs to the `main` sweep alone. Issue #558's own rejected alternatives are
+tabled in "Release lifecycle (issue #558)" above.
 
 ## Future: approval gate
 
@@ -802,5 +1095,34 @@ correctness, and is not needed today.
 
 ## Open questions
 
-None blocking. The gitops repo layout is deferred rather than unresolved — it
-is answered when the writeback stub is replaced with the real implementation.
+The gitops repo layout is deferred rather than unresolved — it is answered when
+the writeback stub is replaced with the real implementation.
+
+The rest are AR-7 (issue #558) refinements. None blocks starting AR-7a/AR-7b;
+each is a decision the phase that reaches it must make explicitly rather than
+by default.
+
+1. **Does the run log need a declared intent set pre-cutover?** AR-7 derives
+   "what is incomplete" from artifact rows the run actually attempted, so a run
+   that dies before reaching an app leaves nothing behind (visible only as a
+   red CI job). At stage `allocate` the allocation step writes the intent set
+   as `allocated` rows and the gap closes on its own. The alternative is a
+   `build_target` table written by the plan step — exact at every stage, one
+   more table, and it duplicates something GitHub already knows.
+2. **Should the `main`-push `reconcile-app-registry` job stop being
+   `continue-on-error`?** The wedge in ordering 4 stayed invisible because a
+   red step sits inside a green job. AR-7a makes the sweep partially-applying,
+   which removes the repo-wide blast radius but not the invisibility. The job
+   gates nothing downstream, so failing it red is cheap; it does mean a
+   registry outage turns `main` CI red.
+3. **Where exactly does recording become mandatory?** The stage table above
+   puts it at `promote`. It could equally be at `allocate` only, keeping
+   `promote` best-effort — the tradeoff is how long an unrecorded image can
+   silently accumulate before it breaks a chart release.
+4. **Manifest snapshots as verbatim `JSONB` vs. typed columns.** Verbatim is
+   chosen (it is the appmeta contract, and `protojson` already round-trips it);
+   typed columns would make snapshot-level SQL filtering possible without a
+   `->>` expression index. Revisit only if a real query needs it.
+5. **AR-7f — compose-time enforcement that charts may only pin registry-known
+   images.** The genuine hermeticity fix, deliberately sequenced after
+   adoption. Decide whether it is the steady state or never.

--- a/tools/app_registry/ARCHITECTURE.md
+++ b/tools/app_registry/ARCHITECTURE.md
@@ -76,7 +76,7 @@ erDiagram
 | `reconcile_watermark` | singleton, mutable | Migration 006 (issue #545). Exactly one row (`id = 1`), seeded as a sentinel. Guards `Reconcile` against a stale (older-commit) call — see "Reconcile watermark" below. |
 
 **Planned (AR-7, issue #558; none of this is built):** `artifact` gains
-`state`/`provenance` with nullable `digest`/`build_id`, absorbing
+`state`/`provenance`/`version_source` with nullable `digest`/`build_id`, absorbing
 `version_allocation`, which is dropped; `app`/`chart` shed their mutable
 metadata to new append-only `app_manifest`/`chart_manifest` snapshot tables and
 a `v_current_app` view. See "Release lifecycle (issue #558)" below.
@@ -531,6 +531,15 @@ Cost: reads that want "what does this app look like today" need the newest
 snapshot), the same pre-joined-view pattern `v_current_promotion` uses.
 `ListApps`/`GetApp` responses are unchanged on the wire.
 
+**Storage: verbatim protojson `JSONB`, plus stored generated columns for the
+fields the hot paths read** (`deploy_unit`, `image_repository`) — decided in
+review of PR #559. The JSONB stays the single source of truth, so a new
+appmeta field needs no migration and cannot drift from the manifest; the
+generated columns keep `v_current_app` and promotability derivation ordinarily
+indexable instead of resting on `->>` expression indexes. Fully typed columns
+were rejected: they would reintroduce the hand-maintained duplicate of the
+manifest schema that AR-M spent a phase deleting.
+
 ### `AssertApps` (additive) vs. `ReconcileApps` (absence sweep)
 
 `ReconcileApps` conflates two jobs: assert identity, and assert *absence*.
@@ -580,13 +589,31 @@ path. `writeback_outbox` + Temporal stays what it is — the *outbound* path
 - Exposed as `GetReleaseRun(workflow_run_id[, attempt])` and
   `app-registry builds status --incomplete` (AR-7d).
 
-**Boundary, stated deliberately:** the registry logs what was *attempted*;
-GitHub logs what was *planned*. A run that dies before reaching an app leaves
-no row for it, and that is visible as a red CI job rather than as registry
-state. Declaring the intended child set up front (a `build_target` table
-written by the plan step) was considered and is **not** in AR-7 — at adoption
-stage `allocate` the allocation step already writes the intent set as
-`allocated` rows, so the gap only exists pre-cutover. See "Open questions".
+**The intent set is written up front, at every adoption stage** (decided in
+review of PR #559). The release plan step writes one `allocated` artifact row
+per target *before* anything is pushed — at stage `allocate` that row is the
+`AllocateVersion` result; at `observe`/`promote` the version still comes from
+the tag path and the registry is merely recording the intent. So "is this run
+complete?" is exact from the first phase rather than only after the AR-5
+cutover, and the cutover itself becomes a change of *who authors the version*,
+not a new write.
+
+Two consequences that are part of the design, not caveats:
+
+- `allocated` means "this run intends to publish this version" — who *chose*
+  the version is a separate axis, `artifact.version_source ∈ ('registry',
+  'tag')`. That column is not bookkeeping for its own sake: AR-5's parity exit
+  criterion ("allocated versions match what tag-scanning would have produced")
+  becomes a query over rows that carry both, instead of a manual comparison
+  against soak data.
+- **The reaper must expire stale `allocated` rows too**, not just
+  `publishing`. A cancelled run would otherwise hold a version number in
+  `UNIQUE (owner_id, kind, version)` forever. Same sweep, same timeout
+  configuration, `failed` with reason `stale`.
+
+Declaring the set in a separate `build_target` table was considered and
+rejected: the `allocated` state already is the declaration, and a second table
+would restate it in a shape that can disagree with what the run actually did.
 
 ### Availability, restated per adoption stage
 
@@ -602,12 +629,27 @@ registry authoritative for," so it also means "how critical is it."
 | `promote` | required — the recording step fails the job | release fails rather than silently skipping a record that later chart releases depend on |
 | `allocate` | release-critical | release cannot proceed; the registry hands out the version number |
 
+Recording becomes mandatory at `promote`, not only at `allocate` (decided in
+review of PR #559): under the artifact lifecycle an unrecorded image is no
+longer merely a missing row — it makes every later chart release pinning it
+reject, so "skip it and carry on" is the expensive option, not the safe one.
+
 At `allocate` the registry is already release-critical whether or not this is
 written down — `AllocateVersion` is in the version path. Per-domain rollback is
 moving the stage back; the global rollback is still
 `APP_REGISTRY_CICD_OPT_IN=false`. This restates, and partially retracts, the
 promise in "Availability and bootstrap" below; that section stays accurate for
 `observe`, which is where every domain is today.
+
+**The `main`-push sweep is not on this scale — it fails red on any error**
+(decided in review of PR #559). `ci.yml`'s `reconcile-app-registry` job drops
+`continue-on-error` entirely: a rejected sweep is our manifests being wrong,
+an unreachable registry is worth knowing about immediately, and the job gates
+nothing downstream, so a red costs attention and nothing else. The consequence
+is deliberate and worth stating plainly: **once the opt-in is on, a registry
+outage turns `main` CI red**, and `APP_REGISTRY_CICD_OPT_IN=false` is the only
+lever that stops it. That is the same kill switch the rest of the integration
+already hangs on, not a new one.
 
 ### Adoption and disaster recovery
 
@@ -630,6 +672,30 @@ state is re-adoptable. OPERATIONS.md carries the runbook (AR-7e). The design
 goal is that this is *rare and deliberate*, not a recurring chore — every
 other part of AR-7 exists to keep it that way.
 
+### Relationship to AR-5 (allocation cutover)
+
+**AR-7 does not conflict with what remains of AR-5, and belongs strictly
+before it.** AR-5a shipped `AllocateVersion` fully implemented and *inert* —
+no domain is at stage `allocate`, `plan.go`'s `autoIncrementVersion` is
+untouched, and `version_allocation` is empty in every environment. That is the
+cheapest possible moment to re-home its storage into `artifact` (AR-7b):
+after a cutover, migration 007 would be folding rows a live release path is
+writing.
+
+What AR-7 does to each of AR-5's remaining items:
+
+| AR-5 leftover | Effect of AR-7 |
+|---|---|
+| Replace `autoIncrementVersion` in `plan.go` | Unchanged in shape — but the plan step is already writing an intent row per target by then (`version_source = 'tag'`), so the cutover flips *who authors the version*, not who writes the row. |
+| Seed each domain's starting version from its tags at cutover | Largely obviated: by cutover the registry already holds tag-derived versions as real `artifact` rows, so "latest" is answerable from the table that `AllocateVersion` reads. |
+| Parity check ("allocated versions match tag-scanning") | Becomes a query rather than a manual comparison against soak logs — `version_source` records which path authored each version, and a shadow allocation can be compared against the recorded tag version while a domain is still at `observe`. |
+| Per-domain cutover gate, rollback by moving the stage back | Unchanged, and now carries two more meanings (recording mandatory at `promote`, compose-time chart enforcement at `allocate`). |
+| Remove the release workflow's version-allocation concurrency group | Unchanged AR-5 concern. AR-7's `UNIQUE (owner_id, kind, version)` across all states is the constraint that makes dropping it safe. |
+
+The one ordering rule: **do not move any domain to `allocate` before AR-7b
+lands.** Everything else in AR-7 can be built, merged, and run while every
+domain sits at `observe`.
+
 ### Rejected alternatives (issue #558)
 
 | Approach | Why rejected |
@@ -639,8 +705,8 @@ other part of AR-7 exists to keep it that way.
 | One atomic `RecordRelease` RPC (build + assertions + images + charts + links in one transaction) | A release spans real GHCR pushes; it cannot be one database transaction. All-or-nothing would also discard expensive partial progress. The run log gives the same "a re-run is a complete repair" property, as *resume*. |
 | Registry orchestrates the release saga (inbound Temporal workflow) | Breaks "Record, don't act" — the registry would become a deployment system. CI orchestrates; the registry logs. Temporal stays on the outbound writeback path only. |
 | SCD2 on `app` for "what did this app look like at time T" | The append-only per-build manifest snapshot already *is* the history and matches the rest of the schema; SCD2 on identity would add a second history mechanism. Consistent with #553. |
-| A `build_target` table declaring the run's intended children up front | Deferred, not rejected outright — `allocated` rows already carry intent at stage `allocate`. See "Open questions". |
-| Enforce "charts may only pin registry-known images" at chart **compose** time | Deferred (AR-7f). It is the steady state that makes chart builds genuinely hermetic and fails early instead of after every push, but it means no chart can build until every member app has released through the registry once — a real cutover cost that should follow adoption, not precede it. |
+| A `build_target` table declaring the run's intended children up front | Rejected: the plan step writes `allocated` rows at every adoption stage (see "The run log"), so that state already *is* the declaration. A second table would restate it in a shape that can disagree with the run. |
+| Enforce "charts may only pin registry-known images" at chart **compose** time, repo-wide | Rejected as a repo-wide switch, kept as a per-domain one (AR-7f): gated on `domain_adoption.stage = 'allocate'`, exactly like every other tightening here. Repo-wide, no chart could build until every member app had released through the registry once; per-domain, a domain only meets the strict rule after it has been releasing through the registry anyway, and chart builds fail before anything is pushed instead of after. |
 
 ## Promotability
 
@@ -1098,31 +1164,13 @@ correctness, and is not needed today.
 The gitops repo layout is deferred rather than unresolved — it is answered when
 the writeback stub is replaced with the real implementation.
 
-The rest are AR-7 (issue #558) refinements. None blocks starting AR-7a/AR-7b;
-each is a decision the phase that reaches it must make explicitly rather than
-by default.
+All five AR-7 (issue #558) refinements that were parked here have been decided
+in review of PR #559 and folded into the sections that own them:
 
-1. **Does the run log need a declared intent set pre-cutover?** AR-7 derives
-   "what is incomplete" from artifact rows the run actually attempted, so a run
-   that dies before reaching an app leaves nothing behind (visible only as a
-   red CI job). At stage `allocate` the allocation step writes the intent set
-   as `allocated` rows and the gap closes on its own. The alternative is a
-   `build_target` table written by the plan step — exact at every stage, one
-   more table, and it duplicates something GitHub already knows.
-2. **Should the `main`-push `reconcile-app-registry` job stop being
-   `continue-on-error`?** The wedge in ordering 4 stayed invisible because a
-   red step sits inside a green job. AR-7a makes the sweep partially-applying,
-   which removes the repo-wide blast radius but not the invisibility. The job
-   gates nothing downstream, so failing it red is cheap; it does mean a
-   registry outage turns `main` CI red.
-3. **Where exactly does recording become mandatory?** The stage table above
-   puts it at `promote`. It could equally be at `allocate` only, keeping
-   `promote` best-effort — the tradeoff is how long an unrecorded image can
-   silently accumulate before it breaks a chart release.
-4. **Manifest snapshots as verbatim `JSONB` vs. typed columns.** Verbatim is
-   chosen (it is the appmeta contract, and `protojson` already round-trips it);
-   typed columns would make snapshot-level SQL filtering possible without a
-   `->>` expression index. Revisit only if a real query needs it.
-5. **AR-7f — compose-time enforcement that charts may only pin registry-known
-   images.** The genuine hermeticity fix, deliberately sequenced after
-   adoption. Decide whether it is the steady state or never.
+| Question | Decision | Where |
+|---|---|---|
+| Declared intent set for a release run | The plan step writes an `allocated` row per target at **every** adoption stage; no `build_target` table | "The run log" |
+| `reconcile-app-registry` and `continue-on-error` | Dropped — the job fails red on any error, with `APP_REGISTRY_CICD_OPT_IN` as the only lever | "Availability, restated per adoption stage" |
+| Where recording becomes mandatory | At `promote`, not only at `allocate` | same |
+| Manifest snapshot storage | Verbatim `JSONB` + stored generated columns for `deploy_unit` / `image_repository` | "App identity vs. per-build manifest snapshot" |
+| AR-7f compose-time chart enforcement | Steady state, gated per domain on `stage = 'allocate'` | "Rejected alternatives (issue #558)" |

--- a/tools/app_registry/PLAN.md
+++ b/tools/app_registry/PLAN.md
@@ -43,6 +43,14 @@ still out of scope (see AR-4b below).
 for what it delivered and what is deliberately still missing before any
 domain can be cut over.
 
+**AR-7 (issue #558) is designed, nothing implemented.** It makes a release run
+hermetic — no dependency on `main`'s reconcile having gone first — via an
+artifact `allocated → publishing → published` lifecycle, an identity/manifest-
+snapshot split of `app`, and a run log CI writes to. It is a prerequisite for
+the AR-5 cutover, and AR-7a/AR-7b fix two failure modes that are silent on
+`main` today. Design is in ARCHITECTURE.md's "Release lifecycle (issue #558)";
+delivery is "AR-7" below.
+
 **Where deferred work is tracked.** Three places, deliberately:
 [Carry-over items](#carry-over-items) for small cross-cutting gaps that
 belong to no single phase; each phase's own **"Deliberately NOT done"**
@@ -231,12 +239,21 @@ graph LR
     AR1 --> AR2["AR-2<br/>Observe"]
     AR2 --> AR3["AR-3<br/>Promote"]
     AR3 --> AR4["AR-4<br/>Writeback"]
-    AR4 --> AR5["AR-5<br/>Allocate versions"]
+    AR4 --> AR7["AR-7<br/>Release lifecycle"]
+    AR7 --> AR5["AR-5b+<br/>Allocate versions"]
     AR2 -. "soak period" .-> AR3
     style AR0 fill:#e8f5e8
     style ARM fill:#fff4e0
+    style AR7 fill:#fff4e0
     style AR5 fill:#ffe9e9
 ```
+
+**AR-7 (issue #558) sits between AR-4 and the AR-5 cutover**, despite its
+number. AR-5a's inert foundations already landed; the cutover to `allocate`
+must not happen before AR-7, because version allocation happens *before* a
+build exists, so a release will need identity resolved even earlier than it
+does today — the release-vs-reconcile gap gets strictly worse under AR-5, not
+better. AR-7a and AR-7b are independently valuable and can land at any time.
 
 AR-M stands alone and delivers value with or without the registry — it fixes
 drift that exists today. It is sequenced first because AR-2 otherwise adds a
@@ -839,6 +856,166 @@ trailing term. Do not add the column now; do note the extension point in
 `ARCHITECTURE.md`.
 
 ---
+
+## AR-7 — Release lifecycle (issue #558)
+
+**Goal:** make a release run hermetic — it depends on no other CI run having
+gone first — and make an incomplete run recoverable by *resuming* it rather
+than by hand. Read ARCHITECTURE.md's "Release lifecycle (issue #558)" first;
+it carries the design, the four orderings this fixes, and the rejected
+alternatives. This section is delivery only.
+
+**Nothing here is implemented.** The sub-phases are ordered by dependency;
+AR-7a and AR-7b each stand alone and fix a failure mode that is silent today.
+
+### AR-7a — Sweep robustness — no schema change
+
+Independent of everything else in AR-7. Land first.
+
+**Scope**
+- `Reconcile` becomes **partially applying**: a chart whose apps fail to
+  resolve is skipped and reported (new `unresolved_charts` field on
+  `ReconcileAppsResponse`, each entry naming the chart and the offending app
+  reference); every other app and chart applies and the watermark advances.
+  Today one bad manifest rolls the whole transaction back, wedging identity
+  registration repo-wide until someone notices.
+- **Domain-qualified app references in chart manifests.** `resolveChartApps`
+  currently falls back to `SELECT app_id FROM app WHERE name = $1` and fails
+  on more than one match, so adding an app in domain B whose bare name
+  collides with one in domain A that any chart references breaks the sweep.
+  Qualify the reference at the manifest level (`tools/helm` +
+  `//tools/appmeta/proto`), keep bare-name resolution as a deprecated
+  compatibility path for one release cycle, then delete it.
+- Surface a skipped/failed sweep in CI rather than only in the step log —
+  see ARCHITECTURE.md "Open questions" #2 for the `continue-on-error`
+  decision this needs.
+
+**Exit criteria**
+- A chart manifest naming a nonexistent app leaves every other app/chart
+  registered, advances the watermark, and reports the offending chart.
+- A bare app name that is ambiguous across domains cannot be produced by
+  `tools/helm` at all.
+- Postgres integration test: sweep with one bad chart, assert partial apply
+  (the fake cannot catch the transaction-rollback behavior this changes).
+
+### AR-7b — Artifact lifecycle states — migration `007_artifact_lifecycle`
+
+**Scope**
+- Migration: `artifact.state` (`allocated`/`publishing`/`published`/`failed`),
+  `artifact.provenance` (`observed`/`adopted`), `state_changed_at`;
+  `digest`/`build_id`/`published_at` become nullable;
+  `artifact_digest_idx` becomes `UNIQUE ... WHERE digest IS NOT NULL`;
+  `version_allocation` rows fold into `artifact` as `allocated` and the table
+  is **dropped**. Existing rows backfill to `state = 'published'`,
+  `provenance = 'observed'`. `UNIQUE (owner_id, kind, version)` is unchanged
+  and now spans every state — it keeps doing the allocation-collision job
+  `version_allocation`'s index did.
+- `AllocateVersion` writes an `allocated` artifact row instead of a
+  `version_allocation` row; "next version" becomes one query instead of a max
+  across two tables. Its concurrency test (8 goroutines, zero collisions) must
+  stay green unchanged — that is the regression that matters here.
+- New RPCs: `BeginPublish` (`∅|allocated|failed → publishing`, takes
+  `build_id`) and `FailPublish` (`publishing → failed`, takes a reason).
+  `RecordArtifact` becomes `publishing → published`, and keeps its
+  create-directly-as-`published` path for domains at stage `observe`.
+- Transition enforcement server-side; `published` terminal; re-recording the
+  same digest idempotent, a different digest for a published version rejected.
+- **Stale-`publishing` reaper** in `app-registry-worker` (new periodic loop
+  alongside the outbox drainer), timeout configurable, documented in ENV.md.
+  Ships in this phase, not after it.
+- `release.yml`: call `BeginPublish` immediately before each image/chart push
+  and `FailPublish` on the error path.
+- Docs: ARCHITECTURE.md's availability-per-stage table becomes reality for
+  `observe`; ENV.md for the reaper; migrate/README.md's migration table.
+
+**Exit criteria**
+- An image row exists in `publishing` before its GHCR push, and a killed
+  release leaves rows that the reaper moves to `failed` within the timeout.
+- A chart pinning an image that was never published still fails — and the
+  failure now names a genuinely unpublished image, not a bookkeeping miss.
+- Postgres integration tests: every legal transition, every illegal one
+  rejected, reaper timeout, and the folded `version_allocation` data.
+
+### AR-7c — App identity / manifest snapshot split — migration `008`
+
+The design change. Depends on AR-7b (it touches the same write path).
+
+**Scope**
+- Migration: append-only `app_manifest` / `chart_manifest`
+  (`(owner_id, source_git_sha)` unique, verbatim protojson `JSONB`,
+  `source_committed_at`, sweep-vs-release provenance); `artifact.manifest_id`
+  and `artifact.promotability` (stored, derived at publish time);
+  `app`/`chart` drop their mutable metadata columns; `v_current_app` /
+  `v_current_chart` views. Backfill snapshots from the current `app`/`chart`
+  rows against the latest reconciled `git_sha` so nothing loses metadata.
+- New `AppRegistry.AssertApps`: additive identity + snapshot write, safe from
+  any ref, never marks `MISSING`, rejects assertion against an `ARCHIVED` app
+  per item. `RecordArtifact` against an `ARCHIVED` owner is rejected too.
+- `ReconcileApps` keeps the absence sweep, `chart_app` membership, the
+  watermark, and now writes `main`-sweep snapshots.
+- `release.yml` calls `AssertApps` as the first step of the release job, from
+  the released ref — this is what closes #547's gap.
+- Reads (`ListApps`/`GetApp`/promotability) move to the views; wire responses
+  are unchanged.
+- Docs: ARCHITECTURE.md's #547 section moves from "accept the gap" to
+  "closed"; OPERATIONS.md's owner-not-reconciled runbook entry retires.
+
+**Exit criteria**
+- A release from a branch that never merges records its build, artifacts and
+  a manifest snapshot, and writes no mutable state anything else can observe.
+- Editing an app's `deploy_unit` does not change the promotability of an
+  artifact published before the edit (the retroactivity bug, proven by test).
+- `exit 3` / `ReasonOwnerNotReconciled` becomes unreachable from `release.yml`.
+
+### AR-7d — Run log and resume — no schema change
+
+**Scope**
+- `GetReleaseRun(workflow_run_id[, attempt])` returning the build and every
+  child artifact with its state; CLI `app-registry builds status <run-id>`
+  and `--incomplete`.
+- `release.yml` re-run behaves as a **resume**: skip children already
+  `published`, re-attempt the rest, then the chart.
+- OPERATIONS.md: "a release run didn't complete" runbook built on the above.
+
+**Exit criteria**
+- A run killed between two image pushes, re-run, publishes only what was
+  missing and ends with every child `published`.
+
+### AR-7e — Adoption and disaster recovery
+
+**Scope**
+- `ArtifactRegistry.AdoptArtifact` — admin role only, never the builder
+  credential — recording a pre-existing GHCR image or chart as `published`
+  with `provenance = 'adopted'` and a required reason. CLI
+  `app-registry artifacts adopt`; `artifacts list --provenance adopted`.
+- OPERATIONS.md disaster-recovery runbook: registry restored behind / lost,
+  chart release failing on a pre-registry pin, and the explicit statement that
+  this is a rare deliberate operation, not routine maintenance.
+
+**Exit criteria**
+- A chart pinning an image published before the registry existed can be
+  unblocked by one documented, audited command, and the adopted row is
+  distinguishable from an observed one in one query.
+
+### AR-7f — Compose-time chart hermeticity — deferred
+
+Enforce "a chart may only pin images the registry has published" at chart
+**compose** time, so the failure lands before anything is pushed rather than
+after. This is the steady state the issue title actually asks for, and the
+reason it is deferred is cutover cost: no chart could build until every member
+app had released through the registry once. Decide after AR-7e — see
+ARCHITECTURE.md "Open questions" #5.
+
+### Deliberately NOT in AR-7
+
+- **A `build_target` table** declaring a run's intended children up front. See
+  ARCHITECTURE.md "Open questions" #1 — `allocated` rows already carry intent
+  once a domain is at `allocate`.
+- **Bulk backfill of historical GHCR artifacts.** "Resolved questions" #3
+  still stands; AR-7e is lazy and per-artifact, not a sweep.
+- **A live GHCR existence verifier.** `published` is proof-of-existence at
+  write time and deliberately not a liveness check.
+- **Any inbound Temporal workflow.** CI orchestrates; the registry logs.
 
 ## Explicitly out of scope
 

--- a/tools/app_registry/PLAN.md
+++ b/tools/app_registry/PLAN.md
@@ -16,8 +16,8 @@ Read [ARCHITECTURE.md](ARCHITECTURE.md) before executing any phase.
 
 ## Current status
 
-*Last updated at the start of the AR-2d/AR-3 session. **AR-M through AR-2c are
-all merged to `main`.***
+*Last updated in the AR-7 design session (issue #558). **AR-M through AR-6 are
+all merged to `main`** — see the table below.*
 
 | Phase | PR | State |
 |---|---|---|
@@ -27,21 +27,26 @@ all merged to `main`.***
 | AR-2b | [#500](https://github.com/whale-net/everything/pull/500) | merged — charts byte-identical |
 | AR-2c | [#502](https://github.com/whale-net/everything/pull/502) | merged — CI path unexercised until the registry is deployed |
 | dbtest | [#498](https://github.com/whale-net/everything/pull/498) | merged — `libs/go/dbtest` available |
+| AR-2d | [#503](https://github.com/whale-net/everything/pull/503) | merged |
+| AR-3a…AR-3d | [#504](https://github.com/whale-net/everything/pull/504), [#508](https://github.com/whale-net/everything/pull/508), [#509](https://github.com/whale-net/everything/pull/509), [#511](https://github.com/whale-net/everything/pull/511) | merged |
+| AR-4a / AR-4b | [#512](https://github.com/whale-net/everything/pull/512), [#514](https://github.com/whale-net/everything/pull/514) | merged — writeback `Publish` is still the stub |
+| AR-5a | [#513](https://github.com/whale-net/everything/pull/513) | merged — **inert**: no domain at stage `allocate`, `plan.go`'s tag path untouched |
+| AR-6a / AR-6b | [#516](https://github.com/whale-net/everything/pull/516), [#515](https://github.com/whale-net/everything/pull/515) | merged |
+| AR-7 | [#559](https://github.com/whale-net/everything/pull/559) | design only — no implementation |
 
 The registry is being deployed to `dev` by the repo owner. `app-registry-api`
 and `app-registry-migration` images publish from `apps=all`.
 `APP_REGISTRY_CICD_OPT_IN` is still unset, so CI makes no registry calls.
 
-**AR-3 is now fully implemented** (AR-3a through AR-3d), stacked on top of
-`main` and not yet merged. AR-2d is also done, not merged. **AR-4 (AR-4a +
-AR-4b) is now also fully implemented**, stacked on `ar-4a-temporal` /
-`main` and not yet merged -- the writeback *contract* (outbox, worker,
-workflow, stub activity) is done; the real gitops/S3 publish is deliberately
-still out of scope (see AR-4b below).
+**AR-3 (promotion) and AR-4 (writeback) are implemented and merged.** The
+writeback *contract* — outbox, worker, workflow, stub activity — is done; the
+real gitops/S3 publish is deliberately still out of scope (see AR-4b below).
+The per-phase sections below were written while these were still in flight and
+say "not merged" in places; the table above is authoritative.
 
-**AR-5a (inert foundations) is also done, not merged** — see "AR-5" below
-for what it delivered and what is deliberately still missing before any
-domain can be cut over.
+**AR-5a (inert foundations) is merged** — `AllocateVersion` is fully
+implemented and tested, wired to nothing. See "AR-5" below for what remains
+before any domain can be cut over.
 
 **AR-7 (issue #558) is designed, nothing implemented.** It makes a release run
 hermetic — no dependency on `main`'s reconcile having gone first — via an
@@ -886,9 +891,12 @@ Independent of everything else in AR-7. Land first.
   Qualify the reference at the manifest level (`tools/helm` +
   `//tools/appmeta/proto`), keep bare-name resolution as a deprecated
   compatibility path for one release cycle, then delete it.
-- Surface a skipped/failed sweep in CI rather than only in the step log —
-  see ARCHITECTURE.md "Open questions" #2 for the `continue-on-error`
-  decision this needs.
+- **Drop `continue-on-error` from `ci.yml`'s `reconcile-app-registry` job** —
+  any error reds the job (decided in review; see ARCHITECTURE.md
+  "Availability, restated per adoption stage"). The wedge stayed invisible
+  because a red step sat inside a green job. Accepted consequence: with the
+  opt-in on, a registry outage reds `main` CI, and
+  `APP_REGISTRY_CICD_OPT_IN=false` is the lever.
 
 **Exit criteria**
 - A chart manifest naming a nonexistent app leaves every other app/chart
@@ -902,7 +910,8 @@ Independent of everything else in AR-7. Land first.
 
 **Scope**
 - Migration: `artifact.state` (`allocated`/`publishing`/`published`/`failed`),
-  `artifact.provenance` (`observed`/`adopted`), `state_changed_at`;
+  `artifact.provenance` (`observed`/`adopted`), `artifact.version_source`
+  (`registry`/`tag` — which path authored the version), `state_changed_at`;
   `digest`/`build_id`/`published_at` become nullable;
   `artifact_digest_idx` becomes `UNIQUE ... WHERE digest IS NOT NULL`;
   `version_allocation` rows fold into `artifact` as `allocated` and the table
@@ -920,9 +929,18 @@ Independent of everything else in AR-7. Land first.
   create-directly-as-`published` path for domains at stage `observe`.
 - Transition enforcement server-side; `published` terminal; re-recording the
   same digest idempotent, a different digest for a published version rejected.
-- **Stale-`publishing` reaper** in `app-registry-worker` (new periodic loop
-  alongside the outbox drainer), timeout configurable, documented in ENV.md.
-  Ships in this phase, not after it.
+- **Stale-`publishing` *and* stale-`allocated` reaper** in
+  `app-registry-worker` (new periodic loop alongside the outbox drainer),
+  timeout configurable, documented in ENV.md. Ships in this phase, not after
+  it — `allocated` rows are written up front now, so a cancelled run would
+  otherwise hold a version number in `UNIQUE (owner_id, kind, version)`
+  forever.
+- **The release plan step writes the intent set** — one `allocated` row per
+  target, before anything is pushed, at *every* adoption stage (decided in
+  review). Pre-cutover the version still comes from the tag path and the row
+  records `version_source = 'tag'`; at `allocate` it is `AllocateVersion`'s
+  own result. This is what makes "is this run complete?" exact in AR-7d
+  rather than only after the AR-5 cutover.
 - `release.yml`: call `BeginPublish` immediately before each image/chart push
   and `FailPublish` on the error path.
 - Docs: ARCHITECTURE.md's availability-per-stage table becomes reality for
@@ -942,7 +960,9 @@ The design change. Depends on AR-7b (it touches the same write path).
 
 **Scope**
 - Migration: append-only `app_manifest` / `chart_manifest`
-  (`(owner_id, source_git_sha)` unique, verbatim protojson `JSONB`,
+  (`(owner_id, source_git_sha)` unique, verbatim protojson `JSONB` plus
+  **stored generated columns** for `deploy_unit` and `image_repository` — the
+  two fields the hot read paths need indexable, decided in review;
   `source_committed_at`, sweep-vs-release provenance); `artifact.manifest_id`
   and `artifact.promotability` (stored, derived at publish time);
   `app`/`chart` drop their mutable metadata columns; `v_current_app` /
@@ -980,6 +1000,9 @@ The design change. Depends on AR-7b (it touches the same write path).
 **Exit criteria**
 - A run killed between two image pushes, re-run, publishes only what was
   missing and ends with every child `published`.
+- A run killed *before* reaching an app still reports that app as incomplete —
+  AR-7b's up-front intent rows are what make this answerable, at every
+  adoption stage.
 
 ### AR-7e — Adoption and disaster recovery
 
@@ -997,20 +1020,37 @@ The design change. Depends on AR-7b (it touches the same write path).
   unblocked by one documented, audited command, and the adopted row is
   distinguishable from an observed one in one query.
 
-### AR-7f — Compose-time chart hermeticity — deferred
+### AR-7f — Compose-time chart hermeticity — gated per domain
 
 Enforce "a chart may only pin images the registry has published" at chart
 **compose** time, so the failure lands before anything is pushed rather than
-after. This is the steady state the issue title actually asks for, and the
-reason it is deferred is cutover cost: no chart could build until every member
-app had released through the registry once. Decide after AR-7e — see
-ARCHITECTURE.md "Open questions" #5.
+after every push. This is the steady state the issue title asks for; it is
+last only because of cutover cost, which the per-domain gate bounds.
+
+**Scope**
+- `tools/helm`'s composer (or the release plan step feeding it) checks each
+  member app's pinned version against the registry and fails the chart build
+  if any is not `published`.
+- **Enforced only for domains at `domain_adoption.stage = 'allocate'`**
+  (decided in review) — the same per-domain gate every other tightening uses,
+  so a domain meets the strict rule only after it has been releasing through
+  the registry anyway. Repo-wide enforcement was rejected: it would block
+  every chart build until every member app had released through the registry
+  at least once.
+- Hermeticity constraint: the check runs in the release path, never inside a
+  Bazel action — see "Chart → image lockfile" in ARCHITECTURE.md.
+
+**Exit criteria**
+- A chart in an `allocate`-stage domain whose member app was never published
+  fails at compose time, naming the app, with nothing pushed.
+- A chart in an `observe`/`promote`-stage domain builds exactly as it does
+  today.
 
 ### Deliberately NOT in AR-7
 
-- **A `build_target` table** declaring a run's intended children up front. See
-  ARCHITECTURE.md "Open questions" #1 — `allocated` rows already carry intent
-  once a domain is at `allocate`.
+- **A `build_target` table** declaring a run's intended children up front —
+  the plan step's `allocated` rows already are the declaration, at every
+  adoption stage. See ARCHITECTURE.md "The run log".
 - **Bulk backfill of historical GHCR artifacts.** "Resolved questions" #3
   still stands; AR-7e is lazy and per-artifact, not a sweep.
 - **A live GHCR existence verifier.** `published` is proof-of-existence at

--- a/tools/app_registry/TOC.md
+++ b/tools/app_registry/TOC.md
@@ -22,6 +22,13 @@ that renders environment state to a local path (stub implementation —
 publishing to the gitops repo or S3 is out of scope, see PLAN.md's AR-4b
 section).
 
+**AR-7 (issue #558) — release lifecycle — is designed but not built.** It
+closes the release-vs-reconcile coupling with an artifact
+`allocated → publishing → published` lifecycle, an identity/manifest-snapshot
+split of `app`, and a run log that makes a re-run a resume. Read
+ARCHITECTURE.md's "Release lifecycle (issue #558)" before touching recording,
+reconcile, or anything in `release.yml`'s registry steps.
+
 **See [PLAN.md](PLAN.md) → "Current status" for the branch/PR map,
 what is next, and the carry-over items** — start there when picking this up.
 

--- a/tools/app_registry/migrate/README.md
+++ b/tools/app_registry/migrate/README.md
@@ -35,6 +35,8 @@ ArgoCD sync waves. See `friendly_computing_machine/docs/argocd-integration.md`.
 | `004_writeback_outbox` (AR-4b) | `writeback_outbox` |
 | `005_version_allocation` (AR-5a) | `artifact.version_major/minor/patch` + backfill, `artifact_version_order_idx`, `version_allocation` |
 | `006_reconcile_watermark` (issue #545) | `reconcile_watermark` — singleton row guarding `ReconcileApps` against a stale (older-commit) call landing after a newer one |
+| `007_artifact_lifecycle` (AR-7b, **planned**) | `artifact.state`/`provenance`/`state_changed_at`, nullable `digest`/`build_id`, partial-unique digest index, `version_allocation` folded in and dropped |
+| `008_app_identity_split` (AR-7c, **planned**) | append-only `app_manifest`/`chart_manifest` snapshots, `artifact.manifest_id`/`promotability`, `app`/`chart` lose their mutable metadata, `v_current_app`/`v_current_chart` |
 
 Split this way so AR-2 needs only `001`, AR-3b adds `002`, AR-3c adds `003`,
 AR-4b adds `004`, and AR-5a adds `005` — each phase ships an independently


### PR DESCRIPTION
Closes the design half of #558. **Docs only — no code, no schema.** The thread converged; this is the write-up plus a phased plan to delegate against. All five review questions are now decided (second commit) — see "Decisions" below.

## What the design is

Four cross-run orderings have to hold for the registry to be correct today. Only one is enforced.

| # | Ordering | Enforced by |
|---|---|---|
| 1 | reconcile of `C` before `RecordArtifact` for an app introduced in `C` | nothing (#547) |
| 2 | newer reconcile after older | watermark (#545) + concurrency (#546) — solved |
| 3 | image recorded before a chart pins its digest | hard server-side reject |
| 4 | app rows exist before a chart manifest resolves | `resolveChartApps` fails the *entire* sweep |

Ordering 3 is the expensive one: charts pin digests resolved from **GHCR by tag**, so a chart-only release pins images from earlier runs. One unrecorded image then breaks every future chart release containing that app, permanently — a re-run doesn't fix it and reconcile doesn't fix it. Ordering 4 wedges identity registration repo-wide from inside a green CI job.

The design, per the issue thread:

- **Registry is source of truth for the pipeline; GHCR + the chart repo stay source of truth for artifacts.** Different claims, kept apart deliberately.
- **`allocated → publishing → published`** on `artifact`. The registry records intent *before* the push and completes the record after, so it never infers a record it didn't observe. This **removes** `version_allocation` rather than adding a table — that table already was the `allocated` state, stored elsewhere because `digest`/`build_id` are `NOT NULL`. A reaper expires stale `allocated`/`publishing` rows.
- **`app` becomes pure identity; the manifest a build was made from is an append-only snapshot.** This deletes the divergent-ref question instead of answering it, and fixes a real bug: promotability is currently re-derived from `app.deploy_unit` *as it is now*, so editing a `release_app` rule silently changes the promotability of artifacts published years ago.
- **`AssertApps` (additive, any ref) vs `ReconcileApps` (absence sweep, `main` only)**, plus a partially-applying sweep and domain-qualified chart app references.
- **Run log, not run orchestration.** `build` is already the run aggregate and the artifact states are its children, so "what is incomplete" and *resume-on-re-run* need no new tables. CI pushes and reports; the registry records. No inbound Temporal — that stays the outbound writeback path.
- **Availability restated per `domain_adoption.stage`** instead of adding a lever: best-effort at `observe`, required at `promote`, release-critical at `allocate`.
- **`AdoptArtifact`** (admin-only, `provenance = 'adopted'`) as the bounded way to cross over pre-registry GHCR images, and as the disaster-recovery path.

Rejected alternatives are recorded next to the design, including the two dropped mid-thread (inferring image artifacts from the chart lockfile; one atomic `RecordRelease` RPC).

## Decisions from review

| Question | Decision |
|---|---|
| Declared intent set for a run | The plan step writes an `allocated` row per target at **every** adoption stage — no `build_target` table. Adds `artifact.version_source` (`registry`/`tag`); the reaper must expire stale `allocated` rows. |
| `reconcile-app-registry` loudness | Drops `continue-on-error`, fails red on any error. With the opt-in on, a registry outage reds `main` CI; `APP_REGISTRY_CICD_OPT_IN` is the lever. |
| Where recording becomes mandatory | At `promote`, not only at `allocate`. |
| Manifest snapshot storage | Verbatim protojson `JSONB` + stored generated columns for `deploy_unit` / `image_repository`. |
| AR-7f compose-time chart enforcement | Steady state, gated per domain on `stage = 'allocate'` — not repo-wide, not never. |

## Delivery

| Phase | Scope | Schema |
|---|---|---|
| AR-7a | partially-applying sweep, domain-qualified chart refs, reconcile job fails red | none |
| AR-7b | artifact lifecycle states, intent rows, `BeginPublish`/`FailPublish`, reaper | `007` |
| AR-7c | identity/manifest-snapshot split, `AssertApps` | `008` |
| AR-7d | run log + resume (`GetReleaseRun`, `builds status --incomplete`) | none |
| AR-7e | `AdoptArtifact` + DR runbook | none |
| AR-7f | compose-time chart hermeticity, per-domain gated | none |

AR-7a and AR-7b stand alone and fix the two failure modes that are silent on `main` today.

## Relationship to AR-5

AR-7 does not conflict with the remaining cutover work and belongs strictly before it. AR-5a is merged but **inert** (no domain at `allocate`, `plan.go`'s tag path untouched, `version_allocation` empty), so re-homing its storage into `artifact` is free right now and would be a live-data migration after a cutover. AR-7 also shrinks two AR-5 leftovers: seeding a domain's starting version from tags is largely obviated, and the parity exit criterion becomes a query over `version_source` instead of a manual comparison against soak data. **One rule: no domain moves to `allocate` before AR-7b.**

While verifying that, I found PLAN.md's "Current status" was stale — AR-2d, AR-3, AR-4, AR-5a and AR-6 all said "not merged" and every one is in `main`. Corrected with a per-phase PR table.

Ref: #558, #547, #545, #546