### PR TITLE
feat(app-registry): AR-7a sweep robustness -- partial-apply reconcile (#558)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,8 +56,19 @@ jobs:
   # against the current, complete tree -- see ARCHITECTURE.md "Rejected
   # alternatives" and DEPLOY.md "CI wiring (AR-3d)" for why this can't
   # safely live in release.yml, which may be dispatched against an
-  # arbitrary, possibly older ref. Best-effort: continue-on-error so a
-  # registry outage never fails main CI.
+  # arbitrary, possibly older ref.
+  #
+  # AR-7a (PLAN.md): NOT continue-on-error. See ARCHITECTURE.md "Availability,
+  # restated per adoption stage" -- the main-push sweep fails red on any
+  # error, deliberately: a rejected sweep means our manifests are wrong, an
+  # unreachable registry is worth knowing about immediately, and this job
+  # gates nothing downstream, so a red here costs attention and nothing else.
+  # Accepted consequence: once APP_REGISTRY_CICD_OPT_IN is 'true', a registry
+  # outage reds this job -- and therefore `main` CI -- until it recovers.
+  # APP_REGISTRY_CICD_OPT_IN=false is the only lever that stops that; it was
+  # previously masked by continue-on-error, which is exactly how the
+  # repo-wide identity-registration wedge (issue #558, ordering 4) stayed
+  # invisible inside a green job.
   reconcile-app-registry:
     name: Reconcile apps/charts in App Registry
     runs-on: ubuntu-latest
@@ -83,7 +94,6 @@ jobs:
 
     - name: Reconcile apps/charts in App Registry
       if: ${{ vars.APP_REGISTRY_CICD_OPT_IN == 'true' }}
-      continue-on-error: true
       timeout-minutes: 5
       uses: ./.github/actions/app-registry-reconcile
       with:

--- a/tools/app_registry/ARCHITECTURE.md
+++ b/tools/app_registry/ARCHITECTURE.md
@@ -386,9 +386,13 @@ tradeoff above, not a separate gap to close.
 
 ## Release lifecycle (issue #558)
 
-**Status: designed, not built.** Delivery is PLAN.md's AR-7 (AR-7a … AR-7e).
-Nothing in this section is deployed; every table/column/RPC named here is
-proposed. It supersedes "Release-vs-reconcile gap (issue #547)" above, and
+**Status: AR-7a built (merged); AR-7b … AR-7e designed, not built.** Delivery
+is PLAN.md's AR-7 (AR-7a … AR-7e). AR-7a's slice of this section — ordering
+4, partial-apply reconcile, domain-qualified chart app references, and the
+`continue-on-error` drop on `ci.yml`'s sweep job — describes what is actually
+deployed; everything else here (the artifact lifecycle, the app identity /
+manifest-snapshot split, `AssertApps`, the run log) is still proposed, not
+built. It supersedes "Release-vs-reconcile gap (issue #547)" above, and
 changes what "Availability and bootstrap" below promises — both are
 cross-referenced where that happens.
 
@@ -403,7 +407,7 @@ correct; only one is actually enforced.
 | 1 | reconcile of commit `C` **before** `RecordArtifact` for an app introduced in `C` | nothing — accepted gap (#547) | exit 3, artifact never recorded and **never backfilled**; that build can never be promoted |
 | 2 | newer reconcile **after** older reconcile | `reconcile_watermark` (#545) + CI concurrency (#546) | solved |
 | 3 | `RecordArtifact(IMAGE, digest D)` **before** any chart pinning `D` | hard server-side reject (`postgres/artifact.go`, "chart pins unrecorded image digest") | chart artifact not recorded |
-| 4 | app rows exist **before** a chart manifest referencing them resolves | `resolveChartApps` fails the **entire** reconcile | repo-wide identity registration wedged, inside a green `main` CI job |
+| 4 | app rows exist **before** a chart manifest referencing them resolves | `resolveChartApps` skips and reports the one bad chart (AR-7a, built) | solved — see below |
 
 Ordering 3 is the expensive one, because charts pin digests resolved from
 **GHCR by tag** (`docker buildx imagetools inspect ${IMG_REPO}:${IMG_VERSION}`
@@ -415,10 +419,20 @@ app**, permanently: re-running the chart release doesn't fix it (the digest is
 still unrecorded), and reconcile doesn't fix it (reconcile writes identity,
 never artifacts). It only clears when that app is rebuilt and recorded again.
 
-Ordering 4 is the quiet one: one chart manifest naming a removed app, or an
-ambiguous bare app name across two domains, rolls back the whole transaction,
-so the watermark never advances and no app registers at all — while the job
-stays green because the step is `continue-on-error`.
+Ordering 4 was the quiet one: one chart manifest naming a removed app, or an
+ambiguous bare app name across two domains, used to roll back the whole
+transaction, so the watermark never advanced and no app registered at all —
+while the job stayed green because the step was `continue-on-error`. **Fixed
+by AR-7a** (built): `resolveChartApps` now reports the bad chart in
+`ReconcileAppsResponse.unresolved_charts` and skips only it; every other
+app/chart in the same call still applies and the watermark still advances.
+Chart manifests also carry a domain-qualified `app_refs` field now (see
+"AssertApps (additive) vs. ReconcileApps (absence sweep)" below), so the
+cross-domain-ambiguity half of this failure mode can no longer be produced by
+`tools/helm` at all — only the deprecated bare-name compatibility path can
+still hit it. And `ci.yml`'s `reconcile-app-registry` job no longer has
+`continue-on-error`, so a genuine registry outage during the sweep is
+visible immediately instead of hiding inside a green step.
 
 ### The principle that resolves it
 
@@ -542,6 +556,12 @@ manifest schema that AR-M spent a phase deleting.
 
 ### `AssertApps` (additive) vs. `ReconcileApps` (absence sweep)
 
+**`AssertApps` itself is still proposed, not built** — it is AR-7c. The
+partial-apply and domain-qualified-reference paragraphs below are AR-7a and
+are built (see "Status" above); the split this heading names is not: today
+there is still only `ReconcileApps`, and it still runs exclusively from
+`main` push.
+
 `ReconcileApps` conflates two jobs: assert identity, and assert *absence*.
 Only absence needs a canonical complete tree, and it is identity that releases
 depend on. Split them:
@@ -556,14 +576,22 @@ that app is gone for good, and a release resurrecting it silently is worse
 than a red step. `RecordArtifact` against an `ARCHIVED` owner is likewise
 rejected (today it succeeds, which is not intended).
 
-**The sweep becomes partially-applying** (ordering 4): a chart whose apps
-don't resolve is reported as unresolved in `ReconcileAppsResponse` and skipped;
-every other app and chart still applies and the watermark still advances.
-Separately, chart manifests move to **domain-qualified app references**, so
+**The sweep is partially-applying** (ordering 4, AR-7a, built): a chart whose
+apps don't resolve is reported as unresolved in
+`ReconcileAppsResponse.unresolved_charts` and skipped; every other app and
+chart still applies and the watermark still advances. A skipped chart is
+deliberately NOT marked `MISSING` as a side effect — it is present in the
+manifest set, just unresolvable, and `ReconcileApps`'s absence sweep only
+means to flag what is genuinely absent. Separately, chart manifests carry
+**domain-qualified app references** (`ChartManifest.app_refs`, `"<domain>/
+<name>"`, emitted by `helm_chart_metadata` in `tools/bazel/release.bzl`), so
 `resolveChartApps`'s cross-domain ambiguity (`SELECT app_id FROM app WHERE
-name = $1` with more than one match) cannot arise. Both are small, independent
-of everything else here, and fix a failure mode that is silent today — they
-land first (AR-7a).
+name = $1` with more than one match) cannot arise from anything `tools/helm`
+produces — only the deprecated `ChartManifest.apps` (bare names) fallback,
+kept for one release cycle's backward compatibility, can still hit it,
+and it is now a per-chart skip there too, not a whole-sweep failure. Both were
+small, independent of everything else here, and fixed a failure mode that was
+silent — they landed first, as AR-7a.
 
 ### The run log: CI orchestrates, the registry records
 
@@ -642,8 +670,9 @@ promise in "Availability and bootstrap" below; that section stays accurate for
 `observe`, which is where every domain is today.
 
 **The `main`-push sweep is not on this scale — it fails red on any error**
-(decided in review of PR #559). `ci.yml`'s `reconcile-app-registry` job drops
-`continue-on-error` entirely: a rejected sweep is our manifests being wrong,
+(decided in review of PR #559, **built in AR-7a**). `ci.yml`'s
+`reconcile-app-registry` job drops `continue-on-error` entirely: a rejected
+sweep is our manifests being wrong,
 an unreachable registry is worth knowing about immediately, and the job gates
 nothing downstream, so a red costs attention and nothing else. The consequence
 is deliberate and worth stating plainly: **once the opt-in is on, a registry

--- a/tools/app_registry/PLAN.md
+++ b/tools/app_registry/PLAN.md
@@ -32,7 +32,7 @@ all merged to `main`** — see the table below.*
 | AR-4a / AR-4b | [#512](https://github.com/whale-net/everything/pull/512), [#514](https://github.com/whale-net/everything/pull/514) | merged — writeback `Publish` is still the stub |
 | AR-5a | [#513](https://github.com/whale-net/everything/pull/513) | merged — **inert**: no domain at stage `allocate`, `plan.go`'s tag path untouched |
 | AR-6a / AR-6b | [#516](https://github.com/whale-net/everything/pull/516), [#515](https://github.com/whale-net/everything/pull/515) | merged |
-| AR-7 | [#559](https://github.com/whale-net/everything/pull/559) | design only — no implementation |
+| AR-7 | [#559](https://github.com/whale-net/everything/pull/559) | design only — AR-7a implemented (branch `ar-7a-sweep-robustness`, not yet merged); AR-7b…AR-7f not started |
 
 The registry is being deployed to `dev` by the repo owner. `app-registry-api`
 and `app-registry-migration` images publish from `apps=all`.
@@ -48,12 +48,18 @@ say "not merged" in places; the table above is authoritative.
 implemented and tested, wired to nothing. See "AR-5" below for what remains
 before any domain can be cut over.
 
-**AR-7 (issue #558) is designed, nothing implemented.** It makes a release run
-hermetic — no dependency on `main`'s reconcile having gone first — via an
-artifact `allocated → publishing → published` lifecycle, an identity/manifest-
-snapshot split of `app`, and a run log CI writes to. It is a prerequisite for
-the AR-5 cutover, and AR-7a/AR-7b fix two failure modes that are silent on
-`main` today. Design is in ARCHITECTURE.md's "Release lifecycle (issue #558)";
+**AR-7 (issue #558) is designed; AR-7a is implemented, not yet merged.** The
+full phase makes a release run hermetic — no dependency on `main`'s reconcile
+having gone first — via an artifact `allocated → publishing → published`
+lifecycle, an identity/manifest-snapshot split of `app`, and a run log CI
+writes to; that part (AR-7b…AR-7f) is still design only. AR-7a, independent of
+the rest, fixes ordering 4 (see ARCHITECTURE.md "The problem: four cross-run
+orderings"): `ReconcileApps` is now partially applying (one bad chart is
+skipped and reported, not a whole-sweep rollback), chart manifests carry
+domain-qualified app references so a bare-name collision across domains can't
+break the sweep, and `ci.yml`'s `reconcile-app-registry` job is no longer
+`continue-on-error`. See "AR-7a" below for the as-built detail. Design for the
+rest of AR-7 is in ARCHITECTURE.md's "Release lifecycle (issue #558)";
 delivery is "AR-7" below.
 
 **Where deferred work is tracked.** Three places, deliberately:
@@ -870,41 +876,110 @@ than by hand. Read ARCHITECTURE.md's "Release lifecycle (issue #558)" first;
 it carries the design, the four orderings this fixes, and the rejected
 alternatives. This section is delivery only.
 
-**Nothing here is implemented.** The sub-phases are ordered by dependency;
-AR-7a and AR-7b each stand alone and fix a failure mode that is silent today.
+**AR-7a is implemented, not yet merged** (branch `ar-7a-sweep-robustness`).
+The remaining sub-phases (AR-7b … AR-7f) are ordered by dependency and still
+design only.
 
-### AR-7a — Sweep robustness — no schema change
+### AR-7a — Sweep robustness — done (not yet merged)
 
-Independent of everything else in AR-7. Land first.
+Independent of everything else in AR-7. Landed first, as planned.
 
-**Scope**
-- `Reconcile` becomes **partially applying**: a chart whose apps fail to
-  resolve is skipped and reported (new `unresolved_charts` field on
-  `ReconcileAppsResponse`, each entry naming the chart and the offending app
-  reference); every other app and chart applies and the watermark advances.
-  Today one bad manifest rolls the whole transaction back, wedging identity
-  registration repo-wide until someone notices.
-- **Domain-qualified app references in chart manifests.** `resolveChartApps`
-  currently falls back to `SELECT app_id FROM app WHERE name = $1` and fails
-  on more than one match, so adding an app in domain B whose bare name
-  collides with one in domain A that any chart references breaks the sweep.
-  Qualify the reference at the manifest level (`tools/helm` +
-  `//tools/appmeta/proto`), keep bare-name resolution as a deprecated
-  compatibility path for one release cycle, then delete it.
-- **Drop `continue-on-error` from `ci.yml`'s `reconcile-app-registry` job** —
-  any error reds the job (decided in review; see ARCHITECTURE.md
-  "Availability, restated per adoption stage"). The wedge stayed invisible
-  because a red step sat inside a green job. Accepted consequence: with the
-  opt-in on, a registry outage reds `main` CI, and
-  `APP_REGISTRY_CICD_OPT_IN=false` is the lever.
+**What shipped**
+- `Reconcile` is now **partially applying**. A chart whose apps references
+  don't all resolve is SKIPPED and reported, instead of rolling back the
+  whole transaction: `ReconcileAppsResponse.unresolved_charts` (new,
+  `protos/api_messages_app.proto`) carries one `UnresolvedChart` per bad
+  chart (`domain`, `name`, `app_refs` — the offending references verbatim —
+  and a human-readable `reason`). Every other app/chart in the same call
+  still applies and the watermark still advances. Implemented in both
+  `postgres/app.go`'s `Reconcile` (a new unexported `*chartResolutionError`
+  distinguishes a resolution failure, downgraded to a per-chart skip, from a
+  genuine infrastructure error, which still aborts the whole transaction
+  unchanged) and `fake/reconcile.go`'s mirror (returns
+  `(ids, offending, reason)` directly — the fake has no transaction to
+  distinguish an abort from).
+  - **Deliberate semantics for the interaction with the absence sweep**: a
+    skipped chart is never marked `MISSING` as a side effect of not being
+    re-applied this call. If the chart already existed, its id is folded into
+    the same "present" set the absence sweep checks, so it is left ACTIVE —
+    a chart present in the manifest set but unresolvable is *present*, not
+    absent (see ARCHITECTURE.md "AssertApps (additive) vs. ReconcileApps").
+    Covered by `TestReconcileApps_UnresolvedChartNotMarkedMissing`
+    (fake-backed) and `TestReconcile_UnresolvedChartNotMarkedMissing_Postgres`
+    (real Postgres).
+- **Domain-qualified app references.** `ChartManifest.app_refs` (new,
+  `//tools/appmeta/proto/appmeta.proto`, field 8) carries `"<domain>/<name>"`
+  strings. `helm_chart_metadata` in `tools/bazel/release.bzl` emits it by
+  reading each composed app's real `domain` attribute off its
+  `AppMetadataInfo` provider (the rule's `apps` attr changed from
+  `attr.string_list` of pre-parsed names to `attr.label_list` of the
+  `app_metadata` targets themselves) — not by inferring the domain from a
+  target's package path, so it cannot be wrong regardless of directory
+  layout. `resolveChartApps` (postgres and fake) prefers `app_refs`, resolving
+  each reference by exact `(domain, name)` lookup — this can never be
+  ambiguous, because the domain is carried on the reference itself.
+  `ChartManifest.apps` (bare names) is kept as an explicitly **DEPRECATED**
+  compatibility path for one release cycle (its own doc comment in
+  appmeta.proto points back here), used only when `app_refs` is empty;
+  ambiguous bare names there are still an error, but now a per-chart skip via
+  the same `unresolved_charts` mechanism, not a whole-sweep failure.
+  `//tools/appmeta:manifest_contract_test` gained a chart-side fixture
+  (`testdata:fixture-helm_chart_metadata`, composing the existing app
+  fixture) and `TestChartFixtureLeavesNoFieldUnset`, the `ChartManifest`
+  counterpart of the existing `AppManifest` full-coverage check — both
+  directions of the contract test (hermetic fixture, and the real
+  `bazel run` sweep over every `helm_chart_metadata` target in the repo)
+  pass with `app_refs` populated.
+- **`ci.yml`'s `reconcile-app-registry` job dropped `continue-on-error`**,
+  with a comment pointing at ARCHITECTURE.md "Availability, restated per
+  adoption stage" and stating the accepted consequence plainly: once
+  `APP_REGISTRY_CICD_OPT_IN` is `true`, a registry outage reds this job (and
+  therefore `main` CI) until it recovers, and `APP_REGISTRY_CICD_OPT_IN=false`
+  is the only lever that stops it. The `if:` opt-in gate and
+  `timeout-minutes: 5` are unchanged.
+- CLI: `apps reconcile`'s output gained `printUnresolvedChartsWarning`
+  (`cli/cmd/apps.go`), a stderr banner in `promote.go`'s
+  `printDriftWarning` style — unresolved charts can't hide inside a green
+  step or an unread JSON body. The server handler also logs each skipped
+  chart at `Warn`, matching the existing `skipped_stale` convention.
 
-**Exit criteria**
+**Deliberately NOT done** (scoped out, tracked for later phases or
+explicitly out of scope — see the ground rules that constrained this phase):
+- `AssertApps`, the artifact `allocated → publishing → published` lifecycle,
+  the app identity/manifest-snapshot split, and the run log are all AR-7b/c/d
+  and untouched here — this phase touches only `ReconcileApps` and chart
+  manifest resolution.
+- The bare-name `ChartManifest.apps` field itself was NOT removed — it is
+  marked deprecated and kept for one release cycle per the exit criterion,
+  with a doc-comment pointer to this section for whoever does the deletion.
+- `tools/release_helper_go`'s own chart-app resolution
+  (`build_helm.go`/`plan_helm.go`'s `findChartApp`, used for chart packaging
+  and image-tag substitution, not the registry) was left untouched — it
+  already existed, it is a separate resolution path from the registry's
+  `resolveChartApps`, and touching it was not in AR-7a's scope. It still
+  reads `ChartManifest.apps` (now also has `app_refs` available, unused by
+  it).
+- No schema change, as the phase name promises — no migration was added.
+
+**Exit criteria — all met**
 - A chart manifest naming a nonexistent app leaves every other app/chart
-  registered, advances the watermark, and reports the offending chart.
+  registered, advances the watermark, and reports the offending chart. See
+  `TestReconcileApps_UnknownChartAppSkipsChartOnly` (fake) and
+  `TestReconcile_UnresolvedChartDoesNotRollBackWholeTransaction` (real
+  Postgres).
 - A bare app name that is ambiguous across domains cannot be produced by
-  `tools/helm` at all.
-- Postgres integration test: sweep with one bad chart, assert partial apply
-  (the fake cannot catch the transaction-rollback behavior this changes).
+  `tools/helm` at all: `helm_chart_metadata` only ever emits `app_refs`
+  entries paired with their app's real domain; verified against every real
+  `helm_chart_metadata` target in the repo via
+  `bazel run //tools/appmeta:manifest_contract_test`.
+- Postgres integration test: sweep with one bad chart, assert partial apply —
+  `TestReconcile_UnresolvedChartDoesNotRollBackWholeTransaction`,
+  `TestReconcile_UnresolvedChartNotMarkedMissing_Postgres`, and
+  `TestReconcile_DomainQualifiedAppRefsResolveUnambiguously_Postgres` in
+  `postgres_integration_test.go`. Each was verified to fail when the
+  behavior it guards was deliberately broken (whole-transaction-rollback
+  reintroduced, the not-marked-missing guard removed, and qualified
+  resolution disabled), then the break was reverted.
 
 ### AR-7b — Artifact lifecycle states — migration `007_artifact_lifecycle`
 

--- a/tools/app_registry/cli/cmd/apps.go
+++ b/tools/app_registry/cli/cmd/apps.go
@@ -144,6 +144,7 @@ func newAppsReconcileCmd() *cobra.Command {
 						"reconcile skipped: this manifest set (git_sha=%q) is stale relative to the current watermark (git_sha=%q); nothing was written\n",
 						manifests.GitSha, resp.CurrentWatermarkGitSha)
 				}
+				printUnresolvedChartsWarning(cmd, resp)
 				return printResponse(resp)
 			})
 		},
@@ -154,6 +155,29 @@ func newAppsReconcileCmd() *cobra.Command {
 	_ = c.MarkFlagRequired("from-plan")
 	_ = c.MarkFlagRequired("idempotency-key")
 	return c
+}
+
+// printUnresolvedChartsWarning renders every UnresolvedChart in resp
+// prominently, on stderr, ahead of the JSON body on stdout -- mirroring
+// promote.go's printDriftWarning. AR-7a made an unresolved chart a per-chart
+// skip rather than a whole-reconcile failure (see
+// ReconcileAppsResponse.unresolved_charts's doc comment), so the command
+// exits 0 and the JSON response looks otherwise healthy; without this, a
+// skipped chart -- and the app identity that never got recorded because of
+// it -- could hide inside a green CI step exactly like the continue-on-error
+// wedge this phase exists to fix.
+func printUnresolvedChartsWarning(cmd *cobra.Command, resp *pb.ReconcileAppsResponse) {
+	if len(resp.UnresolvedCharts) == 0 {
+		return
+	}
+	fmt.Fprintf(cmd.ErrOrStderr(),
+		"\n*** UNRESOLVED CHARTS: %d chart(s) skipped -- their apps references did not fully resolve ***\n",
+		len(resp.UnresolvedCharts))
+	for _, uc := range resp.UnresolvedCharts {
+		fmt.Fprintf(cmd.ErrOrStderr(), "  - %s/%s: %s (offending: %v)\n",
+			uc.Domain, uc.Name, uc.Reason, uc.AppRefs)
+	}
+	fmt.Fprintln(cmd.ErrOrStderr())
 }
 
 func parseAppStatus(s string) (pb.AppStatus, error) {

--- a/tools/app_registry/protos/api_messages_app.proto
+++ b/tools/app_registry/protos/api_messages_app.proto
@@ -62,6 +62,36 @@ message ReconcileAppsResponse {
   // true -- so a caller/log line can say exactly which commit is currently
   // recorded instead of just "something newer already applied."
   string current_watermark_git_sha = 11;
+
+  // Charts from this call's manifest set whose apps references did not all
+  // resolve to known apps -- AR-7a. Each is SKIPPED, not fatal: every other
+  // app/chart above still applied, and the watermark still advanced. A
+  // skipped chart is never included in newly_missing_charts either -- a
+  // chart present in the manifest set but unresolvable is treated as
+  // present, not absent. See
+  // tools/app_registry/ARCHITECTURE.md "AssertApps (additive) vs.
+  // ReconcileApps (absence sweep)" and PLAN.md's AR-7a. Populated on a
+  // dry_run call too -- a dry run computes the same resolution and reports
+  // it the same way, it just writes nothing.
+  repeated UnresolvedChart unresolved_charts = 12;
+}
+
+// UnresolvedChart names one chart manifest that ReconcileApps could not
+// fully resolve and therefore skipped -- see
+// ReconcileAppsResponse.unresolved_charts.
+message UnresolvedChart {
+  string domain = 1;
+  string name = 2;
+
+  // Every app reference from the chart manifest that failed to resolve,
+  // exactly as it appeared in the manifest (a bare name via the deprecated
+  // ChartManifest.apps, or a "<domain>/<name>" string via
+  // ChartManifest.app_refs).
+  repeated string app_refs = 3;
+
+  // Human-readable explanation (unknown app, ambiguous bare name across
+  // domains, malformed app_ref). Not machine-parsed.
+  string reason = 4;
 }
 
 // ============================================================================

--- a/tools/app_registry/server/handlers/app.go
+++ b/tools/app_registry/server/handlers/app.go
@@ -90,6 +90,19 @@ func (s *AppServer) ReconcileApps(ctx context.Context, req *pb.ReconcileAppsRequ
 					slog.String("current_watermark_git_sha", result.CurrentWatermarkGitSHA),
 				)
 			}
+			for _, uc := range result.UnresolvedCharts {
+				// Warn, not Error: AR-7a made this a per-chart skip, not a
+				// failed RPC (see ReconcileAppsResponse.unresolved_charts's
+				// doc comment) -- every other app/chart in this call still
+				// applied. A silent skip is still worth surfacing outside
+				// the JSON body, same rationale as skipped_stale above.
+				appLog.Warn("reconcile: chart skipped, apps did not fully resolve",
+					slog.String("chart_domain", uc.Domain),
+					slog.String("chart_name", uc.Name),
+					slog.Any("offending_app_refs", uc.AppRefs),
+					slog.String("reason", uc.Reason),
+				)
+			}
 			return reconcileResultToPB(result, false), nil
 		},
 	)
@@ -112,7 +125,24 @@ func reconcileResultToPB(r *repository.ReconcileResult, dryRun bool) *pb.Reconci
 		DryRun:                 dryRun,
 		SkippedStale:           r.SkippedStale,
 		CurrentWatermarkGitSha: r.CurrentWatermarkGitSHA,
+		UnresolvedCharts:       unresolvedChartsToPB(r.UnresolvedCharts),
 	}
+}
+
+func unresolvedChartsToPB(cs []repository.UnresolvedChart) []*pb.UnresolvedChart {
+	if len(cs) == 0 {
+		return nil
+	}
+	out := make([]*pb.UnresolvedChart, len(cs))
+	for i, c := range cs {
+		out[i] = &pb.UnresolvedChart{
+			Domain:  c.Domain,
+			Name:    c.Name,
+			AppRefs: c.AppRefs,
+			Reason:  c.Reason,
+		}
+	}
+	return out
 }
 
 func (s *AppServer) ListApps(ctx context.Context, req *pb.ListAppsRequest) (*pb.ListAppsResponse, error) {

--- a/tools/app_registry/server/handlers/app_test.go
+++ b/tools/app_registry/server/handlers/app_test.go
@@ -164,31 +164,190 @@ func TestReconcileApps_IdempotencyReplaysWithoutDoubleWrite(t *testing.T) {
 	}
 }
 
-// TestReconcileApps_UnknownChartAppFailsWholeReconcile covers "resolve
-// ChartManifest.apps (bare app names) to app IDs and fail the reconcile if
-// any is unknown."
-func TestReconcileApps_UnknownChartAppFailsWholeReconcile(t *testing.T) {
+// TestReconcileApps_UnknownChartAppSkipsChartOnly is AR-7a's headline
+// scenario: a chart whose apps reference an unknown app no longer fails the
+// whole reconcile (pre-AR-7a: TestReconcileApps_UnknownChartAppFailsWholeReconcile
+// asserted the opposite). It must be reported in unresolved_charts and
+// skipped, while every other app/chart in the same call still applies.
+func TestReconcileApps_UnknownChartAppSkipsChartOnly(t *testing.T) {
 	ctx := authedCtx()
 	srv := NewAppServer(fake.New())
 
-	_, err := srv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
-		Manifests: manifestSet(nil, []*appmetapb.ChartManifest{
-			{Domain: "demo", Name: "chart", Apps: []string{"nonexistent"}},
-		}),
+	resp, err := srv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
+		Manifests: manifestSet(
+			[]*appmetapb.AppManifest{oneApp("demo", "good-app")},
+			[]*appmetapb.ChartManifest{
+				{Domain: "demo", Name: "bad-chart", Apps: []string{"nonexistent"}},
+				{Domain: "demo", Name: "good-chart", Apps: []string{"good-app"}},
+			},
+		),
 		IdempotencyKey: "run-3-1",
 	})
-	if err == nil {
-		t.Fatal("expected an error for a chart referencing an unknown app")
-	}
-	st, _ := status.FromError(err)
-	if st.Code() != codes.InvalidArgument {
-		t.Fatalf("expected InvalidArgument, got %v", st.Code())
+	if err != nil {
+		t.Fatalf("reconcile with one bad chart must not fail the whole call: %v", err)
 	}
 
-	// Nothing should have been written.
-	listResp, _ := srv.ListCharts(ctx, &pb.ListChartsRequest{})
-	if len(listResp.Charts) != 0 {
-		t.Fatalf("failed reconcile must not write a partial chart, got %d charts", len(listResp.Charts))
+	if len(resp.UnresolvedCharts) != 1 {
+		t.Fatalf("expected exactly 1 unresolved chart, got %+v", resp.UnresolvedCharts)
+	}
+	uc := resp.UnresolvedCharts[0]
+	if uc.Domain != "demo" || uc.Name != "bad-chart" {
+		t.Fatalf("expected unresolved chart demo/bad-chart, got %+v", uc)
+	}
+	if len(uc.AppRefs) != 1 || uc.AppRefs[0] != "nonexistent" {
+		t.Fatalf("expected offending app_refs=[nonexistent], got %+v", uc.AppRefs)
+	}
+	if uc.Reason == "" {
+		t.Fatal("expected a non-empty reason")
+	}
+
+	// The good app and good chart still applied, and the bad chart was not
+	// created.
+	if len(resp.CreatedApps) != 1 {
+		t.Fatalf("expected the good app to still be created, got %+v", resp.CreatedApps)
+	}
+	if len(resp.CreatedCharts) != 1 || resp.CreatedCharts[0].Name != "good-chart" {
+		t.Fatalf("expected only good-chart to be created, got %+v", resp.CreatedCharts)
+	}
+
+	listResp, err := srv.ListCharts(ctx, &pb.ListChartsRequest{})
+	if err != nil {
+		t.Fatalf("list charts: %v", err)
+	}
+	if len(listResp.Charts) != 1 || listResp.Charts[0].Name != "good-chart" {
+		t.Fatalf("expected only good-chart to be registered, got %+v", listResp.Charts)
+	}
+}
+
+// TestReconcileApps_UnresolvedChartNotMarkedMissing proves the deliberate
+// semantics called out in ARCHITECTURE.md "AssertApps (additive) vs.
+// ReconcileApps (absence sweep)": a chart that was already registered, and
+// becomes unresolvable in a later reconcile (its manifest now names an app
+// that does not exist), is SKIPPED -- not swept into MISSING as a side
+// effect of not being re-applied this call. A chart present in the manifest
+// set but unresolvable is present, not absent.
+func TestReconcileApps_UnresolvedChartNotMarkedMissing(t *testing.T) {
+	ctx := authedCtx()
+	srv := NewAppServer(fake.New())
+
+	// 1. Register app + chart normally.
+	first, err := srv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
+		Manifests: manifestSet(
+			[]*appmetapb.AppManifest{oneApp("demo", "svc")},
+			[]*appmetapb.ChartManifest{{Domain: "demo", Name: "chart", Apps: []string{"svc"}}},
+		),
+		IdempotencyKey: "run-5-1",
+	})
+	if err != nil {
+		t.Fatalf("initial reconcile: %v", err)
+	}
+	chartID := first.CreatedCharts[0].ChartId
+
+	// 2. Reconcile again: the chart's manifest now references an app that
+	// does not exist ("svc" renamed without updating the chart) -- an
+	// unresolvable reference. The chart itself is still present in this
+	// call's manifest set, unlike an app/chart that simply drops out.
+	second, err := srv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
+		Manifests: manifestSet(
+			[]*appmetapb.AppManifest{oneApp("demo", "svc")},
+			[]*appmetapb.ChartManifest{{Domain: "demo", Name: "chart", Apps: []string{"renamed-away"}}},
+		),
+		IdempotencyKey: "run-5-2",
+	})
+	if err != nil {
+		t.Fatalf("second reconcile: %v", err)
+	}
+	if len(second.UnresolvedCharts) != 1 {
+		t.Fatalf("expected the chart to be reported unresolved, got %+v", second.UnresolvedCharts)
+	}
+	if len(second.NewlyMissingCharts) != 0 {
+		t.Fatalf("an unresolved chart must NOT be swept into newly_missing_charts, got %+v", second.NewlyMissingCharts)
+	}
+
+	listResp, err := srv.ListCharts(ctx, &pb.ListChartsRequest{})
+	if err != nil {
+		t.Fatalf("list charts: %v", err)
+	}
+	found := false
+	for _, c := range listResp.Charts {
+		if c.ChartId == chartID {
+			found = true
+			if c.Status == pb.AppStatus_APP_STATUS_MISSING {
+				t.Fatalf("chart was incorrectly marked MISSING after becoming unresolvable, got %+v", c)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("expected the chart to still be listed (active, untouched), got %+v", listResp.Charts)
+	}
+}
+
+// TestReconcileApps_DomainQualifiedAppRefsResolveUnambiguously proves
+// AR-7a's fix for cross-domain bare-name ambiguity: two apps sharing a bare
+// name in different domains previously made resolveChartApps fail on the
+// ambiguous bare name; a chart using AppRefs (domain-qualified) instead
+// resolves deterministically to the correct app regardless of the collision.
+func TestReconcileApps_DomainQualifiedAppRefsResolveUnambiguously(t *testing.T) {
+	ctx := authedCtx()
+	srv := NewAppServer(fake.New())
+
+	resp, err := srv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
+		Manifests: manifestSet(
+			[]*appmetapb.AppManifest{oneApp("domain-a", "shared-name"), oneApp("domain-b", "shared-name")},
+			[]*appmetapb.ChartManifest{
+				{Domain: "domain-b", Name: "chart", AppRefs: []string{"domain-b/shared-name"}},
+			},
+		),
+		IdempotencyKey: "run-6-1",
+	})
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if len(resp.UnresolvedCharts) != 0 {
+		t.Fatalf("expected the domain-qualified ref to resolve without ambiguity, got unresolved=%+v", resp.UnresolvedCharts)
+	}
+	if len(resp.CreatedCharts) != 1 || len(resp.CreatedCharts[0].AppIds) != 1 {
+		t.Fatalf("expected 1 chart composing exactly 1 app, got %+v", resp.CreatedCharts)
+	}
+
+	var domainBAppID string
+	for _, a := range resp.CreatedApps {
+		if a.Domain == "domain-b" {
+			domainBAppID = a.AppId
+		}
+	}
+	if resp.CreatedCharts[0].AppIds[0] != domainBAppID {
+		t.Fatalf("expected the chart to resolve to domain-b's app (id=%s), got %+v", domainBAppID, resp.CreatedCharts[0].AppIds)
+	}
+}
+
+// TestReconcileApps_AmbiguousBareNameSkipsChartNotWholeReconcile proves the
+// deprecated bare-name compatibility path still rejects ambiguity -- but as
+// a per-chart skip now, not a whole-reconcile failure (AR-7a).
+func TestReconcileApps_AmbiguousBareNameSkipsChartNotWholeReconcile(t *testing.T) {
+	ctx := authedCtx()
+	srv := NewAppServer(fake.New())
+
+	resp, err := srv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
+		Manifests: manifestSet(
+			[]*appmetapb.AppManifest{oneApp("domain-a", "shared-name"), oneApp("domain-b", "shared-name")},
+			[]*appmetapb.ChartManifest{
+				// domain "other" has no app named "shared-name" itself, so
+				// the same-domain preference doesn't disambiguate, and both
+				// domain-a and domain-b match -- genuinely ambiguous.
+				{Domain: "other", Name: "chart", Apps: []string{"shared-name"}},
+			},
+		),
+		IdempotencyKey: "run-7-1",
+	})
+	if err != nil {
+		t.Fatalf("reconcile must not fail the whole call for an ambiguous bare name: %v", err)
+	}
+	if len(resp.UnresolvedCharts) != 1 {
+		t.Fatalf("expected the ambiguous chart to be reported unresolved, got %+v", resp.UnresolvedCharts)
+	}
+	if len(resp.CreatedApps) != 2 {
+		t.Fatalf("expected both apps to still be created despite the ambiguous chart, got %+v", resp.CreatedApps)
 	}
 }
 

--- a/tools/app_registry/server/repository/fake/reconcile.go
+++ b/tools/app_registry/server/repository/fake/reconcile.go
@@ -2,6 +2,7 @@ package fake
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -98,9 +99,20 @@ func reconcile(s *state, apps []*appmetapb.AppManifest, charts []*appmetapb.Char
 
 	presentChartIDs := map[string]bool{}
 	for _, cm := range charts {
-		appIDs, err := resolveChartApps(workState, cm)
-		if err != nil {
-			return nil, err
+		appIDs, offending, reason := resolveChartApps(workState, cm)
+		if len(offending) > 0 {
+			// AR-7a: skip this chart, report it, but do not let it be swept
+			// into MISSING -- a chart present in the manifest set but
+			// unresolvable is *present*, not absent. See
+			// ARCHITECTURE.md "AssertApps (additive) vs. ReconcileApps" and
+			// postgres/app.go's Reconcile, which this mirrors.
+			result.UnresolvedCharts = append(result.UnresolvedCharts, repository.UnresolvedChart{
+				Domain: cm.Domain, Name: cm.Name, AppRefs: offending, Reason: reason,
+			})
+			if id, _, found := findChartByDomainName(workState, cm.Domain, cm.Name); found {
+				presentChartIDs[id] = true
+			}
+			continue
 		}
 
 		id, existing, found := findChartByDomainName(workState, cm.Domain, cm.Name)
@@ -178,14 +190,47 @@ func findChartByDomainName(s *state, domain, name string) (string, repository.Ch
 	return "", repository.Chart{}, false
 }
 
-// resolveChartApps resolves ChartManifest.apps (bare app names) to app_ids,
-// per ARCHITECTURE.md/PLAN.md: "fail the reconcile if any is unknown."
-// Same-domain matches are preferred; a cross-domain match is accepted only
-// if it is unique.
-func resolveChartApps(s *state, cm *appmetapb.ChartManifest) ([]string, error) {
-	ids := make([]string, 0, len(cm.Apps))
-	for _, name := range cm.Apps {
-		if id, _, ok := findAppByDomainName(s, cm.Domain, name); ok {
+// resolveChartApps resolves a chart manifest's app references to app_ids,
+// mirroring postgres/app.go's resolveChartApps exactly (see its doc comment
+// for the full rationale). Prefers cm.AppRefs (domain-qualified
+// "<domain>/<name>", never ambiguous); falls back to the DEPRECATED
+// cm.Apps (bare names, same-domain preferred, cross-domain accepted only if
+// unique) when AppRefs is empty -- AR-7a, one release cycle's compatibility.
+//
+// AR-7a: does not fail on an unresolved reference. Returns the ids resolved
+// so far (meaningless if offending is non-empty), every offending reference,
+// and a combined reason string -- the caller downgrades a non-empty
+// offending to a per-chart skip instead of failing the whole reconcile.
+func resolveChartApps(s *state, cm *appmetapb.ChartManifest) (ids []string, offending []string, reason string) {
+	qualified := len(cm.AppRefs) > 0
+	refs := cm.AppRefs
+	if !qualified {
+		refs = cm.Apps
+	}
+
+	ids = make([]string, 0, len(refs))
+	var reasons []string
+
+	for _, ref := range refs {
+		if qualified {
+			domain, name, ok := strings.Cut(ref, "/")
+			if !ok {
+				offending = append(offending, ref)
+				reasons = append(reasons, fmt.Sprintf("app_ref %q is not domain-qualified", ref))
+				continue
+			}
+			if id, _, found := findAppByDomainName(s, domain, name); found {
+				ids = append(ids, id)
+				continue
+			}
+			offending = append(offending, ref)
+			reasons = append(reasons, fmt.Sprintf("app_ref %q not found", ref))
+			continue
+		}
+
+		// DEPRECATED bare-name path -- see doc comment above.
+		name := ref
+		if id, _, found := findAppByDomainName(s, cm.Domain, name); found {
 			ids = append(ids, id)
 			continue
 		}
@@ -197,14 +242,20 @@ func resolveChartApps(s *state, cm *appmetapb.ChartManifest) ([]string, error) {
 		}
 		switch len(matches) {
 		case 0:
-			return nil, fmt.Errorf("%w: chart %s/%s references unknown app %q", repository.ErrInvalidArgument, cm.Domain, cm.Name, name)
+			offending = append(offending, name)
+			reasons = append(reasons, fmt.Sprintf("unknown app %q", name))
 		case 1:
 			ids = append(ids, matches[0])
 		default:
-			return nil, fmt.Errorf("%w: chart %s/%s app name %q is ambiguous across domains", repository.ErrInvalidArgument, cm.Domain, cm.Name, name)
+			offending = append(offending, name)
+			reasons = append(reasons, fmt.Sprintf("app name %q is ambiguous across domains", name))
 		}
 	}
-	return ids, nil
+
+	if len(offending) > 0 {
+		reason = fmt.Sprintf("chart %s/%s: %s", cm.Domain, cm.Name, strings.Join(reasons, "; "))
+	}
+	return ids, offending, reason
 }
 
 func normalizeDeployUnit(du appmetapb.DeployUnit) appmetapb.DeployUnit {

--- a/tools/app_registry/server/repository/models.go
+++ b/tools/app_registry/server/repository/models.go
@@ -81,6 +81,16 @@ type ReconcileResult struct {
 	NewlyMissingCharts []Chart
 	RecoveredCharts    []Chart
 
+	// UnresolvedCharts lists every chart in this call's manifest set whose
+	// apps entries could not all be resolved to identity rows -- AR-7a. Each
+	// such chart is SKIPPED, not fatal: every other app/chart in the same
+	// call still applies, and the watermark still advances. See
+	// ARCHITECTURE.md "AssertApps (additive) vs. ReconcileApps (absence
+	// sweep)" and PLAN.md's AR-7a. Always empty for a dry run's diff in the
+	// same shape as every other bucket here -- a dry run computes the same
+	// resolution and reports it the same way, it just writes nothing.
+	UnresolvedCharts []UnresolvedChart
+
 	// SkippedStale is true when the reconcile watermark rejected this call
 	// as older (in commit order) than the most recently applied one -- see
 	// watermark.go's ShouldApplyReconcile. A no-op success, not an error:
@@ -90,6 +100,23 @@ type ReconcileResult struct {
 	// CurrentWatermarkGitSHA is the git_sha this call lost to. Populated
 	// only when SkippedStale is true.
 	CurrentWatermarkGitSHA string
+}
+
+// UnresolvedChart is one chart manifest whose apps references could not all
+// be resolved to app identity rows during Reconcile -- AR-7a. Modeled on the
+// existing App/Chart result buckets: enough to act on without re-deriving it
+// from server logs.
+type UnresolvedChart struct {
+	Domain string
+	Name   string
+	// AppRefs is every app reference from the chart manifest that failed to
+	// resolve, exactly as it appeared in the manifest (a bare name via the
+	// deprecated `ChartManifest.apps` path, or a "<domain>/<name>" string
+	// via `app_refs`).
+	AppRefs []string
+	// Reason is a human-readable explanation (unknown app, ambiguous bare
+	// name across domains, malformed app_ref) -- not machine-parsed.
+	Reason string
 }
 
 // AppListFilter is ListAppsRequest's filter set, decoupled from the proto.

--- a/tools/app_registry/server/repository/postgres/app.go
+++ b/tools/app_registry/server/repository/postgres/app.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -193,7 +194,31 @@ func (r *appRepo) Reconcile(ctx context.Context, apps []*appmetapb.AppManifest, 
 	for _, cm := range charts {
 		appIDs, err := r.resolveChartApps(ctx, appIDByKey, cm)
 		if err != nil {
-			return nil, err
+			var re *chartResolutionError
+			if !errors.As(err, &re) {
+				// A real infrastructure error (failed query, etc) -- abort
+				// the whole reconcile, unchanged from pre-AR-7a behavior.
+				return nil, err
+			}
+			// AR-7a: this chart's apps didn't all resolve. Report it and
+			// skip it -- every other app/chart in this call still applies,
+			// and the watermark still advances (see Reconcile's doc comment
+			// on repository.AppRepository and ARCHITECTURE.md "AssertApps
+			// (additive) vs. ReconcileApps"). Deliberately NOT marked
+			// MISSING as a side effect: if this chart already exists, add
+			// its id to presentChartIDs so the absence sweep below leaves it
+			// alone -- a chart present in the manifest set but unresolvable
+			// is present, not absent. If it doesn't exist yet, there is
+			// nothing to mark missing either way.
+			result.UnresolvedCharts = append(result.UnresolvedCharts, repository.UnresolvedChart{
+				Domain: cm.Domain, Name: cm.Name, AppRefs: re.offending, Reason: re.reason,
+			})
+			if existingChart, lookErr := r.getChartByDomainName(ctx, cm.Domain, cm.Name); lookErr == nil {
+				presentChartIDs[existingChart.ChartID] = true
+			} else if !errors.Is(lookErr, repository.ErrNotFound) {
+				return nil, fmt.Errorf("reconcile: look up chart %s/%s after unresolved apps: %w", cm.Domain, cm.Name, lookErr)
+			}
+			continue
 		}
 
 		existing, err := r.getChartByDomainName(ctx, cm.Domain, cm.Name)
@@ -339,14 +364,75 @@ func (r *appRepo) setChartApps(ctx context.Context, chartID string, appIDs []str
 	return nil
 }
 
-// resolveChartApps resolves ChartManifest.apps (bare app names) to app_ids.
-// Same-domain matches are preferred (checked first against appIDByKey, which
-// includes apps created/updated earlier in this same reconcile call);
-// otherwise a cross-domain match is accepted only if unique. Fails the whole
-// reconcile with ErrInvalidArgument if any name is unknown.
+// chartResolutionError carries every app reference in one chart manifest
+// that failed to resolve, so Reconcile's caller can build a precise
+// ReconcileResult.UnresolvedCharts entry and skip only this chart -- AR-7a.
+// Deliberately distinct from the plain errors resolveChartApps returns for a
+// real infrastructure failure (a failed query): only THIS type is downgraded
+// to a per-chart skip; anything else still aborts the whole Reconcile
+// transaction, unchanged from pre-AR-7a behavior. See Reconcile's call site.
+type chartResolutionError struct {
+	offending []string // app refs that failed, exactly as they appeared in the manifest
+	reason    string
+}
+
+func (e *chartResolutionError) Error() string { return e.reason }
+
+// resolveChartApps resolves a chart manifest's app references to app_ids.
+//
+// Prefers cm.AppRefs, domain-qualified "<domain>/<name>" strings emitted by
+// tools/bazel/release.bzl's helm_chart_metadata rule -- each reference
+// carries its own domain, so it can never be ambiguous. Falls back to the
+// DEPRECATED cm.Apps (bare names) only when AppRefs is empty, for one
+// release cycle's backward compatibility with a chart metadata JSON built
+// before AR-7a; same-domain matches are preferred there (checked first
+// against appIDByKey, which includes apps created/updated earlier in this
+// same reconcile call), and a cross-domain match is accepted only if unique.
+// See ChartManifest.apps's doc comment in appmeta.proto and PLAN.md's AR-7a
+// for the removal pointer.
+//
+// AR-7a: an unresolved reference no longer fails the whole reconcile. Every
+// unresolved reference for this chart is collected and returned together as
+// a *chartResolutionError; the caller downgrades that to a per-chart skip. A
+// genuine query failure is returned as a plain error and still aborts the
+// whole Reconcile, unchanged.
 func (r *appRepo) resolveChartApps(ctx context.Context, appIDByKey map[string]string, cm *appmetapb.ChartManifest) ([]string, error) {
-	ids := make([]string, 0, len(cm.Apps))
-	for _, name := range cm.Apps {
+	qualified := len(cm.AppRefs) > 0
+	refs := cm.AppRefs
+	if !qualified {
+		refs = cm.Apps
+	}
+
+	ids := make([]string, 0, len(refs))
+	var offending, reasons []string
+
+	for _, ref := range refs {
+		if qualified {
+			domain, name, ok := strings.Cut(ref, "/")
+			if !ok {
+				offending = append(offending, ref)
+				reasons = append(reasons, fmt.Sprintf("app_ref %q is not domain-qualified", ref))
+				continue
+			}
+			if id, ok := appIDByKey[domain+"|"+name]; ok {
+				ids = append(ids, id)
+				continue
+			}
+			existing, err := r.getAppByDomainName(ctx, domain, name)
+			if err != nil {
+				if errors.Is(err, repository.ErrNotFound) {
+					offending = append(offending, ref)
+					reasons = append(reasons, fmt.Sprintf("app_ref %q not found", ref))
+					continue
+				}
+				return nil, fmt.Errorf("reconcile: resolve chart app_ref %q: %w", ref, err)
+			}
+			ids = append(ids, existing.AppID)
+			continue
+		}
+
+		// DEPRECATED bare-name path -- see doc comment above.
+		name := ref
 		if id, ok := appIDByKey[cm.Domain+"|"+name]; ok {
 			ids = append(ids, id)
 			continue
@@ -369,11 +455,20 @@ func (r *appRepo) resolveChartApps(ctx context.Context, appIDByKey map[string]st
 
 		switch len(matches) {
 		case 0:
-			return nil, fmt.Errorf("%w: chart %s/%s references unknown app %q", repository.ErrInvalidArgument, cm.Domain, cm.Name, name)
+			offending = append(offending, name)
+			reasons = append(reasons, fmt.Sprintf("unknown app %q", name))
 		case 1:
 			ids = append(ids, matches[0])
 		default:
-			return nil, fmt.Errorf("%w: chart %s/%s app name %q is ambiguous across domains", repository.ErrInvalidArgument, cm.Domain, cm.Name, name)
+			offending = append(offending, name)
+			reasons = append(reasons, fmt.Sprintf("app name %q is ambiguous across domains", name))
+		}
+	}
+
+	if len(offending) > 0 {
+		return nil, &chartResolutionError{
+			offending: offending,
+			reason:    fmt.Sprintf("chart %s/%s: %s", cm.Domain, cm.Name, strings.Join(reasons, "; ")),
 		}
 	}
 	return ids, nil

--- a/tools/app_registry/server/repository/postgres/postgres_integration_test.go
+++ b/tools/app_registry/server/repository/postgres/postgres_integration_test.go
@@ -1542,6 +1542,15 @@ func appStatus(t *testing.T, pool *pgxpool.Pool, appID string) string {
 	return status
 }
 
+func chartStatus(t *testing.T, pool *pgxpool.Pool, chartID string) string {
+	t.Helper()
+	var status string
+	if err := pool.QueryRow(context.Background(), `SELECT status FROM chart WHERE chart_id = $1`, chartID).Scan(&status); err != nil {
+		t.Fatalf("read chart status for %s: %v", chartID, err)
+	}
+	return status
+}
+
 // TestMigration006SeedsSentinelWatermarkRow proves migration 006's seed:
 // exactly one row, the documented sentinel (empty git_sha, zero
 // timestamps) -- see that migration's comments for why a seeded sentinel,
@@ -1859,5 +1868,192 @@ func TestReconcileWatermark_ConcurrentCallsSerializeOnTheLockedRow(t *testing.T)
 	if gitSha != "high-sha" || sourceCommittedAt != 200 {
 		t.Fatalf("expected the higher ordering key (high-sha, 200) to win regardless of goroutine scheduling, got (%q, %d) -- this means the two concurrent Reconcile calls were NOT properly serialized by the watermark's locking read",
 			gitSha, sourceCommittedAt)
+	}
+}
+
+// ============================================================================
+// AR-7a: sweep robustness -- partial-apply Reconcile
+// ============================================================================
+//
+// PLAN.md's AR-7a calls out a real-Postgres integration test explicitly: the
+// fake (server/repository/fake) cannot catch a transaction-rollback
+// regression here, because its dryRun path is a superficial in-memory clone,
+// not a real database transaction. Pre-AR-7a, resolveChartApps returning any
+// error propagated straight out of Reconcile and aborted the WHOLE WithTx
+// transaction -- see TestRecordArtifact_ChartLinkFailureRollsBackTransaction
+// above for the established "real rollback" pattern this mirrors. AR-7a's
+// fix only works if the unresolved-chart error stays IN-BAND (the
+// *chartResolutionError path in postgres/app.go's Reconcile) rather than
+// propagating -- if that regressed, this test would see the whole call fail
+// and nothing committed, exactly like the pre-AR-7a behavior.
+
+// TestReconcile_UnresolvedChartDoesNotRollBackWholeTransaction is AR-7a's
+// headline exit criterion: "a chart manifest naming a nonexistent app leaves
+// every other app/chart registered, advances the watermark, and reports the
+// offending chart."
+func TestReconcile_UnresolvedChartDoesNotRollBackWholeTransaction(t *testing.T) {
+	reg, pool := newTestRegistry(t)
+	ctx := authedCtx()
+	srv := handlers.NewAppServer(reg)
+
+	resp, err := srv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
+		Manifests: reconcileManifests("sha-ar7a-1", 10000, 10000,
+			[]*appmetapb.AppManifest{oneAppManifest("acme", "good-app")},
+			[]*appmetapb.ChartManifest{
+				{Domain: "acme", Name: "bad-chart", Apps: []string{"nonexistent-app"}},
+				{Domain: "acme", Name: "good-chart", Apps: []string{"good-app"}},
+			},
+		),
+		IdempotencyKey: "ar7a-1",
+	})
+	if err != nil {
+		t.Fatalf("reconcile with one bad chart must not fail the whole call: %v", err)
+	}
+
+	// 1. The offending chart is reported, not fatal.
+	if len(resp.UnresolvedCharts) != 1 {
+		t.Fatalf("expected exactly 1 unresolved chart, got %+v", resp.UnresolvedCharts)
+	}
+	uc := resp.UnresolvedCharts[0]
+	if uc.Domain != "acme" || uc.Name != "bad-chart" {
+		t.Fatalf("expected unresolved chart acme/bad-chart, got %+v", uc)
+	}
+	if len(uc.AppRefs) != 1 || uc.AppRefs[0] != "nonexistent-app" {
+		t.Fatalf("expected offending app_refs=[nonexistent-app], got %+v", uc.AppRefs)
+	}
+	if uc.Reason == "" {
+		t.Fatal("expected a non-empty reason")
+	}
+
+	// 2. Every OTHER app and chart in the same call still registered -- the
+	// assertion only a real Postgres transaction proves: a regression back to
+	// whole-transaction rollback would make good-app/good-chart vanish along
+	// with bad-chart.
+	if len(resp.CreatedApps) != 1 || resp.CreatedApps[0].Name != "good-app" {
+		t.Fatalf("expected good-app to be created, got %+v", resp.CreatedApps)
+	}
+	if len(resp.CreatedCharts) != 1 || resp.CreatedCharts[0].Name != "good-chart" {
+		t.Fatalf("expected only good-chart to be created, got %+v", resp.CreatedCharts)
+	}
+
+	appRow, err := reg.Apps().GetAppByFullName(ctx, "acme-good-app")
+	if err != nil {
+		t.Fatalf("good-app must be queryable after commit: %v", err)
+	}
+	if appRow.Status != repository.StatusActive {
+		t.Fatalf("expected good-app ACTIVE, got %s", appRow.Status)
+	}
+
+	chartRow, err := reg.Apps().GetChartByFullName(ctx, "acme-good-chart")
+	if err != nil {
+		t.Fatalf("good-chart must be queryable after commit: %v", err)
+	}
+	if chartRow.Status != repository.StatusActive {
+		t.Fatalf("expected good-chart ACTIVE, got %s", chartRow.Status)
+	}
+
+	// bad-chart must not have been written at all.
+	if _, err := reg.Apps().GetChartByFullName(ctx, "acme-bad-chart"); !errors.Is(err, repository.ErrNotFound) {
+		t.Fatalf("expected bad-chart to not exist, got err=%v", err)
+	}
+
+	// 3. The watermark still advanced -- pre-AR-7a this call would have
+	// rolled back before ever reaching the watermark write.
+	gitSha, sourceCommittedAt, _ := watermarkRow(t, pool)
+	if gitSha != "sha-ar7a-1" || sourceCommittedAt != 10000 {
+		t.Fatalf("expected the watermark to advance to (sha-ar7a-1, 10000) despite the unresolved chart, got (%q, %d)", gitSha, sourceCommittedAt)
+	}
+}
+
+// TestReconcile_UnresolvedChartNotMarkedMissing_Postgres proves the
+// deliberate semantics ARCHITECTURE.md "AssertApps (additive) vs.
+// ReconcileApps (absence sweep)" states: a chart already registered that
+// becomes unresolvable in a later reconcile is skipped, not swept into
+// MISSING -- against real Postgres, where the absence sweep is a real SQL
+// statement scanning `status = 'active'` (see Reconcile's `SELECT ... FROM
+// chart WHERE status = 'active'`), not the fake's map iteration.
+func TestReconcile_UnresolvedChartNotMarkedMissing_Postgres(t *testing.T) {
+	reg, pool := newTestRegistry(t)
+	ctx := authedCtx()
+	srv := handlers.NewAppServer(reg)
+
+	first, err := srv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
+		Manifests: reconcileManifests("sha-ar7a-2a", 20000, 20000,
+			[]*appmetapb.AppManifest{oneAppManifest("acme", "svc")},
+			[]*appmetapb.ChartManifest{{Domain: "acme", Name: "chart", Apps: []string{"svc"}}},
+		),
+		IdempotencyKey: "ar7a-2a",
+	})
+	if err != nil {
+		t.Fatalf("initial reconcile: %v", err)
+	}
+	if len(first.CreatedCharts) != 1 {
+		t.Fatalf("expected 1 created chart, got %+v", first.CreatedCharts)
+	}
+	chartID := first.CreatedCharts[0].ChartId
+
+	// Reconcile again: the chart's manifest now references an app that does
+	// not exist ("svc" renamed without updating the chart) -- an unresolvable
+	// reference. The chart itself is still present in this call's manifest
+	// set, unlike an app/chart that simply drops out.
+	second, err := srv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
+		Manifests: reconcileManifests("sha-ar7a-2b", 21000, 21000,
+			[]*appmetapb.AppManifest{oneAppManifest("acme", "svc")},
+			[]*appmetapb.ChartManifest{{Domain: "acme", Name: "chart", Apps: []string{"renamed-away"}}},
+		),
+		IdempotencyKey: "ar7a-2b",
+	})
+	if err != nil {
+		t.Fatalf("second reconcile: %v", err)
+	}
+	if len(second.UnresolvedCharts) != 1 {
+		t.Fatalf("expected the chart to be reported unresolved, got %+v", second.UnresolvedCharts)
+	}
+	if len(second.NewlyMissingCharts) != 0 {
+		t.Fatalf("an unresolved chart must NOT be swept into newly_missing_charts, got %+v", second.NewlyMissingCharts)
+	}
+
+	if got := chartStatus(t, pool, chartID); got != "active" {
+		t.Fatalf("expected the chart to remain ACTIVE (present, not absent) after becoming unresolvable, got %q", got)
+	}
+}
+
+// TestReconcile_DomainQualifiedAppRefsResolveUnambiguously_Postgres proves
+// AR-7a's fix for cross-domain bare-name ambiguity against real Postgres:
+// two apps sharing a bare name in different domains previously made
+// resolveChartApps's `SELECT app_id FROM app WHERE name = $1` return 2 rows
+// and fail; a chart using AppRefs (domain-qualified) resolves
+// deterministically via getAppByDomainName instead, bypassing that query
+// entirely.
+func TestReconcile_DomainQualifiedAppRefsResolveUnambiguously_Postgres(t *testing.T) {
+	reg, _ := newTestRegistry(t)
+	ctx := authedCtx()
+	srv := handlers.NewAppServer(reg)
+
+	resp, err := srv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
+		Manifests: reconcileManifests("sha-ar7a-3", 30000, 30000,
+			[]*appmetapb.AppManifest{oneAppManifest("domain-a", "shared-name"), oneAppManifest("domain-b", "shared-name")},
+			[]*appmetapb.ChartManifest{
+				{Domain: "domain-b", Name: "chart", AppRefs: []string{"domain-b/shared-name"}},
+			},
+		),
+		IdempotencyKey: "ar7a-3",
+	})
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if len(resp.UnresolvedCharts) != 0 {
+		t.Fatalf("expected the domain-qualified ref to resolve without ambiguity, got unresolved=%+v", resp.UnresolvedCharts)
+	}
+	if len(resp.CreatedCharts) != 1 || len(resp.CreatedCharts[0].AppIds) != 1 {
+		t.Fatalf("expected 1 chart composing exactly 1 app, got %+v", resp.CreatedCharts)
+	}
+
+	domainBApp, err := reg.Apps().GetAppByFullName(ctx, "domain-b-shared-name")
+	if err != nil {
+		t.Fatalf("get domain-b's app: %v", err)
+	}
+	if resp.CreatedCharts[0].AppIds[0] != domainBApp.AppID {
+		t.Fatalf("expected the chart to resolve to domain-b's app (id=%s), got %+v", domainBApp.AppID, resp.CreatedCharts[0].AppIds)
 	}
 }

--- a/tools/app_registry/server/repository/repository.go
+++ b/tools/app_registry/server/repository/repository.go
@@ -54,9 +54,20 @@ type AppRepository interface {
 	// app/chart in the manifest set is created or updated and set ACTIVE;
 	// anything known but absent is marked MISSING (ARCHIVED rows are left
 	// alone); anything MISSING that reappears is reported as recovered.
-	// chart.apps entries are resolved to app_ids and the call fails with
-	// ErrInvalidArgument if any name is unknown. dryRun computes the result
-	// without writing.
+	// chart.apps/app_refs entries are resolved to app_ids.
+	//
+	// AR-7a: this is PARTIALLY applying with respect to chart resolution. A
+	// chart whose apps references don't all resolve (unknown app, or an
+	// ambiguous bare name across domains) is reported in
+	// ReconcileResult.UnresolvedCharts and SKIPPED -- it is not created or
+	// updated, its chart_app membership is not touched, and critically it is
+	// NOT marked MISSING by the absence sweep either: a chart present in the
+	// manifest set but unresolvable is *present*, not absent (see
+	// ARCHITECTURE.md "AssertApps (additive) vs. ReconcileApps"). Every
+	// other app and chart in the same call still applies, and the watermark
+	// still advances. This is a deliberate change from pre-AR-7a behavior,
+	// where any resolution failure aborted the whole transaction and left
+	// the watermark unmoved. dryRun computes the result without writing.
 	//
 	// source carries the ordering metadata (git_sha / source_committed_at /
 	// discovered_at) this call is checked against the reconcile watermark

--- a/tools/appmeta/BUILD.bazel
+++ b/tools/appmeta/BUILD.bazel
@@ -1,5 +1,20 @@
 load("@rules_go//go:def.bzl", "go_test")
 
+# gazelle:exclude proto_to_rule_test.go
+# gazelle:exclude rule_to_proto_test.go
+#
+# Without these, gazelle doesn't associate the hand-written
+# manifest_contract_test rule below with these two source files (there is no
+# go_library in this package for it to key off of) and generates a SECOND,
+# competing go_test rule for them on every `bazel run //:gazelle` -- with
+# neither the `data` fixture deps nor the `manual` tag, so it would fail
+# outright under a plain `bazel test //tools/...` (the fixture JSON isn't a
+# declared input). `# keep` alone (see the rule below) only stops gazelle
+# from touching the rule it's attached to; it does not stop gazelle from
+# adding a new one. Discovered and fixed in AR-7a
+# (//tools/app_registry/PLAN.md) -- if a future field addition needs a THIRD
+# fixture/test file pair here, exclude it here too.
+
 # Anti-drift enforcement for the appmeta schema, both directions — see
 # README.md's "The contract test" section.
 #
@@ -13,6 +28,14 @@ load("@rules_go//go:def.bzl", "go_test")
 # this target follows the same idiom: tagged "manual" so it's excluded from
 # `//tools/...` / `//...` wildcards, and invoked by explicit name in CI.
 go_test(
+    # keep -- gazelle does not recognize this rule as covering
+    # proto_to_rule_test.go/rule_to_proto_test.go on its own (it has no
+    # go_library to embed) and otherwise generates a second, competing
+    # go_test rule for the same srcs with neither the `data` fixture deps nor
+    # the `manual` tag -- breaking under a plain `bazel test //tools/...`
+    # since the fixture JSON wouldn't be a declared input. See AR-7a and the
+    # `# keep` convention on
+    # //tools/app_registry/server/repository/postgres:postgres_integration_test.
     name = "manifest_contract_test",
     srcs = [
         "proto_to_rule_test.go",
@@ -20,12 +43,13 @@ go_test(
     ],
     data = [
         "//tools/appmeta/testdata:fixture-app_metadata",
+        "//tools/appmeta/testdata:fixture-helm_chart_metadata",
     ],
     tags = [
+        "integration",
         "manual",  # requires a real bazel invocation against the full checkout; see doc comment
         "no-cache",
         "no-sandbox",
-        "integration",
     ],
     deps = [
         "//tools/appmeta/proto:appmetapb",

--- a/tools/appmeta/README.md
+++ b/tools/appmeta/README.md
@@ -90,13 +90,16 @@ without anyone extending the proto. The enforcement is
    each result with `DiscardUnknown: false`. Unlike `release_helper_go`'s
    `ListAllApps`/`ListAllHelmCharts`, this query does **not** exclude
    `testonly` targets: it needs to validate the fixture below, not release it.
-2. **proto → rule** (`TestFixtureLeavesNoFieldUnset`): the fixture in
-   `testdata/` calls `app_metadata` directly (not the `release_app` macro) so
-   it creates no image/openapi_spec targets, and is marked `testonly = True`
-   so `ListAllApps` excludes it from `plan --apps all` — a test fixture must
-   never become a real release. It still sets every `app_metadata` attribute;
-   assert the decoded message has no unset field, to catch a field defined
-   here that the rule never populates.
+2. **proto → rule** (`TestFixtureLeavesNoFieldUnset` /
+   `TestChartFixtureLeavesNoFieldUnset`): the fixtures in `testdata/` call
+   `app_metadata` / `helm_chart_metadata` directly (not the `release_app` /
+   `release_helm_chart` macros) so they create no image/helm_chart targets,
+   and are marked `testonly = True` so `ListAllApps`/`ListAllHelmCharts`
+   exclude them from `plan --apps all` — a test fixture must never become a
+   real release. Each still sets every attribute on its rule (the chart
+   fixture composes the app fixture, so `apps`/`app_refs` are non-empty
+   too); assert the decoded message has no unset field, to catch a field
+   defined here that the rule never populates.
 
 Direction 2 is fully hermetic — it just reads the fixture's built metadata
 JSON as a `data` dependency, so it runs under a normal `bazel test`.
@@ -130,9 +133,17 @@ reverting.
 
 Three edits, and the contract test fails until all three are done:
 
-1. Add the attr to `app_metadata` in `release.bzl` and emit it.
-2. Add the field to `AppManifest` in `appmeta.proto`.
-3. Extend the fixture in `testdata/`.
+1. Add the attr to `app_metadata` (or `helm_chart_metadata`) in `release.bzl`
+   and emit it.
+2. Add the field to `AppManifest` (or `ChartManifest`) in `appmeta.proto`.
+3. Extend the corresponding fixture in `testdata/`.
+
+`ChartManifest.app_refs` (AR-7a) is a worked example: the attr
+(`helm_chart_metadata`'s `apps` label_list, reading each app's `domain` off
+`AppMetadataInfo`), the proto field, and `fixture-helm_chart_metadata`'s
+composed app all went in together. `ChartManifest.apps` (bare app names) is
+now deprecated in favor of it — see the proto's doc comment and
+`//tools/app_registry/PLAN.md`'s AR-7a section.
 
 ## Migration
 

--- a/tools/appmeta/proto/appmeta.proto
+++ b/tools/appmeta/proto/appmeta.proto
@@ -110,12 +110,30 @@ message ChartManifest {
   string namespace = 4;
   string environment = 5;
 
-  // App names composed into this chart. Not "<domain>-<name>" — these are bare
-  // app names, matching what the Starlark rule extracts from the app_metadata
-  // target labels.
+  // DEPRECATED — bare app names, not "<domain>-<name>" or domain-qualified.
+  // resolveChartApps falls back to matching these by name alone when
+  // app_refs (below) is empty, which fails when the name is ambiguous
+  // across domains — see tools/app_registry/ARCHITECTURE.md "AssertApps
+  // (additive) vs. ReconcileApps (absence sweep)" and PLAN.md's AR-7a.
+  // `tools/bazel:release.bzl`'s `helm_chart_metadata` rule still populates
+  // this for one release cycle's backward compatibility (an
+  // already-cached, pre-AR-7a chart metadata JSON on a CI runner); new
+  // consumers should read app_refs instead. Slated for deletion once every
+  // chart manifest in the tree is produced by a tools/helm build that
+  // emits app_refs — see PLAN.md's AR-7a for the removal pointer.
   repeated string apps = 6;
 
   string chart_target = 7;
+
+  // App references composed into this chart, domain-qualified as
+  // "<domain>/<name>" — the field resolveChartApps prefers when present.
+  // Because each reference carries its own domain, it can never be
+  // ambiguous across domains the way a bare name in `apps` can be. Emitted
+  // by `helm_chart_metadata` in tools/bazel/release.bzl, which reads each
+  // referenced app's `domain` attribute directly (via the AppMetadataInfo
+  // provider) rather than inferring it from the target's package path — see
+  // PLAN.md's AR-7a.
+  repeated string app_refs = 8;
 }
 
 // AppManifestSet is the full set of manifests discovered by a `bazel query`

--- a/tools/appmeta/proto_to_rule_test.go
+++ b/tools/appmeta/proto_to_rule_test.go
@@ -15,6 +15,10 @@ import (
 // Bazel builds it as a normal (cheap) dependency — no nested bazel needed.
 const fixtureMetadataPath = "testdata/fixture-app_metadata_metadata.json"
 
+// fixtureChartMetadataPath is the analogous full-coverage fixture for
+// ChartManifest — see TestChartFixtureLeavesNoFieldUnset.
+const fixtureChartMetadataPath = "testdata/fixture-helm_chart_metadata_chart_metadata.json"
+
 // TestFixtureLeavesNoFieldUnset is the proto -> rule direction of the
 // contract: //tools/appmeta/testdata sets every release_app attribute, so
 // decoding its emitted manifest must leave no AppManifest field unset. If a
@@ -29,6 +33,28 @@ func TestFixtureLeavesNoFieldUnset(t *testing.T) {
 	var manifest appmetapb.AppManifest
 	if err := (protojson.UnmarshalOptions{DiscardUnknown: false}).Unmarshal(data, &manifest); err != nil {
 		t.Fatalf("decode fixture metadata: %v", err)
+	}
+
+	assertNoFieldUnset(t, manifest.ProtoReflect())
+}
+
+// TestChartFixtureLeavesNoFieldUnset is TestFixtureLeavesNoFieldUnset's
+// counterpart for ChartManifest, added in AR-7a alongside the app_refs
+// field: //tools/appmeta/testdata's fixture-helm_chart_metadata sets every
+// helm_chart_metadata attribute (including composing an app, so `apps` and
+// `app_refs` are both non-empty), so decoding its emitted manifest must
+// leave no ChartManifest field unset -- catching a field added to
+// appmeta.proto that the rule never populates, same as the AppManifest
+// direction above.
+func TestChartFixtureLeavesNoFieldUnset(t *testing.T) {
+	data, err := os.ReadFile(fixtureChartMetadataPath)
+	if err != nil {
+		t.Fatalf("read fixture chart metadata: %v", err)
+	}
+
+	var manifest appmetapb.ChartManifest
+	if err := (protojson.UnmarshalOptions{DiscardUnknown: false}).Unmarshal(data, &manifest); err != nil {
+		t.Fatalf("decode fixture chart metadata: %v", err)
 	}
 
 	assertNoFieldUnset(t, manifest.ProtoReflect())

--- a/tools/appmeta/testdata/BUILD.bazel
+++ b/tools/appmeta/testdata/BUILD.bazel
@@ -22,7 +22,7 @@
 # or dereferences them — so a single placeholder filegroup stands in for all
 # three rather than a real binary or image.
 
-load("//tools/bazel:release.bzl", "app_metadata")
+load("//tools/bazel:release.bzl", "app_metadata", "helm_chart_metadata")
 
 filegroup(
     name = "placeholder-target",
@@ -31,32 +31,58 @@ filegroup(
 
 app_metadata(
     name = "fixture-app_metadata",
+    testonly = True,
     app_name = "fixture-app",
-    binary_target = ":placeholder-target",
-    image_target = ":placeholder-target",
-    openapi_spec_target = ":placeholder-target",
-    description = "Full-coverage fixture for the appmeta manifest contract test.",
-    version = "v1.2.3",
-    language = "python",
-    registry = "ghcr.io",
-    organization = "whale-net",
-    repo_name = "appmeta-fixture-app",
-    domain = "appmeta",
     app_type = "external-api",
-    port = 8080,
-    replicas = 3,
+    args = [
+        "-m",
+        "tools.appmeta.testdata.main",
+    ],
+    binary_target = ":placeholder-target",
+    command = ["python3"],
+    deploy_unit = "image",
+    description = "Full-coverage fixture for the appmeta manifest contract test.",
+    domain = "appmeta",
     health_check_enabled = True,
     health_check_path = "/healthz",
+    image_target = ":placeholder-target",
     ingress_host = "fixture.example.local",
     ingress_tls_secret = "fixture-tls",
-    command = ["python3"],
-    args = ["-m", "tools.appmeta.testdata.main"],
-    resources_requests_cpu = "100m",
-    resources_requests_memory = "128Mi",
+    language = "python",
+    openapi_spec_target = ":placeholder-target",
+    organization = "whale-net",
+    port = 8080,
+    registry = "ghcr.io",
+    replicas = 3,
+    repo_name = "appmeta-fixture-app",
     resources_limits_cpu = "200m",
     resources_limits_memory = "256Mi",
-    deploy_unit = "image",
-    testonly = True,
+    resources_requests_cpu = "100m",
+    resources_requests_memory = "128Mi",
     tags = ["release-metadata"],
+    version = "v1.2.3",
+    visibility = ["//visibility:public"],
+)
+
+# Full-coverage fixture for the same test's ChartManifest coverage
+# (TestChartFixtureLeavesNoFieldUnset, added in AR-7a alongside app_refs) --
+# calls the low-level `helm_chart_metadata` rule directly, same rationale as
+# fixture-app_metadata above: no real helm_chart/image target, and
+# testonly = True keeps it out of release discovery. Composes
+# fixture-app_metadata itself so app_refs is non-empty (a repeated field
+# with zero elements reads as "unset" to assertNoFieldUnset, same as any
+# other proto3 field) and, since fixture-app_metadata's domain is "appmeta",
+# proves app_refs is domain-qualified rather than copied bare.
+helm_chart_metadata(
+    name = "fixture-helm_chart_metadata",
+    testonly = True,
+    apps = [":fixture-app_metadata"],
+    chart_name = "fixture-chart",
+    chart_target = ":placeholder-target",
+    chart_version = "0.1.0",
+    domain = "appmeta",
+    environment = "production",
+    namespace = "appmeta",
+    tags = ["helm-release-metadata"],
     visibility = ["//visibility:public"],
 )

--- a/tools/bazel/release.bzl
+++ b/tools/bazel/release.bzl
@@ -323,6 +323,21 @@ HelmChartMetadataInfo = provider(
 
 def _helm_chart_metadata_impl(ctx):
     """Implementation for helm_chart_metadata rule."""
+
+    # app_refs is domain-qualified ("<domain>/<name>") per app, read from
+    # each app_metadata target's own AppMetadataInfo provider rather than
+    # inferred from the target's package path -- the path is not guaranteed
+    # to match the app's declared `domain` attr, and inferring it would
+    # reintroduce exactly the kind of guess this field exists to remove. See
+    # //tools/app_registry/PLAN.md's AR-7a and appmeta.proto's ChartManifest
+    # doc comment.
+    app_names = []
+    app_refs = []
+    for dep in ctx.attr.apps:
+        info = dep[AppMetadataInfo]
+        app_names.append(info.metadata["name"])
+        app_refs.append("{}/{}".format(info.metadata["domain"], info.metadata["name"]))
+
     # Create a JSON file with helm chart metadata
     metadata = {
         "name": ctx.attr.chart_name,
@@ -330,8 +345,13 @@ def _helm_chart_metadata_impl(ctx):
         "namespace": ctx.attr.namespace,
         "environment": ctx.attr.environment,
         "domain": ctx.attr.domain,
-        "apps": ctx.attr.app_names,  # List of app names this chart includes
+        # DEPRECATED bare names -- kept for one release cycle's backward
+        # compatibility. New consumers should read app_refs. See
+        # ChartManifest.apps's doc comment in appmeta.proto and PLAN.md's
+        # AR-7a.
+        "apps": app_names,
         "chart_target": ctx.attr.chart_target,  # The actual helm_chart target
+        "app_refs": app_refs,  # domain-qualified "<domain>/<name>" references
     }
 
     output = ctx.actions.declare_file(ctx.label.name + "_chart_metadata.json")
@@ -353,7 +373,11 @@ helm_chart_metadata = rule(
         "namespace": attr.string(mandatory = True),
         "environment": attr.string(default = "production"),
         "domain": attr.string(mandatory = True),
-        "app_names": attr.string_list(mandatory = True),
+        # app_metadata targets composed into this chart -- a label_list (not
+        # attr.string_list) so the rule can read each app's real `domain`
+        # attribute off AppMetadataInfo at analysis time instead of parsing
+        # it out of a target label. See AR-7a.
+        "apps": attr.label_list(mandatory = True, providers = [AppMetadataInfo]),
         "chart_target": attr.string(mandatory = True),
     },
 )
@@ -434,20 +458,11 @@ def release_helm_chart(
         **kwargs
     )
     
-    # Extract app names from app_metadata targets
-    # Target format: "//demo/hello_python:hello-python_metadata"
-    app_names = []
-    for app_target in apps:
-        # Extract the app name from the target
-        # Split on : to get the target name, then remove _metadata suffix
-        target_parts = app_target.split(":")
-        if len(target_parts) == 2:
-            target_name = target_parts[1]
-            if target_name.endswith("_metadata"):
-                app_name = target_name[:-9]  # Remove "_metadata"
-                app_names.append(app_name)
-    
-    # Create release metadata for the chart
+    # Create release metadata for the chart. `apps` is passed straight
+    # through as the label list of app_metadata targets -- helm_chart_metadata
+    # reads each app's real `domain` attr off its AppMetadataInfo provider to
+    # emit domain-qualified app_refs, rather than this macro guessing the
+    # domain from the target's package path. See AR-7a.
     helm_chart_metadata(
         name = name + "_chart_metadata",
         chart_name = actual_chart_name,
@@ -455,7 +470,7 @@ def release_helm_chart(
         namespace = namespace,
         environment = environment,
         domain = domain,
-        app_names = app_names,
+        apps = apps,
         chart_target = ":" + name,
         tags = ["helm-release-metadata", "manual", "no_test"],
         visibility = ["//visibility:public"],


### PR DESCRIPTION
Implements **AR-7a — Sweep robustness** from `tools/app_registry/PLAN.md`. Design merged in #559 (docs only); this is the code. Bottom of a 2-PR stack — #562 (AR-7b) sits on top.

Fixes ordering 4 of the four cross-run orderings in ARCHITECTURE.md's "Release lifecycle (issue #558)": one bad chart manifest currently rolls back the *entire* reconcile transaction, so the watermark never advances and no app registers at all — while the CI job stays green because the step is `continue-on-error`.

## What changed

**`ReconcileApps` is partially applying.** A chart whose app references don't resolve is skipped and reported; every other app and chart still applies and the watermark still advances. New `ReconcileAppsResponse.unresolved_charts` (`UnresolvedChart{domain, name, app_refs, reason}`), threaded through the repository interface, the postgres implementation, the in-memory fake, and the handler.

Two deliberate distinctions in that path:

- Only a *chart resolution* failure downgrades to a per-chart skip (a typed `chartResolutionError`). A genuine infrastructure error — a failed query — still aborts the whole `Reconcile`, unchanged from before.
- A skipped chart that already exists is added to `presentChartIDs`, so the absence sweep does **not** mark it `MISSING`. A chart present in the manifest set but unresolvable is present, not absent.

**Domain-qualified app references in chart manifests.** `resolveChartApps` fell back to `SELECT app_id FROM app WHERE name = $1` and failed on more than one match, so an app name colliding across two domains broke the sweep. New `ChartManifest.app_refs` (`"<domain>/<name>"`), emitted by `helm_chart_metadata`.

This changed the rule's shape: `app_names` (`attr.string_list`) became `apps` (`attr.label_list`), so the rule reads each app's real `domain` off its `AppMetadataInfo` provider instead of the macro string-munging names out of target labels. The old path inferred identity from label text, which is exactly the guessing qualified refs exist to remove. All in-repo callers go through the `release_helm_chart` macro, which now passes `apps` straight through.

Bare-name resolution stays as an explicitly deprecated compatibility path for one release cycle, commented with a pointer to AR-7a so the deletion is findable.

**`ci.yml`'s `reconcile-app-registry` job drops `continue-on-error`.** Any error reds the job. The opt-in gate and timeout are unchanged. Accepted consequence, per ARCHITECTURE.md "Availability, restated per adoption stage": once the opt-in is on, a registry outage turns `main` CI red, and `APP_REGISTRY_CICD_OPT_IN=false` is the lever.

## Tests

Handler and fake unit tests for the partial apply, one existing test rewritten for the new semantics, a new `TestChartFixtureLeavesNoFieldUnset` contract test with a `helm_chart_metadata` fixture, and three Postgres integration tests covering the plan's exit criteria: partial apply against a real transaction, a skipped chart not being marked `MISSING`, and domain-qualified refs resolving unambiguously.

Each new behavior was verified by deliberately breaking it, confirming the guarding test failed, then reverting.

## Verification status

`bazel build //tools/...` and `bazel test //tools/...` are green, and the Docker-backed `postgres_integration_test` passes on the rebased stack tip (83.9s, real Postgres via `libs/go/dbtest`). CI's `Test Database Integration` job runs the same target.

Ref: #558, #559
