### PR TITLE
feat(app-registry): AR-7b artifact lifecycle states (issue #558)

### DIFF
--- a/.github/actions/app-registry-begin-publish/action.yml
+++ b/.github/actions/app-registry-begin-publish/action.yml
@@ -1,0 +1,78 @@
+name: 'App Registry: Begin Publish'
+description: >-
+  Transitions an artifact to "publishing" via `app-registry artifacts
+  begin-publish`, immediately before the image/chart it names is pushed --
+  AR-7b (issue #558), see tools/app_registry/ARCHITECTURE.md "Artifact
+  lifecycle: allocated -> publishing -> published". ∅|allocated|failed ->
+  publishing: works whether or not a prior AllocateVersion call reserved
+  this version (it does not, at every domain today -- see PLAN.md's AR-5a
+  status), which is what lets this step run unconditionally ahead of every
+  push regardless of a domain's adoption stage.
+
+  Requires APP_REGISTRY_CLI env var already set (see
+  .github/actions/download-release-tools).
+
+  Best-effort by default: like app-registry-record-build/-image, this step
+  still fails its own exit status on error (matching the calling step's
+  `continue-on-error: true`), so a caller can branch on
+  `steps.<id>.outcome` to decide whether to attempt FailPublish later.
+
+inputs:
+  address:
+    required: true
+  token-url:
+    required: true
+  client-id:
+    required: true
+  client-secret:
+    required: true
+  kind:
+    description: 'image | chart'
+    required: true
+  owner-full-name:
+    description: '<domain>-<name>, e.g. manmanv2-host-manager'
+    required: true
+  version:
+    description: 'Semver tag, e.g. v1.2.3'
+    required: true
+  build-id:
+    required: true
+  idempotency-key:
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - uses: ./.github/actions/app-registry-auth
+      with:
+        address: ${{ inputs.address }}
+        token-url: ${{ inputs.token-url }}
+        client-id: ${{ inputs.client-id }}
+        client-secret: ${{ inputs.client-secret }}
+
+    - name: Begin publish
+      shell: bash
+      env:
+        KIND: ${{ inputs.kind }}
+        OWNER: ${{ inputs.owner-full-name }}
+        VERSION: ${{ inputs.version }}
+        BUILD_ID: ${{ inputs.build-id }}
+        IDEMPOTENCY_KEY: ${{ inputs.idempotency-key }}
+      run: |
+        set +e
+        BEGIN_OUTPUT=$("$APP_REGISTRY_CLI" artifacts begin-publish \
+          --kind "$KIND" \
+          --owner "$OWNER" \
+          --version "$VERSION" \
+          --build-id "$BUILD_ID" \
+          --idempotency-key "$IDEMPOTENCY_KEY" 2>&1)
+        BEGIN_EXIT=$?
+        set -e
+
+        if [[ $BEGIN_EXIT -ne 0 ]]; then
+          echo "$BEGIN_OUTPUT"
+          echo "::warning title=App Registry: begin-publish skipped (registry error)::Could not transition ${OWNER} ${VERSION} to 'publishing' in the App Registry -- a registry outage, auth failure, or other transient error. Recording is best-effort; the push still proceeds."
+          exit 1
+        fi
+
+        echo "✅ ${OWNER} ${VERSION} is now 'publishing' in App Registry"

--- a/.github/actions/app-registry-fail-publish/action.yml
+++ b/.github/actions/app-registry-fail-publish/action.yml
@@ -1,0 +1,80 @@
+name: 'App Registry: Fail Publish'
+description: >-
+  Transitions an artifact from "publishing" to "failed" via `app-registry
+  artifacts fail-publish` -- AR-7b (issue #558), called from a release
+  job's error path (`if: failure()`) immediately after the corresponding
+  app-registry-begin-publish step for the same target. See
+  tools/app_registry/ARCHITECTURE.md "Artifact lifecycle: allocated ->
+  publishing -> published".
+
+  Requires APP_REGISTRY_CLI env var already set (see
+  .github/actions/download-release-tools).
+
+  Best-effort: still fails its own exit status on error (matching the
+  calling step's `continue-on-error: true`) -- a failed FailPublish call
+  just means the row is left in 'publishing' until the reaper
+  (ARTIFACT_REAPER_TIMEOUT, see ENV.md) expires it to 'failed' with reason
+  "stale" instead of the caller-supplied reason. Never fails the release
+  job itself; the release already failed for its own reason by the time
+  this step runs.
+
+inputs:
+  address:
+    required: true
+  token-url:
+    required: true
+  client-id:
+    required: true
+  client-secret:
+    required: true
+  kind:
+    description: 'image | chart'
+    required: true
+  owner-full-name:
+    description: '<domain>-<name>, e.g. manmanv2-host-manager'
+    required: true
+  version:
+    description: 'Semver tag, e.g. v1.2.3'
+    required: true
+  reason:
+    description: 'Why the publish failed, for operator diagnosis'
+    required: true
+  idempotency-key:
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - uses: ./.github/actions/app-registry-auth
+      with:
+        address: ${{ inputs.address }}
+        token-url: ${{ inputs.token-url }}
+        client-id: ${{ inputs.client-id }}
+        client-secret: ${{ inputs.client-secret }}
+
+    - name: Fail publish
+      shell: bash
+      env:
+        KIND: ${{ inputs.kind }}
+        OWNER: ${{ inputs.owner-full-name }}
+        VERSION: ${{ inputs.version }}
+        REASON: ${{ inputs.reason }}
+        IDEMPOTENCY_KEY: ${{ inputs.idempotency-key }}
+      run: |
+        set +e
+        FAIL_OUTPUT=$("$APP_REGISTRY_CLI" artifacts fail-publish \
+          --kind "$KIND" \
+          --owner "$OWNER" \
+          --version "$VERSION" \
+          --reason "$REASON" \
+          --idempotency-key "$IDEMPOTENCY_KEY" 2>&1)
+        FAIL_EXIT=$?
+        set -e
+
+        if [[ $FAIL_EXIT -ne 0 ]]; then
+          echo "$FAIL_OUTPUT"
+          echo "::warning title=App Registry: fail-publish skipped (registry error)::Could not transition ${OWNER} ${VERSION} to 'failed' in the App Registry -- it will sit as 'publishing' until the stale-row reaper expires it (see ENV.md's ARTIFACT_REAPER_TIMEOUT)."
+          exit 1
+        fi
+
+        echo "⚠️ ${OWNER} ${VERSION} marked 'failed' in App Registry (${REASON})"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -386,53 +386,6 @@ jobs:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GHCR_PAT || secrets.GITHUB_TOKEN }}
-        
-    - name: Build and release app using multiarch release
-      env:
-        APP: ${{ matrix.app }}
-        DOMAIN: ${{ matrix.domain }}
-        VERSION: ${{ matrix.version || needs.plan-release.outputs.version }}
-        DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
-        GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
-      run: |
-        # Use full domain-app format to avoid ambiguity
-        FULL_APP_NAME="${DOMAIN}-${APP}"
-        echo "Building and releasing $FULL_APP_NAME version $VERSION using multiarch release system"
-
-        # $RELEASE_HELPER comes from the "Download release tools" step (built
-        # once by build-release-tools, not per matrix leg). Executed directly,
-        # not via 'bazel run', to avoid nested-Bazel-invocation deadlocks --
-        # release-multiarch itself shells out to Bazel to build the images.
-
-        # Use release-multiarch with full domain-app name to ensure correct artifact is released
-        if [[ "$DRY_RUN" == "true" ]]; then
-          echo "DRY RUN: Building multiarch images without publishing"
-          "$RELEASE_HELPER" release-multiarch "$FULL_APP_NAME" --version "$VERSION" --commit "${{ github.sha }}" --dry-run
-        else
-          echo "Building and publishing multiarch images for $FULL_APP_NAME $VERSION"
-          "$RELEASE_HELPER" release-multiarch "$FULL_APP_NAME" --version "$VERSION" --commit "${{ github.sha }}"
-          echo "Successfully released multiarch $FULL_APP_NAME $VERSION"
-        fi
-        
-    - name: Create git tag for release
-      if: ${{ github.event.inputs.dry_run == 'false' }}
-      env:
-        APP: ${{ matrix.app }}
-        DOMAIN: ${{ matrix.domain }}
-        VERSION: ${{ matrix.version || needs.plan-release.outputs.version }}
-      run: |
-        # Use domain from matrix (avoids ambiguity when apps share names across domains)
-        TAG_NAME="${DOMAIN}-${APP}.${VERSION}"
-        
-        # Check if tag already exists
-        if git rev-parse "$TAG_NAME" >/dev/null 2>&1; then
-          echo "ℹ️  Tag $TAG_NAME already exists, skipping creation"
-        else
-          echo "Creating git tag: $TAG_NAME"
-          git tag -a "$TAG_NAME" -m "Release ${DOMAIN}-${APP} version $VERSION" "${{ github.sha }}"
-          git push origin "$TAG_NAME"
-          echo "✅ Created and pushed git tag: $TAG_NAME"
-        fi
 
     # Best-effort recording into the App Registry. See
     # tools/app_registry/ARCHITECTURE.md -> "APP_REGISTRY_CICD_OPT_IN": with
@@ -448,6 +401,12 @@ jobs:
     # operator does when that happens. The recording actions below classify
     # that specific failure into its own annotation instead of a generic
     # registry-error one.
+    #
+    # AR-7b (issue #558): this step and "Begin publish" below MOVED ahead of
+    # the actual image push -- the artifact lifecycle
+    # (ARCHITECTURE.md "Artifact lifecycle: allocated -> publishing ->
+    # published") needs a build_id and a 'publishing' row to exist BEFORE
+    # anything is pushed, not after.
     - name: Record build in App Registry
       if: ${{ github.event.inputs.dry_run == 'false' && vars.APP_REGISTRY_CICD_OPT_IN == 'true' }}
       id: app-registry-build
@@ -482,6 +441,97 @@ jobs:
         workflow-attempt: ${{ github.run_attempt }}
         actor: ${{ github.actor }}
         idempotency-key: ${{ github.run_id }}-${{ github.run_attempt }}
+
+    # AR-7b (issue #558): allocated|failed|∅ -> publishing, immediately
+    # before the push below. Works with no prior AllocateVersion call (no
+    # domain is at adoption stage "allocate" today -- see PLAN.md's AR-5a
+    # status), which is why this runs unconditionally rather than only for
+    # allocate-stage domains.
+    - name: Begin publish (image) in App Registry
+      if: ${{ github.event.inputs.dry_run == 'false' && vars.APP_REGISTRY_CICD_OPT_IN == 'true' && steps.app-registry-build.outputs.build-id != '' }}
+      id: app-registry-begin-publish
+      continue-on-error: true
+      timeout-minutes: 5
+      uses: ./.github/actions/app-registry-begin-publish
+      with:
+        address: ${{ vars.APP_REGISTRY_ADDRESS }}
+        token-url: ${{ vars.APP_REGISTRY_AUTH_TOKEN_URL }}
+        client-id: app-registry-builder-${{ vars.APP_REGISTRY_BUILDER_ENV || 'dev' }}
+        client-secret: ${{ secrets.APP_REGISTRY_BUILDER_CLIENT_SECRET }}
+        kind: image
+        owner-full-name: ${{ matrix.domain }}-${{ matrix.app }}
+        version: ${{ matrix.version || needs.plan-release.outputs.version }}
+        build-id: ${{ steps.app-registry-build.outputs.build-id }}
+        idempotency-key: ${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.domain }}-${{ matrix.app }}-image
+
+    - name: Build and release app using multiarch release
+      env:
+        APP: ${{ matrix.app }}
+        DOMAIN: ${{ matrix.domain }}
+        VERSION: ${{ matrix.version || needs.plan-release.outputs.version }}
+        DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+        GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
+      run: |
+        # Use full domain-app format to avoid ambiguity
+        FULL_APP_NAME="${DOMAIN}-${APP}"
+        echo "Building and releasing $FULL_APP_NAME version $VERSION using multiarch release system"
+
+        # $RELEASE_HELPER comes from the "Download release tools" step (built
+        # once by build-release-tools, not per matrix leg). Executed directly,
+        # not via 'bazel run', to avoid nested-Bazel-invocation deadlocks --
+        # release-multiarch itself shells out to Bazel to build the images.
+
+        # Use release-multiarch with full domain-app name to ensure correct artifact is released
+        if [[ "$DRY_RUN" == "true" ]]; then
+          echo "DRY RUN: Building multiarch images without publishing"
+          "$RELEASE_HELPER" release-multiarch "$FULL_APP_NAME" --version "$VERSION" --commit "${{ github.sha }}" --dry-run
+        else
+          echo "Building and publishing multiarch images for $FULL_APP_NAME $VERSION"
+          "$RELEASE_HELPER" release-multiarch "$FULL_APP_NAME" --version "$VERSION" --commit "${{ github.sha }}"
+          echo "Successfully released multiarch $FULL_APP_NAME $VERSION"
+        fi
+
+    # AR-7b (issue #558): publishing -> failed on the error path, so the
+    # row doesn't sit as "publishing" until the reaper times it out. Only
+    # attempted if Begin publish actually succeeded (steps.*.outcome
+    # reflects the raw pass/fail, unaffected by continue-on-error) -- a
+    # push failure after a skipped/failed Begin publish has no 'publishing'
+    # row to fail.
+    - name: Fail publish (image) in App Registry
+      if: ${{ failure() && github.event.inputs.dry_run == 'false' && vars.APP_REGISTRY_CICD_OPT_IN == 'true' && steps.app-registry-begin-publish.outcome == 'success' }}
+      continue-on-error: true
+      timeout-minutes: 5
+      uses: ./.github/actions/app-registry-fail-publish
+      with:
+        address: ${{ vars.APP_REGISTRY_ADDRESS }}
+        token-url: ${{ vars.APP_REGISTRY_AUTH_TOKEN_URL }}
+        client-id: app-registry-builder-${{ vars.APP_REGISTRY_BUILDER_ENV || 'dev' }}
+        client-secret: ${{ secrets.APP_REGISTRY_BUILDER_CLIENT_SECRET }}
+        kind: image
+        owner-full-name: ${{ matrix.domain }}-${{ matrix.app }}
+        version: ${{ matrix.version || needs.plan-release.outputs.version }}
+        reason: 'image push failed (workflow run ${{ github.run_id }}, attempt ${{ github.run_attempt }})'
+        idempotency-key: ${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.domain }}-${{ matrix.app }}-image-fail
+
+    - name: Create git tag for release
+      if: ${{ github.event.inputs.dry_run == 'false' }}
+      env:
+        APP: ${{ matrix.app }}
+        DOMAIN: ${{ matrix.domain }}
+        VERSION: ${{ matrix.version || needs.plan-release.outputs.version }}
+      run: |
+        # Use domain from matrix (avoids ambiguity when apps share names across domains)
+        TAG_NAME="${DOMAIN}-${APP}.${VERSION}"
+
+        # Check if tag already exists
+        if git rev-parse "$TAG_NAME" >/dev/null 2>&1; then
+          echo "ℹ️  Tag $TAG_NAME already exists, skipping creation"
+        else
+          echo "Creating git tag: $TAG_NAME"
+          git tag -a "$TAG_NAME" -m "Release ${DOMAIN}-${APP} version $VERSION" "${{ github.sha }}"
+          git push origin "$TAG_NAME"
+          echo "✅ Created and pushed git tag: $TAG_NAME"
+        fi
 
     - name: Record image artifact in App Registry
       if: ${{ github.event.inputs.dry_run == 'false' && vars.APP_REGISTRY_CICD_OPT_IN == 'true' && steps.app-registry-build.outputs.build-id != '' }}
@@ -862,13 +912,91 @@ jobs:
         # List generated charts with versions
         echo "Generated versioned charts:"
         ls -lh /tmp/helm-charts/
-        
+
+    # AR-7b (issue #558): Record chart build + Begin publish MOVED ahead of
+    # the actual ChartMuseum push below -- see the image release job's
+    # matching comment. Best-effort, same APP_REGISTRY_CICD_OPT_IN /
+    # continue-on-error posture as every other App Registry step in this
+    # workflow.
+    - name: Record chart build in App Registry
+      if: steps.plan.outputs.charts != '' && github.event.inputs.dry_run == 'false' && vars.APP_REGISTRY_CICD_OPT_IN == 'true'
+      id: app-registry-build
+      continue-on-error: true
+      timeout-minutes: 5
+      uses: ./.github/actions/app-registry-record-build
+      with:
+        address: ${{ vars.APP_REGISTRY_ADDRESS }}
+        token-url: ${{ vars.APP_REGISTRY_AUTH_TOKEN_URL }}
+        client-id: app-registry-builder-${{ vars.APP_REGISTRY_BUILDER_ENV || 'dev' }}
+        client-secret: ${{ secrets.APP_REGISTRY_BUILDER_CLIENT_SECRET }}
+        git-sha: ${{ github.sha }}
+        git-ref: ${{ github.ref }}
+        workflow-run-id: ${{ github.run_id }}
+        workflow-attempt: ${{ github.run_attempt }}
+        actor: ${{ github.actor }}
+        idempotency-key: ${{ github.run_id }}-${{ github.run_attempt }}
+
+    # AR-7b: ∅|allocated|failed -> publishing, one call per chart, before
+    # ANY chart in this batch is pushed -- "Publish charts to ChartMuseum"
+    # below uploads every chart in one step, so this necessarily runs at
+    # batch granularity too (coarser than the image job's one-app-per-leg
+    # BeginPublish, which the matrix already gives for free).
+    - name: Begin publish (charts) in App Registry
+      if: steps.plan.outputs.charts != '' && github.event.inputs.dry_run == 'false' && vars.APP_REGISTRY_CICD_OPT_IN == 'true' && steps.app-registry-build.outputs.build-id != ''
+      id: app-registry-begin-publish
+      continue-on-error: true
+      timeout-minutes: 10
+      env:
+        CHARTS: ${{ steps.plan.outputs.charts }}
+        APP_REGISTRY_ADDRESS: ${{ vars.APP_REGISTRY_ADDRESS }}
+        GRPC_AUTH_MODE: oidc
+        GRPC_AUTH_TOKEN_URL: ${{ vars.APP_REGISTRY_AUTH_TOKEN_URL }}
+        GRPC_AUTH_CLIENT_ID: app-registry-builder-${{ vars.APP_REGISTRY_BUILDER_ENV || 'dev' }}
+        GRPC_AUTH_CLIENT_SECRET: ${{ secrets.APP_REGISTRY_BUILDER_CLIENT_SECRET }}
+        BUILD_ID: ${{ steps.app-registry-build.outputs.build-id }}
+      run: |
+        IDEMPOTENCY_PREFIX="${{ github.run_id }}-${{ github.run_attempt }}"
+        BEGIN_HAD_FAILURE=0
+
+        IFS=' ' read -ra CHART_ARRAY <<< "$CHARTS"
+        for CHART in "${CHART_ARRAY[@]}"; do
+          PUBLISHED_NAME="${CHART#helm-}"
+          CHART_FILE=$(ls /tmp/helm-charts/${PUBLISHED_NAME}-*.tgz 2>/dev/null | head -n1)
+          if [[ ! -f "$CHART_FILE" ]]; then
+            echo "::warning::Could not find chart file for $CHART, skipping App Registry begin-publish"
+            continue
+          fi
+          CHART_VERSION=$(basename "$CHART_FILE" | sed -E "s/${PUBLISHED_NAME}-(.+)\.tgz/\1/")
+
+          set +e
+          BEGIN_OUTPUT=$("$APP_REGISTRY_CLI" artifacts begin-publish \
+            --kind chart \
+            --owner "$PUBLISHED_NAME" \
+            --version "$CHART_VERSION" \
+            --build-id "$BUILD_ID" \
+            --idempotency-key "${IDEMPOTENCY_PREFIX}-${PUBLISHED_NAME}-chart" 2>&1)
+          BEGIN_EXIT=$?
+          set -e
+
+          if [[ $BEGIN_EXIT -eq 0 ]]; then
+            echo "✅ ${PUBLISHED_NAME} ${CHART_VERSION} is now 'publishing' in App Registry"
+          else
+            echo "$BEGIN_OUTPUT"
+            echo "::warning title=App Registry: begin-publish skipped (registry error)::Could not transition ${PUBLISHED_NAME} ${CHART_VERSION} to 'publishing'."
+            BEGIN_HAD_FAILURE=1
+          fi
+        done
+
+        if [[ "$BEGIN_HAD_FAILURE" -eq 1 ]]; then
+          exit 1
+        fi
+
     - name: Configure Git for tagging
       if: steps.plan.outputs.charts != '' && github.event.inputs.dry_run == 'false'
       run: |
         git config --global user.name "${{ github.actor }}"
         git config --global user.email "${{ github.actor }}@users.noreply.github.com"
-        
+
     - name: Create and push helm chart tags
       if: steps.plan.outputs.charts != '' && github.event.inputs.dry_run == 'false'
       env:
@@ -965,6 +1093,53 @@ jobs:
         
         echo "✅ All charts published successfully"
 
+    # AR-7b (issue #558): publishing -> failed for every chart this batch
+    # began publishing, on the ChartMuseum push's error path -- mirrors the
+    # image job's "Fail publish" step, at the same batch granularity Begin
+    # publish above used. steps.*.outcome is unaffected by
+    # continue-on-error, so this only runs at all when Begin publish (charts)
+    # actually ran and produced 'publishing' rows to fail.
+    - name: Fail publish (charts) in App Registry
+      if: ${{ failure() && steps.plan.outputs.charts != '' && github.event.inputs.dry_run == 'false' && vars.APP_REGISTRY_CICD_OPT_IN == 'true' && steps.app-registry-begin-publish.outcome == 'success' }}
+      continue-on-error: true
+      timeout-minutes: 10
+      env:
+        CHARTS: ${{ steps.plan.outputs.charts }}
+        APP_REGISTRY_ADDRESS: ${{ vars.APP_REGISTRY_ADDRESS }}
+        GRPC_AUTH_MODE: oidc
+        GRPC_AUTH_TOKEN_URL: ${{ vars.APP_REGISTRY_AUTH_TOKEN_URL }}
+        GRPC_AUTH_CLIENT_ID: app-registry-builder-${{ vars.APP_REGISTRY_BUILDER_ENV || 'dev' }}
+        GRPC_AUTH_CLIENT_SECRET: ${{ secrets.APP_REGISTRY_BUILDER_CLIENT_SECRET }}
+      run: |
+        IDEMPOTENCY_PREFIX="${{ github.run_id }}-${{ github.run_attempt }}"
+
+        IFS=' ' read -ra CHART_ARRAY <<< "$CHARTS"
+        for CHART in "${CHART_ARRAY[@]}"; do
+          PUBLISHED_NAME="${CHART#helm-}"
+          CHART_FILE=$(ls /tmp/helm-charts/${PUBLISHED_NAME}-*.tgz 2>/dev/null | head -n1)
+          if [[ ! -f "$CHART_FILE" ]]; then
+            continue
+          fi
+          CHART_VERSION=$(basename "$CHART_FILE" | sed -E "s/${PUBLISHED_NAME}-(.+)\.tgz/\1/")
+
+          set +e
+          FAIL_OUTPUT=$("$APP_REGISTRY_CLI" artifacts fail-publish \
+            --kind chart \
+            --owner "$PUBLISHED_NAME" \
+            --version "$CHART_VERSION" \
+            --reason "chart push failed (workflow run ${{ github.run_id }}, attempt ${{ github.run_attempt }})" \
+            --idempotency-key "${IDEMPOTENCY_PREFIX}-${PUBLISHED_NAME}-chart-fail" 2>&1)
+          FAIL_EXIT=$?
+          set -e
+
+          if [[ $FAIL_EXIT -eq 0 ]]; then
+            echo "⚠️ ${PUBLISHED_NAME} ${CHART_VERSION} marked 'failed' in App Registry"
+          else
+            echo "$FAIL_OUTPUT"
+            echo "::warning title=App Registry: fail-publish skipped (registry error)::Could not transition ${PUBLISHED_NAME} ${CHART_VERSION} to 'failed'; it will sit as 'publishing' until the stale-row reaper expires it."
+          fi
+        done
+
     # Best-effort recording into the App Registry. See
     # tools/app_registry/ARCHITECTURE.md -> "APP_REGISTRY_CICD_OPT_IN": with
     # the variable unset (the default), this step is skipped entirely and CI
@@ -983,29 +1158,10 @@ jobs:
     # the chart have been pushed — see ARCHITECTURE.md "Chart -> image
     # lockfile" for why that resolution can't happen inside the hermetic
     # Bazel action that composes the chart.
-    - name: Record chart build in App Registry
-      if: steps.plan.outputs.charts != '' && github.event.inputs.dry_run == 'false' && vars.APP_REGISTRY_CICD_OPT_IN == 'true'
-      id: app-registry-build
-      continue-on-error: true
-      # See the "Record build in App Registry" step above -- same hang risk
-      # (issue #539), same fix.
-      timeout-minutes: 5
-      uses: ./.github/actions/app-registry-record-build
-      with:
-        address: ${{ vars.APP_REGISTRY_ADDRESS }}
-        # See the "Record build in App Registry" step above -- same builder
-        # credential, same repository-secret placement, same reason
-        # (DEPLOY.md section 4), same env-scoped client id.
-        token-url: ${{ vars.APP_REGISTRY_AUTH_TOKEN_URL }}
-        client-id: app-registry-builder-${{ vars.APP_REGISTRY_BUILDER_ENV || 'dev' }}
-        client-secret: ${{ secrets.APP_REGISTRY_BUILDER_CLIENT_SECRET }}
-        git-sha: ${{ github.sha }}
-        git-ref: ${{ github.ref }}
-        workflow-run-id: ${{ github.run_id }}
-        workflow-attempt: ${{ github.run_attempt }}
-        actor: ${{ github.actor }}
-        idempotency-key: ${{ github.run_id }}-${{ github.run_attempt }}
-
+    #
+    # AR-7b: build-id comes from the "Record chart build in App Registry"
+    # step ABOVE (moved ahead of the push, alongside Begin publish) -- this
+    # step's own former build-recording call was removed, not duplicated.
     - name: Record chart artifacts in App Registry
       if: steps.plan.outputs.charts != '' && github.event.inputs.dry_run == 'false' && vars.APP_REGISTRY_CICD_OPT_IN == 'true' && steps.app-registry-build.outputs.build-id != ''
       continue-on-error: true

--- a/tools/app_registry/ARCHITECTURE.md
+++ b/tools/app_registry/ARCHITECTURE.md
@@ -386,15 +386,20 @@ tradeoff above, not a separate gap to close.
 
 ## Release lifecycle (issue #558)
 
-**Status: AR-7a built (merged); AR-7b … AR-7e designed, not built.** Delivery
-is PLAN.md's AR-7 (AR-7a … AR-7e). AR-7a's slice of this section — ordering
-4, partial-apply reconcile, domain-qualified chart app references, and the
-`continue-on-error` drop on `ci.yml`'s sweep job — describes what is actually
-deployed; everything else here (the artifact lifecycle, the app identity /
-manifest-snapshot split, `AssertApps`, the run log) is still proposed, not
-built. It supersedes "Release-vs-reconcile gap (issue #547)" above, and
-changes what "Availability and bootstrap" below promises — both are
-cross-referenced where that happens.
+**Status: AR-7a and AR-7b built (not yet merged); AR-7c … AR-7f designed,
+not built.** Delivery is PLAN.md's AR-7. Two slices of this section describe
+real code: AR-7a's — ordering 4, partial-apply reconcile, domain-qualified
+chart app references, and the `continue-on-error` drop on `ci.yml`'s sweep
+job — and AR-7b's — the artifact lifecycle
+(`allocated → publishing → published → failed`), migration `007`,
+`BeginPublish`/`FailPublish`, `RecordArtifact`'s `publishing → published`
+transition, and the stale-row reaper. Everything else here (the app identity
+/ manifest-snapshot split, `AssertApps`, the run log, `AdoptArtifact`,
+compose-time chart hermeticity) is still proposed: every table, column and
+RPC named in those subsections is unbuilt. This section supersedes
+"Release-vs-reconcile gap (issue #547)" above for the artifact lifecycle
+specifically, and changes what "Availability and bootstrap" below promises —
+both are cross-referenced where that happens.
 
 ### The problem: four cross-run orderings, three of them unenforced
 
@@ -501,6 +506,21 @@ existing row keeps working, creating the row directly in `published` —
 allowed while a domain is at adoption stage `observe`, rejected at
 `allocate` (where allocation must have happened first). That is what lets CI
 adopt `BeginPublish` per domain instead of in one cutover.
+
+**As built (AR-7b).** Everything above is real: migration `007` ships
+exactly this shape, plus an `artifact.fail_reason TEXT` column (not
+originally named in this design) so `FailPublish`'s caller-supplied reason
+and the reaper's hardcoded `"stale"` are both recorded, not just implied by
+the state transition. One decision this section left implicit and the
+implementation had to make explicit: the direct-create fallback is legal
+**only** at `observe`, not at `promote` too — `promote`'s own row in
+"Availability, restated per adoption stage" below already makes recording
+mandatory there, so a domain at `promote` with no prior `publishing` row
+means `BeginPublish` itself failed (or was skipped), and that must surface
+as a rejection, not a silent fallback to the old behavior. The reaper
+(`worker/reaper`) is a third loop in `app-registry-worker`, alongside the
+outbox drainer, configured via `ENV.md`'s `ARTIFACT_REAPER_TIMEOUT` /
+`ARTIFACT_REAPER_POLL_INTERVAL` — see `worker/README.md`.
 
 ### App identity vs. per-build manifest snapshot
 
@@ -643,6 +663,26 @@ Declaring the set in a separate `build_target` table was considered and
 rejected: the `allocated` state already is the declaration, and a second table
 would restate it in a shape that can disagree with what the run actually did.
 
+**As built (AR-7b), the intent-set write is narrower than "before anything
+is pushed" describes.** No third RPC exists to declare intent independently
+of `BeginPublish` (the phase's scope named exactly two new RPCs,
+`BeginPublish`/`FailPublish`), and `AllocateVersion`'s per-domain gate
+(this document's "Version model" section) structurally cannot serve `observe`/
+`promote` domains — it would misattribute `version_source` to `registry` for
+a version the tag path actually chose. So AR-7b implements the intent write
+as `BeginPublish` called as the **first step of each matrix leg**, strictly
+before that leg's own push, rather than from the plan job before the whole
+matrix fans out. This is `allocated|∅ → publishing` directly, not a separate
+`∅ → allocated` row for `observe`/`promote` domains — the `allocated` state
+in that case is authored by `AllocateVersion` only at `allocate` stage, per
+the table above. The gap this leaves: a matrix leg that never starts at all
+(the job itself failed to schedule) has no row of any kind, so "is this run
+complete?" cannot distinguish that from "not part of this run" for such a
+leg. Closing that gap needs either a new RPC or loosening
+`AllocateVersion`'s stage gate, and is deliberately left to AR-7d, which
+owns `GetReleaseRun`/resume semantics — see PLAN.md's AR-7b "Deliberately
+NOT done".
+
 ### Availability, restated per adoption stage
 
 "The registry can be down for hours without blocking a release" and "the
@@ -723,7 +763,13 @@ What AR-7 does to each of AR-5's remaining items:
 
 The one ordering rule: **do not move any domain to `allocate` before AR-7b
 lands.** Everything else in AR-7 can be built, merged, and run while every
-domain sits at `observe`.
+domain sits at `observe`. **AR-7b has landed** (migration `007`,
+`AllocateVersion` writing `artifact` rows directly, `BeginPublish`/
+`FailPublish`, the reaper) — this rule is satisfied, and a domain may now be
+moved to `allocate` as far as AR-7 is concerned. No domain has been, as of
+this writing; that cutover is a separate, explicit operational action (see
+"Per-domain cutover gate" in the Version model section above), not part of
+this change.
 
 ### Rejected alternatives (issue #558)
 

--- a/tools/app_registry/ENV.md
+++ b/tools/app_registry/ENV.md
@@ -138,6 +138,19 @@ needs `PG_DATABASE_URL` to drain the outbox and `TEMPORAL_HOST` to run
 | `WRITEBACK_CLAIM_STALE_AFTER` | `2m` | How long a `'claimed'` outbox row is left alone before a later pass reclaims it — must exceed `WritebackWorkflow`'s activity `StartToCloseTimeout` (30s) comfortably, or a still-healthy claim gets needlessly reclaimed. This is the knob that makes "worker killed mid-run" recoverable — see `worker/README.md`'s verification section. |
 | `WORKER_ID` | `app-registry-worker-<hostname>` | Recorded in `writeback_outbox.claimed_by`, for operator visibility into which process holds a claim. |
 
+### Artifact reaper (AR-7b, issue #558)
+
+The stale-row reaper (`worker/reaper`) runs as a third loop in the same
+`app-registry-worker` process, alongside the Temporal worker and the outbox
+drainer, sweeping `artifact` rows stuck in `allocated`/`publishing` to
+`failed` — see ARCHITECTURE.md "The reaper is not optional" and
+`worker/README.md`.
+
+| Variable | Default | Description |
+|----------|---------|--------------|
+| `ARTIFACT_REAPER_TIMEOUT` | `30m` | How long an `artifact` row may sit in `allocated` or `publishing` (measured from `state_changed_at`) before the next sweep moves it to `failed` with `fail_reason = 'stale'`. Go duration syntax. Set comfortably longer than the slowest real release leg (cross-arch image builds included) takes end to end, or an in-flight run gets reaped out from under itself. |
+| `ARTIFACT_REAPER_POLL_INTERVAL` | `5m` | Delay between sweep passes (Go duration syntax). Coarser than `WRITEBACK_POLL_INTERVAL` — this is a background hygiene sweep, not a redelivery loop reacting to a worker crash. |
+
 ## Local Development (Tilt)
 
 ```bash

--- a/tools/app_registry/PLAN.md
+++ b/tools/app_registry/PLAN.md
@@ -32,7 +32,9 @@ all merged to `main`** — see the table below.*
 | AR-4a / AR-4b | [#512](https://github.com/whale-net/everything/pull/512), [#514](https://github.com/whale-net/everything/pull/514) | merged — writeback `Publish` is still the stub |
 | AR-5a | [#513](https://github.com/whale-net/everything/pull/513) | merged — **inert**: no domain at stage `allocate`, `plan.go`'s tag path untouched |
 | AR-6a / AR-6b | [#516](https://github.com/whale-net/everything/pull/516), [#515](https://github.com/whale-net/everything/pull/515) | merged |
-| AR-7 | [#559](https://github.com/whale-net/everything/pull/559) | design only — AR-7a implemented (branch `ar-7a-sweep-robustness`, not yet merged); AR-7b…AR-7f not started |
+| AR-7 (design) | [#559](https://github.com/whale-net/everything/pull/559) | merged — design + delivery plan only, no implementation |
+| AR-7a | branch `ar-7a-sweep-robustness`, not yet merged | **implemented** — sweep robustness, no schema change |
+| AR-7b | branch `ar-7b-artifact-lifecycle`, not yet merged | **implemented** — artifact lifecycle, migration `007`, `BeginPublish`/`FailPublish`, stale-row reaper |
 
 The registry is being deployed to `dev` by the repo owner. `app-registry-api`
 and `app-registry-migration` images publish from `apps=all`.
@@ -48,19 +50,20 @@ say "not merged" in places; the table above is authoritative.
 implemented and tested, wired to nothing. See "AR-5" below for what remains
 before any domain can be cut over.
 
-**AR-7 (issue #558) is designed; AR-7a is implemented, not yet merged.** The
-full phase makes a release run hermetic — no dependency on `main`'s reconcile
-having gone first — via an artifact `allocated → publishing → published`
-lifecycle, an identity/manifest-snapshot split of `app`, and a run log CI
-writes to; that part (AR-7b…AR-7f) is still design only. AR-7a, independent of
-the rest, fixes ordering 4 (see ARCHITECTURE.md "The problem: four cross-run
-orderings"): `ReconcileApps` is now partially applying (one bad chart is
-skipped and reported, not a whole-sweep rollback), chart manifests carry
-domain-qualified app references so a bare-name collision across domains can't
-break the sweep, and `ci.yml`'s `reconcile-app-registry` job is no longer
-`continue-on-error`. See "AR-7a" below for the as-built detail. Design for the
-rest of AR-7 is in ARCHITECTURE.md's "Release lifecycle (issue #558)";
-delivery is "AR-7" below.
+**AR-7 (issue #558) is designed; AR-7a and AR-7b are implemented, not yet
+merged.** The full phase makes a release run hermetic — no dependency on
+`main`'s reconcile having gone first — via an artifact `allocated →
+publishing → published` lifecycle, an identity/manifest-snapshot split of
+`app`, and a run log CI writes to. AR-7a fixes ordering 4 (see
+ARCHITECTURE.md "The problem: four cross-run orderings"): `ReconcileApps` is
+now partially applying (one bad chart is skipped and reported, not a
+whole-sweep rollback), chart manifests carry domain-qualified app references
+so a bare-name collision across domains can't break the sweep, and `ci.yml`'s
+`reconcile-app-registry` job is no longer `continue-on-error`. AR-7b adds the
+artifact lifecycle states, migration `007`, `BeginPublish`/`FailPublish` and
+the stale-row reaper, and its exit criteria are met (see its subsection).
+AR-7c…AR-7f remain design-only. Design is in ARCHITECTURE.md's "Release
+lifecycle (issue #558)"; delivery is "AR-7" below.
 
 **Where deferred work is tracked.** Three places, deliberately:
 [Carry-over items](#carry-over-items) for small cross-cutting gaps that
@@ -981,9 +984,132 @@ explicitly out of scope — see the ground rules that constrained this phase):
   reintroduced, the not-marked-missing guard removed, and qualified
   resolution disabled), then the break was reverted.
 
-### AR-7b — Artifact lifecycle states — migration `007_artifact_lifecycle`
+### AR-7b — Artifact lifecycle states — migration `007_artifact_lifecycle` — done
 
-**Scope**
+**As built.** Implemented on branch `ar-7b-artifact-lifecycle`, not yet
+merged. Migration numbering matched the plan exactly — `007`, not `006`:
+`006` was already `006_reconcile_watermark` (issue #545, landed between the
+AR-7 design session and this implementation), so there was no free slot to
+reuse. See `migrate/README.md`'s numbering note.
+
+- Migration `007_artifact_lifecycle`: everything in the original scope
+  below, plus `artifact.fail_reason TEXT` (not originally named) so
+  `FailPublish`'s reason and the reaper's `"stale"` are both actually
+  stored, and a table-level `artifact_state_shape` CHECK tying `state` to
+  which of `digest`/`build_id` may be non-NULL. `version_allocation`'s fold-
+  in derives each folded row's `repository` (NOT NULL, but
+  `version_allocation` never carried one) from the owning app's/chart's
+  stored `image_repository`/`chart_repository` via a `LEFT JOIN` — safe to
+  write as a real derivation rather than a placeholder because the table is
+  empty in every deployed environment (AR-5a is inert), so the fold-in
+  INSERT…SELECT affects zero rows today; see the migration's own comments
+  for the full justification. Existing rows backfill to `state =
+  'published'`, `provenance = 'observed'`, `version_source = 'tag'` (every
+  pre-AR-7b row was written by the git-tag path — AR-5a never authored one).
+  A real `.down.sql` recreates `version_allocation` and reverses every
+  column/index/constraint change, matching `005`'s style; it does not
+  attempt to preserve `allocated`/`publishing`/`failed` rows across the
+  schema change (same tradeoff `003`'s down already makes for `promotion`).
+- `AllocateVersion` writes an `allocated` artifact row directly via a new
+  shared `insertArtifact` helper (postgres and fake both), and now also
+  takes the owner's stored `repository` as a parameter (resolved at the
+  handler layer via `resolveOwnerAndDomain`, extended to return it) since
+  `artifact.repository` is `NOT NULL` even for a digest-less row. "Next
+  version" collapsed from a `UNION ALL` across two tables to one query
+  against `artifact` alone. **Its concurrency test
+  (`TestAllocateVersion_ConcurrentCallsNeverCollide`, 8 goroutines, zero
+  collisions) stays green with its core assertions completely unchanged —
+  the one edit is the final row-count assertion, which now counts
+  `artifact WHERE state = 'allocated'` instead of the dropped
+  `version_allocation` table, because the storage moved, not because the
+  guarantee weakened.**
+- New RPCs `BeginPublish`/`FailPublish`, implemented in the repository
+  interface, postgres, the fake, handlers, and the CLI
+  (`app-registry artifacts begin-publish` / `fail-publish`), wired into
+  `server/auth` exactly like `RecordArtifact` (`RoleBuilder`), with
+  `authz_test.go` coverage. `RecordArtifact` became the
+  `publishing → published` transition (via a new `completePublish` path
+  shared by postgres/fake), keeping its create-directly-as-`published`
+  fallback — but **only at adoption stage `observe`**, rejected at both
+  `promote` and `allocate` (the scope note said "rejected at allocate";
+  `promote` is included too, since recording is already mandatory there —
+  see ARCHITECTURE.md's "As built (AR-7b)" note under "Artifact lifecycle").
+  Every legal/illegal transition and the same-digest-idempotent /
+  different-digest-`AlreadyExists` rule is enforced identically in postgres
+  and the fake, and covered by both a handler-level (fake-backed) test
+  suite and a real-Postgres integration test suite.
+- Stale-row reaper: new `worker/reaper` package, a third loop in
+  `app-registry-worker` alongside the outbox drainer, calling
+  `ArtifactRepository.ExpireStale` on `ARTIFACT_REAPER_TIMEOUT` /
+  `ARTIFACT_REAPER_POLL_INTERVAL` (ENV.md, `worker/README.md`).
+- **The release plan step writes the intent set — narrower than "before
+  anything is pushed" originally described.** No third RPC exists to
+  declare intent independently of `BeginPublish` (the scope named exactly
+  two new RPCs), and `AllocateVersion`'s per-domain gate cannot serve
+  `observe`/`promote` domains without misattributing `version_source`. As
+  built: `BeginPublish` is called as the first step of each matrix leg in
+  `release.yml`, strictly before that leg's own image/chart push, rather
+  than from the plan job before the whole matrix fans out. This satisfies
+  "before that target's own push" but not "before the whole run's fan-out
+  begins" — a matrix leg that never starts at all still has no row of any
+  kind. See ARCHITECTURE.md's as-built note under "The run log" for the
+  full reasoning and why closing that gap is left to AR-7d. **This is the
+  one piece of AR-7b's original scope delivered narrower than described —
+  called out explicitly as "Deliberately NOT done" below, not silently
+  dropped.**
+- `.github/actions/app-registry-begin-publish` / `app-registry-fail-publish`
+  (new composite actions, following `app-registry-record-build`/
+  `app-registry-record-image`'s pattern) and `release.yml` changes: see
+  that file's diff and this phase's report for the exact step reordering
+  (build recording moved ahead of the push so `BeginPublish` has a
+  `build_id` to stamp). `APP_REGISTRY_CICD_OPT_IN` and
+  `dry_run == 'false'` gating and `continue-on-error: true` semantics are
+  unchanged from the existing recording steps — AR-7b does not flip
+  recording from best-effort to mandatory at the workflow-YAML layer for
+  any stage; that tightening is entirely server-side (RecordArtifact's
+  stage-gated fallback above), matching ARCHITECTURE.md's "Availability,
+  restated per adoption stage" table.
+- Docs: this section, ARCHITECTURE.md ("Release lifecycle" status line,
+  "Artifact lifecycle" as-built note, "The run log" as-built note,
+  "Relationship to AR-5" ordering-rule confirmation), ENV.md (reaper
+  variables), `worker/README.md` (reaper section), `migrate/README.md`
+  (migration table + numbering note).
+
+**Verified, not merely built:**
+- `bazel build //tools/app_registry/...` and `bazel test
+  //tools/app_registry/...` (non-`manual` targets) are green.
+- `postgres_integration_test` (`manual`-tagged, requires Docker) was run for
+  real against `postgres:16-alpine` via `libs/go/dbtest` — every legal
+  transition, every illegal one rejected (`TestArtifactLifecycle_
+  LegalTransitions`, `TestArtifactLifecycle_IllegalTransitionsRejected`),
+  the reaper timeout including a fresh row NOT being reaped
+  (`TestExpireStale_ReaperTimeout`), and the `version_allocation` fold-in
+  (`TestMigration007FoldsVersionAllocationIntoArtifact`) all pass, alongside
+  every pre-existing test in that file (a raw-SQL test fixture,
+  `seedArtifact`, needed updating for the new NOT NULL columns — a real,
+  expected fallout of the schema change, not a design change).
+- Several of the new tests (the different-digest-rejected check, BeginPublish
+  rejecting a published row, RecordArtifact's stage gate, and the reaper's
+  cutoff filter) were each verified to fail when the behavior they guard was
+  deliberately broken in the fake or postgres implementation, then reverted.
+- The two touched workflow YAMLs were validated for syntax only
+  (`python3 -c "import yaml,sys; yaml.safe_load(open(...))"`) — they cannot
+  be executed in this environment (no deployed registry, no real Keycloak
+  clients), same as AR-3d's `promote.yml` before it.
+
+**Deliberately NOT done (see "As built" above for the one item with a
+design consequence; the rest are unchanged scope boundaries from other
+phases):**
+- The plan-stage, before-fan-out intent write for `observe`/`promote`
+  domains — narrowed to "first step of each matrix leg" instead. Left to
+  AR-7d, which owns the run-log/resume machinery this gap actually affects.
+- `AssertApps`, manifest snapshot tables, `GetReleaseRun`, `AdoptArtifact`,
+  compose-time chart enforcement — AR-7c/d/e/f, unchanged.
+- Moving any domain to `domain_adoption.stage = 'allocate'` for real — that
+  remains a separate, explicit operational action; AR-7b only removes the
+  blocker ARCHITECTURE.md's "Relationship to AR-5" named.
+
+**Original scope (as designed, for reference)**
 - Migration: `artifact.state` (`allocated`/`publishing`/`published`/`failed`),
   `artifact.provenance` (`observed`/`adopted`), `artifact.version_source`
   (`registry`/`tag` — which path authored the version), `state_changed_at`;

--- a/tools/app_registry/cli/README.md
+++ b/tools/app_registry/cli/README.md
@@ -2,7 +2,8 @@
 
 Thin gRPC client for the App Registry. Skeleton in **AR-1**, commands added
 alongside the RPCs they call in **AR-2** / **AR-3**. All commands below are
-implemented as of **AR-3d**.
+implemented as of **AR-3d**, plus `artifacts begin-publish`/`fail-publish`
+added in **AR-7b**.
 
 ## Thin means thin
 
@@ -26,6 +27,8 @@ app-registry artifacts list <domain-name> [--kind image|chart] [--promotable]
 app-registry artifacts get <domain-name> --version vX.Y.Z
 app-registry artifacts resolve <digest|artifact-id>            # chart -> images
 app-registry artifacts record ... --idempotency-key K          # CI
+app-registry artifacts begin-publish --kind K --owner O --version V --build-id B --idempotency-key K   # CI, AR-7b
+app-registry artifacts fail-publish --kind K --owner O --version V --reason "..." --idempotency-key K  # CI, AR-7b
 
 app-registry builds record ... --idempotency-key K             # CI
 

--- a/tools/app_registry/cli/cmd/artifacts.go
+++ b/tools/app_registry/cli/cmd/artifacts.go
@@ -20,6 +20,8 @@ func newArtifactsCmd() *cobra.Command {
 		newArtifactsGetCmd(),
 		newArtifactsResolveCmd(),
 		newArtifactsRecordCmd(),
+		newArtifactsBeginPublishCmd(),
+		newArtifactsFailPublishCmd(),
 	)
 	return artifactsCmd
 }
@@ -105,6 +107,91 @@ func newArtifactsRecordCmd() *cobra.Command {
 	_ = c.MarkFlagRequired("owner")
 	_ = c.MarkFlagRequired("repository")
 	_ = c.MarkFlagRequired("digest")
+	_ = c.MarkFlagRequired("idempotency-key")
+	return c
+}
+
+// newArtifactsBeginPublishCmd is the AR-7b (issue #558) CI write path,
+// called immediately before an image/chart push -- the ∅|allocated|failed
+// -> publishing transition. See ARCHITECTURE.md "Artifact lifecycle:
+// allocated -> publishing -> published".
+func newArtifactsBeginPublishCmd() *cobra.Command {
+	var kind, owner, version, buildID string
+	c := &cobra.Command{
+		Use:   "begin-publish",
+		Short: "Begin publishing an artifact, before the push (CI)",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			k, err := parseArtifactKind(kind)
+			if err != nil {
+				return err
+			}
+			req := &pb.BeginPublishRequest{
+				Kind:           k,
+				OwnerFullName:  owner,
+				Version:        version,
+				BuildId:        buildID,
+				IdempotencyKey: idempotencyKeyFlag,
+			}
+			return withClient(cmd, func(rc *registryClient) error {
+				resp, err := rc.Artifact.BeginPublish(cmd.Context(), req)
+				if err != nil {
+					return err
+				}
+				return printResponse(resp)
+			})
+		},
+	}
+	c.Flags().StringVar(&kind, "kind", "", "Artifact kind (image|chart)")
+	c.Flags().StringVar(&owner, "owner", "", "Owning app or chart, as <domain>-<name>")
+	c.Flags().StringVar(&version, "version", "", "Semver tag, e.g. v1.2.3")
+	c.Flags().StringVar(&buildID, "build-id", "", "Build id returned by 'builds record'")
+	c.Flags().StringVar(&idempotencyKeyFlag, "idempotency-key", "", "Required. <workflow_run_id>-<attempt>-<owner>-<kind>")
+	_ = c.MarkFlagRequired("kind")
+	_ = c.MarkFlagRequired("owner")
+	_ = c.MarkFlagRequired("version")
+	_ = c.MarkFlagRequired("build-id")
+	_ = c.MarkFlagRequired("idempotency-key")
+	return c
+}
+
+// newArtifactsFailPublishCmd is the AR-7b (issue #558) CI write path,
+// called on release.yml's error path immediately after a begin-publish for
+// the same target -- the publishing -> failed transition.
+func newArtifactsFailPublishCmd() *cobra.Command {
+	var kind, owner, version, reason string
+	c := &cobra.Command{
+		Use:   "fail-publish",
+		Short: "Mark an in-progress publish as failed (CI)",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			k, err := parseArtifactKind(kind)
+			if err != nil {
+				return err
+			}
+			req := &pb.FailPublishRequest{
+				Kind:           k,
+				OwnerFullName:  owner,
+				Version:        version,
+				Reason:         reason,
+				IdempotencyKey: idempotencyKeyFlag,
+			}
+			return withClient(cmd, func(rc *registryClient) error {
+				resp, err := rc.Artifact.FailPublish(cmd.Context(), req)
+				if err != nil {
+					return err
+				}
+				return printResponse(resp)
+			})
+		},
+	}
+	c.Flags().StringVar(&kind, "kind", "", "Artifact kind (image|chart)")
+	c.Flags().StringVar(&owner, "owner", "", "Owning app or chart, as <domain>-<name>")
+	c.Flags().StringVar(&version, "version", "", "Semver tag, e.g. v1.2.3")
+	c.Flags().StringVar(&reason, "reason", "", "Required. Why the publish failed")
+	c.Flags().StringVar(&idempotencyKeyFlag, "idempotency-key", "", "Required. <workflow_run_id>-<attempt>-<owner>-<kind>")
+	_ = c.MarkFlagRequired("kind")
+	_ = c.MarkFlagRequired("owner")
+	_ = c.MarkFlagRequired("version")
+	_ = c.MarkFlagRequired("reason")
 	_ = c.MarkFlagRequired("idempotency-key")
 	return c
 }

--- a/tools/app_registry/migrate/README.md
+++ b/tools/app_registry/migrate/README.md
@@ -35,7 +35,7 @@ ArgoCD sync waves. See `friendly_computing_machine/docs/argocd-integration.md`.
 | `004_writeback_outbox` (AR-4b) | `writeback_outbox` |
 | `005_version_allocation` (AR-5a) | `artifact.version_major/minor/patch` + backfill, `artifact_version_order_idx`, `version_allocation` |
 | `006_reconcile_watermark` (issue #545) | `reconcile_watermark` — singleton row guarding `ReconcileApps` against a stale (older-commit) call landing after a newer one |
-| `007_artifact_lifecycle` (AR-7b, **planned**) | `artifact.state`/`provenance`/`state_changed_at`, nullable `digest`/`build_id`, partial-unique digest index, `version_allocation` folded in and dropped |
+| `007_artifact_lifecycle` (AR-7b, issue #558) | `artifact.state`/`provenance`/`version_source`/`state_changed_at`/`fail_reason`, nullable `digest`/`build_id`/`published_at`, `artifact_state_shape` CHECK, partial-unique `artifact_digest_idx` (`WHERE digest IS NOT NULL`), `artifact_state_idx` (reaper sweep), `version_allocation` folded into `artifact` as `state = 'allocated'` and dropped |
 | `008_app_identity_split` (AR-7c, **planned**) | append-only `app_manifest`/`chart_manifest` snapshots, `artifact.manifest_id`/`promotability`, `app`/`chart` lose their mutable metadata, `v_current_app`/`v_current_chart` |
 
 Split this way so AR-2 needs only `001`, AR-3b adds `002`, AR-3c adds `003`,
@@ -51,6 +51,15 @@ to `005`. Migration numbers must be unique: golang-migrate fails on a
 duplicate version at **deploy** time, not build time, so a collision is
 invisible to CI.
 
+**Numbering note (AR-7b):** PLAN.md's AR-7 design section names this
+migration `007_artifact_lifecycle` throughout, and that is exactly what it
+is numbered here too — `006` was already taken by `006_reconcile_watermark`
+(issue #545, landed between the AR-7 design session and AR-7b's
+implementation), so there was no free `006` to reuse and no renumbering was
+needed. Called out explicitly because AR-4b/AR-5a's `004` collision above is
+the kind of mistake this note exists to prevent a future phase from
+repeating.
+
 ## Required indexes
 
 Do not omit these; they are load-bearing, not optimizations.
@@ -65,10 +74,17 @@ CREATE UNIQUE INDEX promotion_current_idx
 CREATE INDEX promotion_window_idx
   ON promotion (environment_id, target_key, valid_from DESC);
 
--- digest is the real artifact identity
-CREATE UNIQUE INDEX artifact_digest_idx ON artifact (digest);
+-- digest is the real artifact identity. As of migration 007 (AR-7b), NULL
+-- for every allocated/publishing/failed row (they have no digest yet) --
+-- WHERE digest IS NOT NULL says what is meant: unique among artifacts that
+-- HAVE one.
+CREATE UNIQUE INDEX artifact_digest_idx ON artifact (digest) WHERE digest IS NOT NULL;
 
--- version allocation collision guard (AR-5 depends on this)
+-- version allocation collision guard (AR-5 depends on this). As of
+-- migration 007, this ALSO spans allocated/publishing/failed rows (the
+-- version_allocation table it used to share this job with is gone -- see
+-- "Planned migrations" above), so it now does double duty as both the
+-- published-artifact collision guard and the allocation-collision guard.
 CREATE UNIQUE INDEX artifact_version_idx ON artifact (owner_id, kind, version);
 
 -- numeric ordering for "latest"/"next" -- TEXT ordering on `version` is
@@ -77,9 +93,13 @@ CREATE UNIQUE INDEX artifact_version_idx ON artifact (owner_id, kind, version);
 CREATE INDEX artifact_version_order_idx
   ON artifact (owner_id, kind, version_major DESC, version_minor DESC, version_patch DESC);
 
--- AllocateVersion's reservation ledger -- same collision guard shape as
--- artifact_version_idx, but on a table that doesn't require a digest/build.
-CREATE UNIQUE INDEX version_allocation_idx ON version_allocation (owner_id, kind, version);
+-- AR-7b (migration 007): backs the stale-row reaper's sweep
+-- ("state IN ('allocated','publishing') AND state_changed_at < cutoff") --
+-- see ENV.md's ARTIFACT_REAPER_* variables and worker/README.md. Partial so
+-- it only ever indexes the small, transient set of in-flight rows,
+-- regardless of how large the published/failed tail of the table grows.
+CREATE INDEX artifact_state_idx ON artifact (state, state_changed_at)
+  WHERE state IN ('allocated', 'publishing');
 ```
 
 `reconcile_watermark` (`006`) is seeded with exactly one sentinel row at

--- a/tools/app_registry/migrate/schema/migrations/007_artifact_lifecycle.down.sql
+++ b/tools/app_registry/migrate/schema/migrations/007_artifact_lifecycle.down.sql
@@ -1,0 +1,55 @@
+-- Rollback App Registry Artifact Lifecycle States (AR-7b, issue #558)
+--
+-- Matches the style of 005_version_allocation.down.sql: simple, and does
+-- not attempt to preserve data across the schema change it is undoing --
+-- the same tradeoff 003's down (DROP TABLE promotion, losing promotion
+-- history) already makes for this repo's migrations.
+--
+-- Rows in 'allocated', 'publishing', or 'failed' state have no meaning
+-- once state/digest-nullability go away (the world this down migration
+-- returns to required digest/build_id NOT NULL on every artifact row), so
+-- they are deleted rather than coerced into a shape the old schema can't
+-- represent. Only 'published' rows -- the only state the pre-AR-7b schema
+-- ever had -- survive the rollback.
+DELETE FROM artifact WHERE state != 'published';
+
+DROP INDEX IF EXISTS artifact_state_idx;
+
+ALTER TABLE artifact DROP CONSTRAINT IF EXISTS artifact_state_shape;
+
+-- Restore the pre-AR-7b column shape. Safe now: every surviving row is
+-- 'published' and therefore already carries a real digest/build_id/
+-- published_at (see the up migration's backfill and the state_shape CHECK
+-- constraint it enforced while this schema was live).
+ALTER TABLE artifact ALTER COLUMN digest SET NOT NULL;
+ALTER TABLE artifact ALTER COLUMN build_id SET NOT NULL;
+ALTER TABLE artifact ALTER COLUMN published_at SET NOT NULL;
+ALTER TABLE artifact ALTER COLUMN published_at SET DEFAULT NOW();
+
+DROP INDEX IF EXISTS artifact_digest_idx;
+CREATE UNIQUE INDEX artifact_digest_idx ON artifact (digest);
+
+ALTER TABLE artifact DROP COLUMN IF EXISTS state;
+ALTER TABLE artifact DROP COLUMN IF EXISTS provenance;
+ALTER TABLE artifact DROP COLUMN IF EXISTS version_source;
+ALTER TABLE artifact DROP COLUMN IF EXISTS state_changed_at;
+ALTER TABLE artifact DROP COLUMN IF EXISTS fail_reason;
+
+-- Recreate version_allocation exactly as 005_version_allocation.up.sql
+-- defined it. Empty on recreation -- any 'allocated' rows this migration's
+-- up direction folded into `artifact` were deleted above, matching this
+-- repo's other down migrations' no-data-preservation convention.
+CREATE TABLE version_allocation (
+    version_allocation_id  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    owner_id                UUID NOT NULL,
+    kind                    TEXT NOT NULL CHECK (kind IN ('image', 'chart')),
+    version                 TEXT NOT NULL,
+    version_major           INTEGER NOT NULL,
+    version_minor           INTEGER NOT NULL,
+    version_patch           INTEGER NOT NULL,
+    allocated_at            TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX version_allocation_idx ON version_allocation (owner_id, kind, version);
+CREATE INDEX version_allocation_order_idx
+    ON version_allocation (owner_id, kind, version_major DESC, version_minor DESC, version_patch DESC);

--- a/tools/app_registry/migrate/schema/migrations/007_artifact_lifecycle.up.sql
+++ b/tools/app_registry/migrate/schema/migrations/007_artifact_lifecycle.up.sql
@@ -1,0 +1,229 @@
+-- App Registry — Artifact lifecycle states (AR-7b, issue #558)
+--
+-- See ARCHITECTURE.md "Release lifecycle (issue #558)" -> "Artifact
+-- lifecycle: allocated -> publishing -> published" for the full design.
+-- Summary: the registry now records the INTENT to publish an artifact
+-- before the push happens (`allocated`/`publishing`), not only the fact
+-- that it happened (`published`). This is what makes ordering 3 ("an image
+-- must be recorded before any chart pins its digest") a genuinely useful
+-- reject instead of a bookkeeping gap, and what makes a killed release run
+-- resumable (AR-7d) instead of silently incomplete.
+--
+-- This migration does five things:
+--   1. Adds artifact.state / provenance / version_source / state_changed_at
+--      / fail_reason.
+--   2. Makes digest / build_id / published_at NULLable -- an `allocated` row
+--      has neither a digest nor a build yet; a `publishing` row has a build
+--      but no digest.
+--   3. Adds a CHECK constraint tying state to which of those three columns
+--      may be non-NULL, so an inconsistent row is a schema violation, not
+--      just an application bug.
+--   4. Narrows artifact_digest_idx to only real (non-NULL) digests -- every
+--      `allocated`/`publishing`/`failed` row would otherwise collide on
+--      NULL under a naive unique index (Postgres actually treats NULLs as
+--      distinct for uniqueness purposes, so this isn't strictly required
+--      for correctness, but WHERE digest IS NOT NULL says what is meant:
+--      "digest is unique among artifacts that HAVE one" -- and keeps the
+--      index smaller by excluding every in-flight row).
+--   5. Folds `version_allocation` (AR-5a's reservation ledger) into
+--      `artifact` as `state = 'allocated'` rows, then drops the table --
+--      see "Fold version_allocation into artifact" below.
+--
+-- `UNIQUE (owner_id, kind, version)` (artifact_version_idx, migration 001)
+-- is UNCHANGED by this migration and now spans every state
+-- (allocated/publishing/published/failed all share it) -- it keeps doing
+-- exactly the job version_allocation's own unique index used to do
+-- (the allocation-collision guard AllocateVersion's concurrency test
+-- depends on), just against one table instead of two. "Next version" also
+-- collapses from a MAX() across two tables into one query against
+-- `artifact` alone -- see server/repository/postgres/artifact.go.
+
+-- ============================================================================
+-- 1 + 2. New columns; existing columns become nullable
+-- ============================================================================
+
+-- Added nullable first (matching migration 005's ADD-COLUMN-then-backfill
+-- style) so the backfill UPDATE below can populate every pre-existing row
+-- before NOT NULL is enforced.
+ALTER TABLE artifact ADD COLUMN state TEXT
+    CHECK (state IN ('allocated', 'publishing', 'published', 'failed'));
+
+ALTER TABLE artifact ADD COLUMN provenance TEXT
+    CHECK (provenance IN ('observed', 'adopted'));
+
+-- version_source: which path authored this row's version. 'registry' means
+-- AllocateVersion (AR-5) reserved it; 'tag' means the pre-cutover git-tag
+-- path chose it and the registry is merely recording the intent (see
+-- ARCHITECTURE.md "The run log" -- the release plan step writes this row at
+-- EVERY adoption stage, not only 'allocate'). This is what turns AR-5's
+-- parity exit criterion ("allocated versions match what tag-scanning would
+-- have produced") into a query instead of a manual soak-log comparison.
+-- Deliberately no default -- unlike `provenance` (where 'observed' is a
+-- safe assumption for any row this migration doesn't otherwise know
+-- about), there is no safe default for "who authored this version": every
+-- write path (RecordArtifact's direct-create fallback, AllocateVersion,
+-- BeginPublish) must set it explicitly, and a forgotten value should be a
+-- NOT NULL violation, not a silently wrong guess.
+ALTER TABLE artifact ADD COLUMN version_source TEXT
+    CHECK (version_source IN ('registry', 'tag'));
+
+-- state_changed_at: when `state` last transitioned. The reaper
+-- (app-registry-worker) sweeps on this column -- see artifact_state_idx
+-- below.
+ALTER TABLE artifact ADD COLUMN state_changed_at TIMESTAMPTZ;
+
+-- fail_reason: set by FailPublish (caller-supplied) or the reaper
+-- (hardcoded "stale" -- see ARCHITECTURE.md "The reaper is not optional").
+-- A plain TEXT column with a safe empty-string default, not an enum: unlike
+-- state/provenance/version_source this is free-text for operator
+-- diagnosis, not a value application code branches on.
+ALTER TABLE artifact ADD COLUMN fail_reason TEXT NOT NULL DEFAULT '';
+
+-- digest/build_id/published_at: an `allocated` row has neither a digest nor
+-- a build yet (AllocateVersionRequest carries neither -- see migration
+-- 005's comments, now folded into this table); a `publishing` row has a
+-- build but not yet a digest (BeginPublish runs before the push that
+-- produces one). DROP DEFAULT on published_at too: it must only ever be
+-- set at the instant a row actually becomes 'published' (RecordArtifact),
+-- never silently defaulted to NOW() by an INSERT that forgot it -- that
+-- would fabricate a publish time for a row that was never published.
+ALTER TABLE artifact ALTER COLUMN digest DROP NOT NULL;
+ALTER TABLE artifact ALTER COLUMN build_id DROP NOT NULL;
+ALTER TABLE artifact ALTER COLUMN published_at DROP NOT NULL;
+ALTER TABLE artifact ALTER COLUMN published_at DROP DEFAULT;
+
+-- ============================================================================
+-- Backfill existing `artifact` rows
+-- ============================================================================
+
+-- Every row that exists before this migration was written by the
+-- pre-AR-7b RecordArtifact, which only ever created a row directly in what
+-- is now called the 'published' state, always with a real digest/build_id,
+-- always via the git-tag version path (AR-5a's AllocateVersion is inert --
+-- see PLAN.md's AR-5a status: no domain has ever been at adoption stage
+-- 'allocate', so no pre-existing artifact row was ever authored by the
+-- registry). provenance = 'observed' because every one of these rows was
+-- recorded from a real CI push, not backfilled/adopted after the fact (see
+-- ARCHITECTURE.md "Resolved questions" #3 -- there is no bulk backfill in
+-- this repo's history to date). state_changed_at backfills to
+-- published_at: for a 'published' row, "when did it last change state" and
+-- "when was it published" are the same instant, since this migration is the
+-- first time `state` exists at all.
+UPDATE artifact SET
+    state = 'published',
+    provenance = 'observed',
+    version_source = 'tag',
+    state_changed_at = published_at
+WHERE state IS NULL;
+
+-- ============================================================================
+-- 5. Fold version_allocation into artifact, then drop it
+-- ============================================================================
+
+-- version_allocation is empty in every deployed environment as of this
+-- migration -- AR-5a shipped AllocateVersion fully implemented but wired to
+-- nothing (no domain_adoption row has ever been set to 'allocate'; see
+-- PLAN.md's AR-5a status and ARCHITECTURE.md "Relationship to AR-5
+-- (allocation cutover)"). That makes this INSERT...SELECT a no-op against
+-- real data today -- this is exactly the cheap moment ARCHITECTURE.md calls
+-- out for doing this re-homing ("after a cutover, this migration would be
+-- folding rows a live release path is writing"). The statement is still
+-- written to be correct for a non-empty table, both so the migration is
+-- well-defined regardless of what a given environment's actual state is,
+-- and so this SQL keeps working if it is ever copied as a reference for a
+-- similar fold-in.
+--
+-- version_allocation carries no `repository` value (AllocateVersionRequest
+-- never did either -- see migration 005's comments: allocation happens
+-- before a build, and originally before `artifact.repository` needed
+-- populating at all). `artifact.repository` is NOT NULL, so a folded row
+-- needs one. Derived here via a LEFT JOIN back to the owning app/chart's
+-- own stored repository (image_repository / chart_repository) -- the same
+-- value RecordArtifact would have used had this owner gone on to publish
+-- normally. The COALESCE(..., '') tail is a defensive fallback for an
+-- owner row that has since been deleted or somehow carries an empty
+-- repository itself; given the table is empty today, this fallback is
+-- unreachable in practice, but the column being NOT NULL means the
+-- migration must still be well-defined if it ever isn't.
+INSERT INTO artifact (
+    artifact_id, kind, app_id, chart_id, repository, version,
+    version_major, version_minor, version_patch,
+    state, provenance, version_source, state_changed_at
+)
+SELECT
+    va.version_allocation_id,
+    va.kind,
+    CASE WHEN va.kind = 'image' THEN va.owner_id END,
+    CASE WHEN va.kind = 'chart' THEN va.owner_id END,
+    COALESCE(app.image_repository, chart.chart_repository, ''),
+    va.version,
+    va.version_major, va.version_minor, va.version_patch,
+    'allocated', 'observed', 'registry', va.allocated_at
+FROM version_allocation va
+LEFT JOIN app   ON va.kind = 'image' AND app.app_id     = va.owner_id
+LEFT JOIN chart ON va.kind = 'chart' AND chart.chart_id = va.owner_id;
+
+DROP TABLE version_allocation;
+
+-- ============================================================================
+-- Enforce NOT NULL now that every row (backfilled + folded) has a value
+-- ============================================================================
+
+ALTER TABLE artifact ALTER COLUMN state SET NOT NULL;
+
+-- provenance gets a DEFAULT: 'observed' is a safe assumption for any future
+-- INSERT that forgets to set it explicitly -- unlike state/version_source,
+-- where no such safe default exists (see version_source's comment above).
+ALTER TABLE artifact ALTER COLUMN provenance SET NOT NULL;
+ALTER TABLE artifact ALTER COLUMN provenance SET DEFAULT 'observed';
+
+ALTER TABLE artifact ALTER COLUMN version_source SET NOT NULL;
+
+ALTER TABLE artifact ALTER COLUMN state_changed_at SET NOT NULL;
+ALTER TABLE artifact ALTER COLUMN state_changed_at SET DEFAULT NOW();
+
+-- ============================================================================
+-- 3. State/column-presence CHECK constraint
+-- ============================================================================
+
+-- Ties `state` to exactly which of digest/build_id may be set, so a
+-- corrupt row (e.g. 'published' with no digest) is impossible at the
+-- schema layer, not just prevented by application code. Added as a
+-- table-level named constraint (rather than inline on one column) because
+-- it spans three columns.
+ALTER TABLE artifact ADD CONSTRAINT artifact_state_shape CHECK (
+    (state = 'allocated'  AND digest IS NULL     AND build_id IS NULL) OR
+    (state = 'publishing' AND digest IS NULL     AND build_id IS NOT NULL) OR
+    (state = 'published'  AND digest IS NOT NULL AND build_id IS NOT NULL) OR
+    (state = 'failed'     AND digest IS NULL)
+);
+
+-- ============================================================================
+-- 4. Narrow the digest unique index to real digests only
+-- ============================================================================
+
+DROP INDEX artifact_digest_idx;
+CREATE UNIQUE INDEX artifact_digest_idx ON artifact (digest) WHERE digest IS NOT NULL;
+
+-- ============================================================================
+-- Reaper support index
+-- ============================================================================
+
+-- The stale-row reaper (app-registry-worker) sweeps
+-- "state IN ('allocated','publishing') AND state_changed_at < cutoff" on a
+-- timer (see ENV.md's ARTIFACT_REAPER_* variables). A partial index keeps
+-- this cheap regardless of how large the `published`/`failed` tail of the
+-- table grows -- it only ever indexes the (small, transient) set of
+-- in-flight rows.
+CREATE INDEX artifact_state_idx ON artifact (state, state_changed_at)
+    WHERE state IN ('allocated', 'publishing');
+
+-- Note on artifact_version_idx (owner_id, kind, version), migration 001:
+-- deliberately UNCHANGED here. It already spans every row regardless of
+-- state (Postgres unique indexes don't care about a `state` column they
+-- don't include), so it was already doing double duty as both the
+-- published-artifact collision guard AND (after this migration) the
+-- allocation-collision guard version_allocation_idx used to provide on its
+-- own table. That is precisely what makes AllocateVersion's concurrency
+-- test (8 goroutines, zero collisions) keep passing unmodified against the
+-- new storage -- the constraint backing it never moved.

--- a/tools/app_registry/protos/api.proto
+++ b/tools/app_registry/protos/api.proto
@@ -40,6 +40,12 @@ service ArtifactRegistry {
   rpc RecordBuild(RecordBuildRequest) returns (RecordBuildResponse);
   rpc RecordArtifact(RecordArtifactRequest) returns (RecordArtifactResponse);
 
+  // Phase AR-7b (issue #558): artifact lifecycle, allocated -> publishing ->
+  // published. Called immediately before/after an image or chart push;
+  // RecordArtifact above completes publishing -> published.
+  rpc BeginPublish(BeginPublishRequest) returns (BeginPublishResponse);
+  rpc FailPublish(FailPublishRequest) returns (FailPublishResponse);
+
   rpc ListArtifacts(ListArtifactsRequest) returns (ListArtifactsResponse);
   rpc GetArtifact(GetArtifactRequest) returns (GetArtifactResponse);
 

--- a/tools/app_registry/protos/api_messages_artifact.proto
+++ b/tools/app_registry/protos/api_messages_artifact.proto
@@ -69,6 +69,56 @@ message RecordArtifactResponse {
 }
 
 // ============================================================================
+// Artifact lifecycle (phase AR-7b, issue #558)
+//
+// See ARCHITECTURE.md "Artifact lifecycle: allocated -> publishing ->
+// published". RecordArtifact above becomes the publishing -> published
+// transition once these are wired into release.yml; it keeps its
+// create-directly-as-published path for owners whose domain is still at
+// adoption stage "observe".
+// ============================================================================
+
+// BeginPublishRequest is the ∅|allocated|failed -> publishing transition,
+// called immediately before a release run pushes an image or chart.
+message BeginPublishRequest {
+  ArtifactKind kind = 1;
+
+  // For kind == IMAGE: the app's "<domain>-<name>".
+  // For kind == CHART: the chart's "<domain>-<name>".
+  string owner_full_name = 2;
+
+  string version = 3;  // semver tag, validated as v<major>.<minor>.<patch>
+  string build_id = 4;
+
+  // Required. "<workflow_run_id>-<attempt>-<owner_full_name>-<kind>".
+  string idempotency_key = 5;
+}
+
+message BeginPublishResponse {
+  Artifact artifact = 1;
+}
+
+// FailPublishRequest is the publishing -> failed transition, called on
+// release.yml's error path immediately after a BeginPublish for the same
+// target (or by the stale-row reaper, server-side, with reason "stale" --
+// not through this RPC).
+message FailPublishRequest {
+  ArtifactKind kind = 1;
+  string owner_full_name = 2;
+  string version = 3;
+
+  // Required -- why the publish failed.
+  string reason = 4;
+
+  // Required. "<workflow_run_id>-<attempt>-<owner_full_name>-<kind>".
+  string idempotency_key = 5;
+}
+
+message FailPublishResponse {
+  Artifact artifact = 1;
+}
+
+// ============================================================================
 // Reads
 // ============================================================================
 

--- a/tools/app_registry/protos/messages.proto
+++ b/tools/app_registry/protos/messages.proto
@@ -80,6 +80,37 @@ enum PromotionAction {
   PROMOTION_ACTION_REJECT = 6;
 }
 
+// ArtifactState is the AR-7b (issue #558) artifact lifecycle. See
+// ARCHITECTURE.md "Artifact lifecycle: allocated -> publishing ->
+// published". Legal transitions are enforced server-side; ARTIFACT_STATE_
+// PUBLISHED is terminal.
+enum ArtifactState {
+  ARTIFACT_STATE_UNSPECIFIED = 0;
+  ARTIFACT_STATE_ALLOCATED = 1;
+  ARTIFACT_STATE_PUBLISHING = 2;
+  ARTIFACT_STATE_PUBLISHED = 3;
+  ARTIFACT_STATE_FAILED = 4;
+}
+
+// ArtifactProvenance distinguishes an artifact the registry watched get
+// published (OBSERVED, every row this phase writes) from one recorded after
+// the fact via AR-7e's (not yet implemented) AdoptArtifact.
+enum ArtifactProvenance {
+  ARTIFACT_PROVENANCE_UNSPECIFIED = 0;
+  ARTIFACT_PROVENANCE_OBSERVED = 1;
+  ARTIFACT_PROVENANCE_ADOPTED = 2;
+}
+
+// VersionSource records which path authored an artifact's version: the
+// registry's own AllocateVersion (AR-5), or the pre-cutover git-tag scan in
+// tools/release_helper_go. See ARCHITECTURE.md "The run log" -- this is
+// what turns AR-5's parity exit criterion into a query.
+enum VersionSource {
+  VERSION_SOURCE_UNSPECIFIED = 0;
+  VERSION_SOURCE_REGISTRY = 1;
+  VERSION_SOURCE_TAG = 2;
+}
+
 // ============================================================================
 // Core entities
 // ============================================================================
@@ -174,6 +205,17 @@ message Artifact {
   // For kind == CHART: the image artifacts this chart pins, resolved to
   // digests at publish time by tools/helm. Empty for kind == IMAGE.
   repeated ArtifactLink contains = 11;
+
+  // AR-7b (issue #558): the artifact lifecycle. digest/build_id/
+  // published_at above are empty/0 until state reaches the point that
+  // requires them -- see ArtifactState's doc comment.
+  ArtifactState state = 12;
+  ArtifactProvenance provenance = 13;
+  VersionSource version_source = 14;
+  int64 state_changed_at = 15;
+  // Set when state == ARTIFACT_STATE_FAILED: the reason FailPublish (or the
+  // reaper, "stale") recorded. Empty otherwise.
+  string fail_reason = 16;
 }
 
 // ArtifactLink records that a chart artifact pins a specific image digest.

--- a/tools/app_registry/server/handlers/artifact.go
+++ b/tools/app_registry/server/handlers/artifact.go
@@ -108,7 +108,16 @@ func (s *ArtifactServer) RecordArtifact(ctx context.Context, req *pb.RecordArtif
 	resp, _, err := runIdempotent(ctx, s.repo, req.IdempotencyKey, "RecordArtifact",
 		func() proto.Message { return &pb.RecordArtifactResponse{} },
 		func(ctx context.Context, r repository.Registry) (proto.Message, error) {
-			owner, err := s.resolveOwner(ctx, r, kind, req.OwnerFullName)
+			owner, domain, err := s.resolveOwner(ctx, r, kind, req.OwnerFullName)
+			if err != nil {
+				return nil, err
+			}
+			// AR-7b: RecordArtifact's direct-create fallback (no prior
+			// BeginPublish) is only legal while this owner's domain is
+			// still at adoption stage "observe" -- see
+			// repository.ArtifactRepository.RecordArtifact's doc comment
+			// and ARCHITECTURE.md "Backward compatibility during rollout".
+			stage, err := r.DomainAdoption().GetStage(ctx, domain)
 			if err != nil {
 				return nil, err
 			}
@@ -127,7 +136,7 @@ func (s *ArtifactServer) RecordArtifact(ctx context.Context, req *pb.RecordArtif
 				a.ChartID = owner
 			}
 
-			artifact, alreadyRecorded, err := r.Artifacts().RecordArtifact(ctx, a, containedImagesFromPB(req.Contains))
+			artifact, alreadyRecorded, err := r.Artifacts().RecordArtifact(ctx, a, containedImagesFromPB(req.Contains), stage)
 			if err != nil {
 				return nil, err
 			}
@@ -140,7 +149,8 @@ func (s *ArtifactServer) RecordArtifact(ctx context.Context, req *pb.RecordArtif
 	return resp.(*pb.RecordArtifactResponse), nil
 }
 
-// resolveOwner resolves owner_full_name to an app_id or chart_id, depending
+// resolveOwner resolves owner_full_name to an app_id or chart_id (and its
+// domain, needed by RecordArtifact's AR-7b adoption-stage check), depending
 // on kind, wrapping repository.ErrNotFound as ErrOwnerNotReconciled (which
 // itself wraps ErrInvalidArgument — an unknown owner is a caller mistake,
 // not a "row doesn't exist yet" case). The wrapped message names the owner
@@ -150,19 +160,19 @@ func (s *ArtifactServer) RecordArtifact(ctx context.Context, req *pb.RecordArtif
 // structured apierrors.ReasonOwnerNotReconciled detail for this specific
 // sentinel (issue #547) so a caller can classify the failure without
 // parsing this message.
-func (s *ArtifactServer) resolveOwner(ctx context.Context, r repository.Registry, kind repository.ArtifactKind, ownerFullName string) (string, error) {
+func (s *ArtifactServer) resolveOwner(ctx context.Context, r repository.Registry, kind repository.ArtifactKind, ownerFullName string) (ownerID, domain string, err error) {
 	if kind == repository.ArtifactKindImage {
-		app, err := r.Apps().GetAppByFullName(ctx, ownerFullName)
-		if err != nil {
-			return "", fmt.Errorf("%w: app %q not found -- has it been reconciled? (ReconcileApps runs on push to main via ci.yml)", repository.ErrOwnerNotReconciled, ownerFullName)
+		app, aerr := r.Apps().GetAppByFullName(ctx, ownerFullName)
+		if aerr != nil {
+			return "", "", fmt.Errorf("%w: app %q not found -- has it been reconciled? (ReconcileApps runs on push to main via ci.yml)", repository.ErrOwnerNotReconciled, ownerFullName)
 		}
-		return app.AppID, nil
+		return app.AppID, app.Domain, nil
 	}
-	chart, err := r.Apps().GetChartByFullName(ctx, ownerFullName)
-	if err != nil {
-		return "", fmt.Errorf("%w: chart %q not found -- has it been reconciled? (ReconcileApps runs on push to main via ci.yml)", repository.ErrOwnerNotReconciled, ownerFullName)
+	chart, cerr := r.Apps().GetChartByFullName(ctx, ownerFullName)
+	if cerr != nil {
+		return "", "", fmt.Errorf("%w: chart %q not found -- has it been reconciled? (ReconcileApps runs on push to main via ci.yml)", repository.ErrOwnerNotReconciled, ownerFullName)
 	}
-	return chart.ChartID, nil
+	return chart.ChartID, chart.Domain, nil
 }
 
 func (s *ArtifactServer) ListArtifacts(ctx context.Context, req *pb.ListArtifactsRequest) (*pb.ListArtifactsResponse, error) {
@@ -285,7 +295,7 @@ func (s *ArtifactServer) AllocateVersion(ctx context.Context, req *pb.AllocateVe
 		return nil, status.Errorf(codes.InvalidArgument, `increment must be "major", "minor", or "patch" (got %q); or set explicit_version`, req.Increment)
 	}
 
-	domain, ownerID, err := s.resolveOwnerAndDomain(ctx, kind, req.OwnerFullName)
+	domain, ownerID, repo, err := s.resolveOwnerAndDomain(ctx, kind, req.OwnerFullName)
 	if err != nil {
 		return nil, err
 	}
@@ -310,7 +320,7 @@ func (s *ArtifactServer) AllocateVersion(ctx context.Context, req *pb.AllocateVe
 		out, wasReplayed, ferr := runIdempotent(ctx, s.repo, req.IdempotencyKey, "AllocateVersion",
 			func() proto.Message { return &pb.AllocateVersionResponse{} },
 			func(ctx context.Context, r repository.Registry) (proto.Message, error) {
-				alloc, aerr := r.Artifacts().AllocateVersion(ctx, kind, ownerID, req.Increment, req.ExplicitVersion)
+				alloc, aerr := r.Artifacts().AllocateVersion(ctx, kind, ownerID, repo, req.Increment, req.ExplicitVersion)
 				if aerr != nil {
 					return nil, aerr
 				}
@@ -344,21 +354,122 @@ func (s *ArtifactServer) AllocateVersion(ctx context.Context, req *pb.AllocateVe
 	return resp, nil
 }
 
-// resolveOwnerAndDomain resolves owner_full_name to its owning row's id and
-// domain, for AllocateVersion's storage key and adoption-stage gate
-// respectively. Mirrors resolveOwner but also needs Domain, which
-// resolveOwner's callers (RecordArtifact) don't.
-func (s *ArtifactServer) resolveOwnerAndDomain(ctx context.Context, kind repository.ArtifactKind, ownerFullName string) (domain, ownerID string, err error) {
+// resolveOwnerAndDomain resolves owner_full_name to its owning row's id,
+// domain, and stored repository (image_repository/chart_repository), for
+// AllocateVersion's storage key + adoption-stage gate and, as of AR-7b,
+// BeginPublish's repositoryHint on its ∅ -> publishing branch. Mirrors
+// resolveOwner but also needs Domain/repository, which resolveOwner's
+// caller (RecordArtifact) doesn't.
+func (s *ArtifactServer) resolveOwnerAndDomain(ctx context.Context, kind repository.ArtifactKind, ownerFullName string) (domain, ownerID, repo string, err error) {
 	if kind == repository.ArtifactKindImage {
 		app, aerr := s.repo.Apps().GetAppByFullName(ctx, ownerFullName)
 		if aerr != nil {
-			return "", "", status.Errorf(codes.InvalidArgument, "app %q not found -- has it been reconciled? (ReconcileApps runs on push to main via ci.yml)", ownerFullName)
+			return "", "", "", status.Errorf(codes.InvalidArgument, "app %q not found -- has it been reconciled? (ReconcileApps runs on push to main via ci.yml)", ownerFullName)
 		}
-		return app.Domain, app.AppID, nil
+		return app.Domain, app.AppID, app.ImageRepository, nil
 	}
 	chart, cerr := s.repo.Apps().GetChartByFullName(ctx, ownerFullName)
 	if cerr != nil {
-		return "", "", status.Errorf(codes.InvalidArgument, "chart %q not found -- has it been reconciled? (ReconcileApps runs on push to main via ci.yml)", ownerFullName)
+		return "", "", "", status.Errorf(codes.InvalidArgument, "chart %q not found -- has it been reconciled? (ReconcileApps runs on push to main via ci.yml)", ownerFullName)
 	}
-	return chart.Domain, chart.ChartID, nil
+	return chart.Domain, chart.ChartID, chart.ChartRepository, nil
+}
+
+// BeginPublish implements the ∅|allocated|failed -> publishing transition
+// (AR-7b, issue #558): called immediately before a release run pushes an
+// image or chart. See ArtifactState's doc comment for the full lifecycle
+// and ARCHITECTURE.md "Artifact lifecycle: allocated -> publishing ->
+// published".
+func (s *ArtifactServer) BeginPublish(ctx context.Context, req *pb.BeginPublishRequest) (*pb.BeginPublishResponse, error) {
+	if err := auth.Require(ctx, auth.RoleBuilder); err != nil {
+		return nil, err
+	}
+	kind := artifactKindFromPB(req.Kind)
+	if kind == "" {
+		return nil, status.Error(codes.InvalidArgument, "kind is required")
+	}
+	if req.OwnerFullName == "" {
+		return nil, status.Error(codes.InvalidArgument, "owner_full_name is required")
+	}
+	if req.Version == "" || !semverRe.MatchString(req.Version) {
+		return nil, status.Errorf(codes.InvalidArgument, "version %q must match v<major>.<minor>.<patch>", req.Version)
+	}
+	if req.BuildId == "" {
+		return nil, status.Error(codes.InvalidArgument, "build_id is required")
+	}
+	if req.IdempotencyKey == "" {
+		return nil, status.Error(codes.InvalidArgument, "idempotency_key is required")
+	}
+
+	_, ownerID, repo, err := s.resolveOwnerAndDomain(ctx, kind, req.OwnerFullName)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, _, err := runIdempotent(ctx, s.repo, req.IdempotencyKey, "BeginPublish",
+		func() proto.Message { return &pb.BeginPublishResponse{} },
+		func(ctx context.Context, r repository.Registry) (proto.Message, error) {
+			// versionSource is only consulted by the ∅ -> publishing branch
+			// (no prior AllocateVersion call for this version) -- an
+			// existing allocated/failed row keeps whatever it was already
+			// given. "tag" is correct there: the caller is the pre-cutover
+			// release path (ARCHITECTURE.md "Backward compatibility during
+			// rollout") recording intent for a version the git-tag path
+			// chose, not one the registry allocated.
+			artifact, aerr := r.Artifacts().BeginPublish(ctx, kind, ownerID, req.Version, req.BuildId, repo, repository.VersionSourceTag)
+			if aerr != nil {
+				return nil, aerr
+			}
+			return &pb.BeginPublishResponse{Artifact: artifactToPB(*artifact)}, nil
+		},
+	)
+	if err != nil {
+		return nil, mapRepoErr(err)
+	}
+	return resp.(*pb.BeginPublishResponse), nil
+}
+
+// FailPublish implements the publishing -> failed transition (AR-7b, issue
+// #558): called on release.yml's error path immediately after a
+// BeginPublish for the same target.
+func (s *ArtifactServer) FailPublish(ctx context.Context, req *pb.FailPublishRequest) (*pb.FailPublishResponse, error) {
+	if err := auth.Require(ctx, auth.RoleBuilder); err != nil {
+		return nil, err
+	}
+	kind := artifactKindFromPB(req.Kind)
+	if kind == "" {
+		return nil, status.Error(codes.InvalidArgument, "kind is required")
+	}
+	if req.OwnerFullName == "" {
+		return nil, status.Error(codes.InvalidArgument, "owner_full_name is required")
+	}
+	if req.Version == "" || !semverRe.MatchString(req.Version) {
+		return nil, status.Errorf(codes.InvalidArgument, "version %q must match v<major>.<minor>.<patch>", req.Version)
+	}
+	if req.Reason == "" {
+		return nil, status.Error(codes.InvalidArgument, "reason is required")
+	}
+	if req.IdempotencyKey == "" {
+		return nil, status.Error(codes.InvalidArgument, "idempotency_key is required")
+	}
+
+	_, ownerID, _, err := s.resolveOwnerAndDomain(ctx, kind, req.OwnerFullName)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, _, err := runIdempotent(ctx, s.repo, req.IdempotencyKey, "FailPublish",
+		func() proto.Message { return &pb.FailPublishResponse{} },
+		func(ctx context.Context, r repository.Registry) (proto.Message, error) {
+			artifact, aerr := r.Artifacts().FailPublish(ctx, kind, ownerID, req.Version, req.Reason)
+			if aerr != nil {
+				return nil, aerr
+			}
+			return &pb.FailPublishResponse{Artifact: artifactToPB(*artifact)}, nil
+		},
+	)
+	if err != nil {
+		return nil, mapRepoErr(err)
+	}
+	return resp.(*pb.FailPublishResponse), nil
 }

--- a/tools/app_registry/server/handlers/artifact_test.go
+++ b/tools/app_registry/server/handlers/artifact_test.go
@@ -428,7 +428,13 @@ func setupAllocate(t *testing.T) (*fake.Registry, *ArtifactServer) {
 
 	if _, err := appSrv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
 		Manifests: manifestSet([]*appmetapb.AppManifest{
-			{Domain: "demo", Name: "image-app", DeployUnit: appmetapb.DeployUnit_DEPLOY_UNIT_IMAGE},
+			// Registry/Organization/RepoName populate App.ImageRepository
+			// (see reconcile.go's imageRepository) -- AR-7b's
+			// AllocateVersion/BeginPublish need a real value here for their
+			// ∅ -> allocated / ∅ -> publishing fresh-create branches, which
+			// stamp it onto the artifact row's NOT NULL repository column.
+			{Domain: "demo", Name: "image-app", DeployUnit: appmetapb.DeployUnit_DEPLOY_UNIT_IMAGE,
+				Registry: "ghcr.io", Organization: "whale-net", RepoName: "demo-image-app"},
 		}, nil),
 		IdempotencyKey: "setup-allocate-1",
 	}); err != nil {
@@ -541,8 +547,14 @@ func TestAllocateVersion_IncrementsFromLatestRecordedArtifact(t *testing.T) {
 			// seeded v1.2.3, not from a previous subtest's allocation.
 			repo, artifactSrv := setupAllocate(t)
 			ctx := authedCtx()
-			repo.SetDomainAdoptionStage("demo", repository.DomainAdoptionStageAllocate)
 
+			// Seed while "demo" is still at its implicit default stage
+			// (observe) -- AR-7b's RecordArtifact only allows the
+			// create-directly-as-published path there (see
+			// ARCHITECTURE.md "Backward compatibility during rollout");
+			// cutting the domain to "allocate" happens AFTER seeding,
+			// exactly like a real cutover would (existing artifacts predate
+			// it), and only AllocateVersion's own gate below needs it.
 			build := recordBuild(t, artifactSrv, "run-allocate-seed-"+tc.increment)
 			if _, err := artifactSrv.RecordArtifact(ctx, &pb.RecordArtifactRequest{
 				BuildId: build.BuildId, Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE,
@@ -551,6 +563,7 @@ func TestAllocateVersion_IncrementsFromLatestRecordedArtifact(t *testing.T) {
 			}); err != nil {
 				t.Fatalf("seed RecordArtifact: %v", err)
 			}
+			repo.SetDomainAdoptionStage("demo", repository.DomainAdoptionStageAllocate)
 
 			resp, err := artifactSrv.AllocateVersion(ctx, &pb.AllocateVersionRequest{
 				Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE, OwnerFullName: "demo-image-app",
@@ -636,5 +649,229 @@ func TestAllocateVersion_ExplicitVersionCollisionFails(t *testing.T) {
 	})
 	if status.Code(err) != codes.AlreadyExists {
 		t.Fatalf("expected AlreadyExists for a taken explicit_version, got %v", err)
+	}
+}
+
+// ============================================================================
+// AR-7b: artifact lifecycle state machine (issue #558)
+//
+// See ARCHITECTURE.md "Artifact lifecycle: allocated -> publishing ->
+// published" for the legal-transition table these tests exercise:
+// ∅ -> allocated (AllocateVersion), ∅ -> publishing / allocated ->
+// publishing / failed -> publishing (BeginPublish), publishing -> published
+// (RecordArtifact), publishing -> failed (FailPublish). published is
+// terminal.
+// ============================================================================
+
+// TestArtifactLifecycle_AllocateBeginPublishRecord walks the full
+// allocated -> publishing -> published happy path end to end through the
+// handlers, asserting wire-level State/VersionSource at each step, then
+// proves published is terminal: the same digest replays idempotently, a
+// different digest for the same version is a real conflict.
+func TestArtifactLifecycle_AllocateBeginPublishRecord(t *testing.T) {
+	repo, artifactSrv := setupAllocate(t)
+	ctx := authedCtx()
+	repo.SetDomainAdoptionStage("demo", repository.DomainAdoptionStageAllocate)
+
+	alloc, err := artifactSrv.AllocateVersion(ctx, &pb.AllocateVersionRequest{
+		Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE, OwnerFullName: "demo-image-app",
+		Increment: "patch", IdempotencyKey: "lifecycle-allocate",
+	})
+	if err != nil {
+		t.Fatalf("AllocateVersion: %v", err)
+	}
+
+	build := recordBuild(t, artifactSrv, "run-lifecycle")
+
+	begun, err := artifactSrv.BeginPublish(ctx, &pb.BeginPublishRequest{
+		Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE, OwnerFullName: "demo-image-app",
+		Version: alloc.Version, BuildId: build.BuildId, IdempotencyKey: "lifecycle-begin",
+	})
+	if err != nil {
+		t.Fatalf("BeginPublish: %v", err)
+	}
+	if begun.Artifact.State != pb.ArtifactState_ARTIFACT_STATE_PUBLISHING {
+		t.Fatalf("expected state PUBLISHING after BeginPublish, got %v", begun.Artifact.State)
+	}
+	if begun.Artifact.VersionSource != pb.VersionSource_VERSION_SOURCE_REGISTRY {
+		t.Fatalf("expected version_source REGISTRY (inherited from AllocateVersion, not overwritten by BeginPublish's own default), got %v", begun.Artifact.VersionSource)
+	}
+
+	recorded, err := artifactSrv.RecordArtifact(ctx, &pb.RecordArtifactRequest{
+		BuildId: build.BuildId, Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE,
+		OwnerFullName: "demo-image-app", Digest: "sha256:lifecycle", Version: alloc.Version,
+		IdempotencyKey: "lifecycle-record",
+	})
+	if err != nil {
+		t.Fatalf("RecordArtifact: %v", err)
+	}
+	if recorded.Artifact.State != pb.ArtifactState_ARTIFACT_STATE_PUBLISHED {
+		t.Fatalf("expected state PUBLISHED after RecordArtifact, got %v", recorded.Artifact.State)
+	}
+	if recorded.Artifact.Digest != "sha256:lifecycle" {
+		t.Fatalf("expected digest to be stamped, got %q", recorded.Artifact.Digest)
+	}
+
+	// published is terminal: re-recording the SAME digest is an idempotent
+	// success...
+	again, err := artifactSrv.RecordArtifact(ctx, &pb.RecordArtifactRequest{
+		BuildId: build.BuildId, Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE,
+		OwnerFullName: "demo-image-app", Digest: "sha256:lifecycle", Version: alloc.Version,
+		IdempotencyKey: "lifecycle-record-replay",
+	})
+	if err != nil {
+		t.Fatalf("re-record same digest: %v", err)
+	}
+	if !again.AlreadyRecorded {
+		t.Fatalf("expected already_recorded=true re-recording the same digest")
+	}
+
+	// ...but a DIFFERENT digest for the same already-published version is a
+	// real conflict, not a retry.
+	_, err = artifactSrv.RecordArtifact(ctx, &pb.RecordArtifactRequest{
+		BuildId: build.BuildId, Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE,
+		OwnerFullName: "demo-image-app", Digest: "sha256:lifecycle-different", Version: alloc.Version,
+		IdempotencyKey: "lifecycle-record-conflict",
+	})
+	if status.Code(err) != codes.AlreadyExists {
+		t.Fatalf("expected AlreadyExists for a different digest on an already-published version, got %v", err)
+	}
+}
+
+// TestBeginPublish_NoPriorAllocation_TagPath proves the ∅ -> publishing
+// transition (the pre-cutover path, ARCHITECTURE.md "Backward
+// compatibility during rollout"): no AllocateVersion call happened, so
+// BeginPublish creates the row itself, with version_source TAG.
+func TestBeginPublish_NoPriorAllocation_TagPath(t *testing.T) {
+	_, artifactSrv := setupAllocate(t)
+	ctx := authedCtx()
+	build := recordBuild(t, artifactSrv, "run-begin-no-alloc")
+
+	begun, err := artifactSrv.BeginPublish(ctx, &pb.BeginPublishRequest{
+		Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE, OwnerFullName: "demo-image-app",
+		Version: "v9.9.9", BuildId: build.BuildId, IdempotencyKey: "begin-no-alloc",
+	})
+	if err != nil {
+		t.Fatalf("BeginPublish with no prior allocation: %v", err)
+	}
+	if begun.Artifact.State != pb.ArtifactState_ARTIFACT_STATE_PUBLISHING {
+		t.Fatalf("expected state PUBLISHING, got %v", begun.Artifact.State)
+	}
+	if begun.Artifact.VersionSource != pb.VersionSource_VERSION_SOURCE_TAG {
+		t.Fatalf("expected version_source TAG for the pre-cutover ∅ -> publishing path, got %v", begun.Artifact.VersionSource)
+	}
+}
+
+// TestBeginPublish_RejectsPublishedRow proves publishing -> published is
+// terminal: BeginPublish against an already-published version is
+// FailedPrecondition, not a silent no-op or re-publish.
+func TestBeginPublish_RejectsPublishedRow(t *testing.T) {
+	_, artifactSrv := setupAllocate(t)
+	ctx := authedCtx()
+	build := recordBuild(t, artifactSrv, "run-begin-on-published")
+
+	if _, err := artifactSrv.RecordArtifact(ctx, &pb.RecordArtifactRequest{
+		BuildId: build.BuildId, Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE,
+		OwnerFullName: "demo-image-app", Digest: "sha256:already-published", Version: "v1.0.0",
+		IdempotencyKey: "begin-on-published-seed",
+	}); err != nil {
+		t.Fatalf("seed published artifact: %v", err)
+	}
+
+	_, err := artifactSrv.BeginPublish(ctx, &pb.BeginPublishRequest{
+		Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE, OwnerFullName: "demo-image-app",
+		Version: "v1.0.0", BuildId: build.BuildId, IdempotencyKey: "begin-on-published",
+	})
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("expected FailedPrecondition for BeginPublish against a published row, got %v", err)
+	}
+}
+
+// TestFailPublish_RejectsNonPublishingRow proves FailPublish only accepts
+// "publishing" as a starting state -- exercised here against "allocated".
+func TestFailPublish_RejectsNonPublishingRow(t *testing.T) {
+	repo, artifactSrv := setupAllocate(t)
+	ctx := authedCtx()
+	repo.SetDomainAdoptionStage("demo", repository.DomainAdoptionStageAllocate)
+
+	alloc, err := artifactSrv.AllocateVersion(ctx, &pb.AllocateVersionRequest{
+		Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE, OwnerFullName: "demo-image-app",
+		Increment: "patch", IdempotencyKey: "fail-on-allocated-seed",
+	})
+	if err != nil {
+		t.Fatalf("AllocateVersion: %v", err)
+	}
+
+	_, err = artifactSrv.FailPublish(ctx, &pb.FailPublishRequest{
+		Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE, OwnerFullName: "demo-image-app",
+		Version: alloc.Version, Reason: "should be rejected",
+		IdempotencyKey: "fail-on-allocated",
+	})
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("expected FailedPrecondition for FailPublish against an allocated row, got %v", err)
+	}
+}
+
+// TestFailPublish_ThenBeginPublishRetries proves failed -> publishing: a
+// later run may retry the same version after a FailPublish, and the retry
+// clears fail_reason.
+func TestFailPublish_ThenBeginPublishRetries(t *testing.T) {
+	_, artifactSrv := setupAllocate(t)
+	ctx := authedCtx()
+	build := recordBuild(t, artifactSrv, "run-retry")
+
+	if _, err := artifactSrv.BeginPublish(ctx, &pb.BeginPublishRequest{
+		Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE, OwnerFullName: "demo-image-app",
+		Version: "v1.0.0", BuildId: build.BuildId, IdempotencyKey: "retry-begin-1",
+	}); err != nil {
+		t.Fatalf("first BeginPublish: %v", err)
+	}
+
+	failed, err := artifactSrv.FailPublish(ctx, &pb.FailPublishRequest{
+		Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE, OwnerFullName: "demo-image-app",
+		Version: "v1.0.0", Reason: "push failed", IdempotencyKey: "retry-fail",
+	})
+	if err != nil {
+		t.Fatalf("FailPublish: %v", err)
+	}
+	if failed.Artifact.State != pb.ArtifactState_ARTIFACT_STATE_FAILED {
+		t.Fatalf("expected state FAILED, got %v", failed.Artifact.State)
+	}
+	if failed.Artifact.FailReason != "push failed" {
+		t.Fatalf("expected fail_reason to be recorded, got %q", failed.Artifact.FailReason)
+	}
+
+	retried, err := artifactSrv.BeginPublish(ctx, &pb.BeginPublishRequest{
+		Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE, OwnerFullName: "demo-image-app",
+		Version: "v1.0.0", BuildId: build.BuildId, IdempotencyKey: "retry-begin-2",
+	})
+	if err != nil {
+		t.Fatalf("retry BeginPublish (failed -> publishing): %v", err)
+	}
+	if retried.Artifact.State != pb.ArtifactState_ARTIFACT_STATE_PUBLISHING {
+		t.Fatalf("expected state PUBLISHING after retry, got %v", retried.Artifact.State)
+	}
+	if retried.Artifact.FailReason != "" {
+		t.Fatalf("expected fail_reason cleared after a successful retry, got %q", retried.Artifact.FailReason)
+	}
+}
+
+// TestRecordArtifact_RejectsAtNonObserveStageWithoutPriorRow proves the
+// AR-7b backward-compat boundary precisely: RecordArtifact's
+// create-directly-as-published fallback is legal ONLY at adoption stage
+// observe -- ARCHITECTURE.md "Backward compatibility during rollout".
+func TestRecordArtifact_RejectsAtNonObserveStageWithoutPriorRow(t *testing.T) {
+	repo, artifactSrv := setupAllocate(t)
+	ctx := authedCtx()
+	build := recordBuild(t, artifactSrv, "run-reject-non-observe")
+	repo.SetDomainAdoptionStage("demo", repository.DomainAdoptionStagePromote)
+
+	_, err := artifactSrv.RecordArtifact(ctx, &pb.RecordArtifactRequest{
+		BuildId: build.BuildId, Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE,
+		OwnerFullName: "demo-image-app", Digest: "sha256:reject-non-observe", Version: "v1.0.0",
+		IdempotencyKey: "reject-non-observe",
+	})
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("expected FailedPrecondition for a direct RecordArtifact create at stage 'promote' with no prior BeginPublish, got %v", err)
 	}
 }

--- a/tools/app_registry/server/handlers/authz_test.go
+++ b/tools/app_registry/server/handlers/authz_test.go
@@ -230,6 +230,56 @@ func TestRecordArtifact_Authorization(t *testing.T) {
 	// which now runs authenticated as auth.AllRoles() via authedCtx().
 }
 
+// TestBeginPublish_Authorization and TestFailPublish_Authorization cover
+// ArtifactRegistry's AR-7b (issue #558) write RPCs, which require
+// RoleBuilder -- same boundary as RecordBuild/RecordArtifact: a promoter
+// credential must not be able to touch the artifact lifecycle either.
+func TestBeginPublish_Authorization(t *testing.T) {
+	req := &pb.BeginPublishRequest{
+		Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE, OwnerFullName: "demo-svc",
+		Version: "v1.0.0", BuildId: "authz-begin-publish-build",
+		IdempotencyKey: "authz-begin-publish",
+	}
+
+	t.Run("wrong role is PermissionDenied", func(t *testing.T) {
+		srv := NewArtifactServer(fake.New())
+		_, err := srv.BeginPublish(ctxWithRoles(auth.RolePromoterDev), req)
+		requireCode(t, err, codes.PermissionDenied, "BeginPublish")
+	})
+
+	t.Run("no claims is Unauthenticated", func(t *testing.T) {
+		srv := NewArtifactServer(fake.New())
+		_, err := srv.BeginPublish(context.Background(), req)
+		requireCode(t, err, codes.Unauthenticated, "BeginPublish")
+	})
+
+	// The "correct role allowed" case is covered end-to-end by
+	// artifact_test.go (owner resolution requires a real app).
+}
+
+func TestFailPublish_Authorization(t *testing.T) {
+	req := &pb.FailPublishRequest{
+		Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE, OwnerFullName: "demo-svc",
+		Version: "v1.0.0", Reason: "ci job cancelled",
+		IdempotencyKey: "authz-fail-publish",
+	}
+
+	t.Run("wrong role is PermissionDenied", func(t *testing.T) {
+		srv := NewArtifactServer(fake.New())
+		_, err := srv.FailPublish(ctxWithRoles(auth.RolePromoterDev), req)
+		requireCode(t, err, codes.PermissionDenied, "FailPublish")
+	})
+
+	t.Run("no claims is Unauthenticated", func(t *testing.T) {
+		srv := NewArtifactServer(fake.New())
+		_, err := srv.FailPublish(context.Background(), req)
+		requireCode(t, err, codes.Unauthenticated, "FailPublish")
+	})
+
+	// The "correct role allowed" case is covered end-to-end by
+	// artifact_test.go (owner resolution requires a real app).
+}
+
 // TestArtifactReads_RequireAuthenticationOnly covers ListArtifacts,
 // GetArtifact, and ResolveArtifact: any authenticated principal, no
 // specific role.

--- a/tools/app_registry/server/handlers/convert.go
+++ b/tools/app_registry/server/handlers/convert.go
@@ -82,6 +82,46 @@ func promotabilityToPB(p repository.Promotability) pb.Promotability {
 	}
 }
 
+// artifactStateToPB, artifactProvenanceToPB, versionSourceToPB: AR-7b
+// (issue #558) artifact lifecycle enum converters. See ArtifactState's doc
+// comment (models.go) for the transitions these values name.
+func artifactStateToPB(s repository.ArtifactState) pb.ArtifactState {
+	switch s {
+	case repository.ArtifactStateAllocated:
+		return pb.ArtifactState_ARTIFACT_STATE_ALLOCATED
+	case repository.ArtifactStatePublishing:
+		return pb.ArtifactState_ARTIFACT_STATE_PUBLISHING
+	case repository.ArtifactStatePublished:
+		return pb.ArtifactState_ARTIFACT_STATE_PUBLISHED
+	case repository.ArtifactStateFailed:
+		return pb.ArtifactState_ARTIFACT_STATE_FAILED
+	default:
+		return pb.ArtifactState_ARTIFACT_STATE_UNSPECIFIED
+	}
+}
+
+func artifactProvenanceToPB(p repository.ArtifactProvenance) pb.ArtifactProvenance {
+	switch p {
+	case repository.ArtifactProvenanceObserved:
+		return pb.ArtifactProvenance_ARTIFACT_PROVENANCE_OBSERVED
+	case repository.ArtifactProvenanceAdopted:
+		return pb.ArtifactProvenance_ARTIFACT_PROVENANCE_ADOPTED
+	default:
+		return pb.ArtifactProvenance_ARTIFACT_PROVENANCE_UNSPECIFIED
+	}
+}
+
+func versionSourceToPB(v repository.VersionSource) pb.VersionSource {
+	switch v {
+	case repository.VersionSourceRegistry:
+		return pb.VersionSource_VERSION_SOURCE_REGISTRY
+	case repository.VersionSourceTag:
+		return pb.VersionSource_VERSION_SOURCE_TAG
+	default:
+		return pb.VersionSource_VERSION_SOURCE_UNSPECIFIED
+	}
+}
+
 func appToPB(a repository.App) *pb.App {
 	return &pb.App{
 		AppId:           a.AppID,
@@ -169,14 +209,19 @@ func artifactLinkToPB(l repository.ArtifactLink) *pb.ArtifactLink {
 
 func artifactToPB(a repository.Artifact) *pb.Artifact {
 	out := &pb.Artifact{
-		ArtifactId:    a.ArtifactID,
-		Kind:          artifactKindToPB(a.Kind),
-		Repository:    a.Repository,
-		Version:       a.Version,
-		Digest:        a.Digest,
-		BuildId:       a.BuildID,
-		PublishedAt:   timeToUnix(a.PublishedAt),
-		Promotability: promotabilityToPB(a.Promotability),
+		ArtifactId:     a.ArtifactID,
+		Kind:           artifactKindToPB(a.Kind),
+		Repository:     a.Repository,
+		Version:        a.Version,
+		Digest:         a.Digest,
+		BuildId:        a.BuildID,
+		PublishedAt:    timeToUnix(a.PublishedAt),
+		Promotability:  promotabilityToPB(a.Promotability),
+		State:          artifactStateToPB(a.State),
+		Provenance:     artifactProvenanceToPB(a.Provenance),
+		VersionSource:  versionSourceToPB(a.VersionSource),
+		StateChangedAt: timeToUnix(a.StateChangedAt),
+		FailReason:     a.FailReason,
 	}
 	if a.Kind == repository.ArtifactKindImage {
 		out.AppId = a.AppID

--- a/tools/app_registry/server/repository/fake/fake.go
+++ b/tools/app_registry/server/repository/fake/fake.go
@@ -37,21 +37,22 @@ type idemEntry struct {
 // (rather than fields directly on Registry) so it round-trips through JSON
 // cleanly for a cheap deep copy.
 type state struct {
-	Apps            map[string]repository.App
-	Charts          map[string]repository.Chart
-	Builds          map[string]repository.Build
+	Apps   map[string]repository.App
+	Charts map[string]repository.Chart
+	Builds map[string]repository.Build
+	// Artifacts holds every state an artifact row can be in
+	// (allocated/publishing/published/failed -- see
+	// repository.ArtifactState's doc comment). As of AR-7b (migration 007)
+	// this is also where AllocateVersion writes its reservation -- the
+	// separate version_allocation table/map this fake used to mirror is
+	// gone, folded in here exactly as the real schema folded it into
+	// `artifact`.
 	Artifacts       map[string]repository.Artifact
 	Idempotency     map[string]idemEntry
 	Environments    map[string]repository.Environment     // keyed by environment_id
 	Promotions      map[string]repository.Promotion       // keyed by promotion_id
 	PromotionEvents map[string]repository.PromotionEvent  // keyed by event_id
 	WritebackOutbox map[string]repository.WritebackOutbox // keyed by outbox_id
-	// VersionAllocations mirrors postgres's version_allocation table: the
-	// reservation ledger AllocateVersion writes to, keyed by
-	// "<owner_id>/<kind>/<version>" -- see
-	// repository/postgres/artifact.go's AllocateVersion doc comment for why
-	// this isn't just the Artifacts map.
-	VersionAllocations map[string]repository.VersionAllocation
 	// DomainAdoption mirrors the `domain_adoption` table, keyed by domain.
 	// Absent means DomainAdoptionStageObserve -- see
 	// DomainAdoptionRepository.GetStage's doc comment.
@@ -68,17 +69,16 @@ type state struct {
 
 func newState() *state {
 	return &state{
-		Apps:               map[string]repository.App{},
-		Charts:             map[string]repository.Chart{},
-		Builds:             map[string]repository.Build{},
-		Artifacts:          map[string]repository.Artifact{},
-		Idempotency:        map[string]idemEntry{},
-		Environments:       map[string]repository.Environment{},
-		Promotions:         map[string]repository.Promotion{},
-		PromotionEvents:    map[string]repository.PromotionEvent{},
-		WritebackOutbox:    map[string]repository.WritebackOutbox{},
-		VersionAllocations: map[string]repository.VersionAllocation{},
-		DomainAdoption:     map[string]repository.DomainAdoptionStage{},
+		Apps:            map[string]repository.App{},
+		Charts:          map[string]repository.Chart{},
+		Builds:          map[string]repository.Build{},
+		Artifacts:       map[string]repository.Artifact{},
+		Idempotency:     map[string]idemEntry{},
+		Environments:    map[string]repository.Environment{},
+		Promotions:      map[string]repository.Promotion{},
+		PromotionEvents: map[string]repository.PromotionEvent{},
+		WritebackOutbox: map[string]repository.WritebackOutbox{},
+		DomainAdoption:  map[string]repository.DomainAdoptionStage{},
 	}
 }
 
@@ -307,57 +307,61 @@ func (r *Registry) GetBuild(ctx context.Context, buildID string) (*repository.Bu
 // ArtifactRepository
 // ============================================================================
 
-func (r *Registry) RecordArtifact(ctx context.Context, a repository.Artifact, contains []repository.ContainedImageInput) (*repository.Artifact, bool, error) {
+// RecordArtifact mirrors postgres's artifactRepo.RecordArtifact -- the
+// publishing -> published transition, plus (at adoption stage "observe"
+// only) the backward-compatible direct-create path. See
+// repository.ArtifactRepository.RecordArtifact's doc comment for the full
+// state-machine contract.
+func (r *Registry) RecordArtifact(ctx context.Context, a repository.Artifact, contains []repository.ContainedImageInput, domainStage repository.DomainAdoptionStage) (*repository.Artifact, bool, error) {
 	for _, existing := range r.state.Artifacts {
-		if existing.Digest == a.Digest {
+		// digest is empty on every non-published row (mirrors migration
+		// 007's artifact_state_shape CHECK) -- guard explicitly rather than
+		// relying on a.Digest never being "" too, which happens to be true
+		// today but shouldn't be load-bearing.
+		if existing.Digest != "" && existing.Digest == a.Digest {
 			out := existing
 			out.Promotability = r.derivePromotability(existing)
 			return &out, true, nil
 		}
 	}
 
-	// Mirrors postgres's UNIQUE INDEX artifact_version_idx (owner_id, kind,
-	// version): a fresh digest for an (owner, kind, version) already claimed
-	// by a different artifact is a conflict, not a new row. This is the
-	// AR-5 "someone else took this version" path — see
-	// repository/postgres/errors.go's doc comment.
-	if existing, found := r.findByOwnerKindVersion(a); found {
-		return nil, false, fmt.Errorf("%w: artifact %s %s already recorded", repository.ErrAlreadyExists, r.ownerFullName(existing), existing.Version)
-	}
-
-	a.ArtifactID = uuid.NewString()
-
-	if a.Kind == repository.ArtifactKindChart {
-		links := make([]repository.ArtifactLink, 0, len(contains))
-		for _, ci := range contains {
-			img, err := r.findImageByDigest(ci.Digest)
-			if err != nil {
-				return nil, false, err
-			}
-			links = append(links, repository.ArtifactLink{
-				ImageArtifactID: img.ArtifactID,
-				AppID:           img.AppID,
-				Repository:      ci.Repository,
-				Version:         ci.Version,
-				Digest:          ci.Digest,
-			})
+	existing, found := r.findByOwnerKindVersion(a.Kind, ownerID(a), a.Version)
+	if !found {
+		// No row at all for this (owner, kind, version). Creating directly
+		// as "published" is the pre-AR-7b behaviour, kept only for domains
+		// still at adoption stage "observe" -- see ARCHITECTURE.md
+		// "Backward compatibility during rollout".
+		if domainStage != repository.DomainAdoptionStageObserve {
+			return nil, false, fmt.Errorf("%w: no publishing artifact found for %s %s -- BeginPublish must run before RecordArtifact once a domain has left adoption stage \"observe\"",
+				repository.ErrFailedPrecondition, r.ownerFullName(a), a.Version)
 		}
-		a.Contains = links
+		out, err := r.insertArtifact(a, contains, repository.ArtifactStatePublished, repository.VersionSourceTag)
+		return out, false, err
 	}
 
-	r.state.Artifacts[a.ArtifactID] = a
-	out := a
-	out.Promotability = r.derivePromotability(a)
-	return &out, false, nil
+	switch existing.State {
+	case repository.ArtifactStatePublishing:
+		out, err := r.completePublish(existing, a, contains)
+		return out, false, err
+	case repository.ArtifactStatePublished:
+		// Reached only when the digest lookup above missed -- i.e. a
+		// DIFFERENT digest than what is already published for this
+		// (owner, kind, version). A real conflict, not a retry.
+		return nil, false, fmt.Errorf("%w: artifact %s %s already published with digest %s",
+			repository.ErrAlreadyExists, r.ownerFullName(existing), a.Version, existing.Digest)
+	default: // allocated, failed
+		return nil, false, fmt.Errorf("%w: artifact %s %s is %q -- BeginPublish must transition it to \"publishing\" before RecordArtifact can complete it",
+			repository.ErrFailedPrecondition, r.ownerFullName(existing), a.Version, existing.State)
+	}
 }
 
-// findByOwnerKindVersion looks up an existing artifact sharing a's owner
-// (AppID for images, ChartID for charts), kind, and version — the collision
-// the real artifact_version_idx unique index enforces.
-func (r *Registry) findByOwnerKindVersion(a repository.Artifact) (repository.Artifact, bool) {
-	owner := ownerID(a)
+// findByOwnerKindVersion looks up an existing artifact by owner (AppID for
+// images, ChartID for charts), kind, and version — the identity
+// BeginPublish/FailPublish/RecordArtifact all key off of, and the collision
+// the real artifact_version_idx unique index enforces regardless of state.
+func (r *Registry) findByOwnerKindVersion(kind repository.ArtifactKind, owner, version string) (repository.Artifact, bool) {
 	for _, existing := range r.state.Artifacts {
-		if existing.Kind == a.Kind && existing.Version == a.Version && ownerID(existing) == owner {
+		if existing.Kind == kind && existing.Version == version && ownerID(existing) == owner {
 			return existing, true
 		}
 	}
@@ -371,25 +375,95 @@ func ownerID(a repository.Artifact) string {
 	return a.ChartID
 }
 
-// syntheticOwnerArtifact builds a zero artifact carrying just enough (Kind +
-// owner id in the right field + Version) to reuse ownerID()/
-// findByOwnerKindVersion()'s existing owner-matching logic — AllocateVersion
-// only ever has an ownerID, not a full Artifact, to look up with.
-func syntheticOwnerArtifact(kind repository.ArtifactKind, ownerID, version string) repository.Artifact {
-	a := repository.Artifact{Kind: kind, Version: version}
-	if kind == repository.ArtifactKindImage {
-		a.AppID = ownerID
-	} else {
-		a.ChartID = ownerID
+// insertArtifact mirrors postgres's artifactRepo.insertArtifact: writes a
+// brand-new artifact row directly in state, with versionSource and
+// Provenance "observed" -- shared by RecordArtifact's direct-create path,
+// BeginPublish's ∅ -> publishing branch, and AllocateVersion's ∅ ->
+// allocated write.
+func (r *Registry) insertArtifact(a repository.Artifact, contains []repository.ContainedImageInput, state repository.ArtifactState, versionSource repository.VersionSource) (*repository.Artifact, error) {
+	a.ArtifactID = uuid.NewString()
+	a.State = state
+	a.Provenance = repository.ArtifactProvenanceObserved
+	a.VersionSource = versionSource
+	a.StateChangedAt = timeNow()
+	if state == repository.ArtifactStatePublished && a.PublishedAt.IsZero() {
+		a.PublishedAt = timeNow()
 	}
-	return a
+
+	if a.Kind == repository.ArtifactKindChart && state == repository.ArtifactStatePublished {
+		links, err := r.linkContains(contains)
+		if err != nil {
+			return nil, err
+		}
+		a.Contains = links
+	}
+
+	r.state.Artifacts[a.ArtifactID] = a
+	out := a
+	out.Promotability = r.derivePromotability(a)
+	return &out, nil
 }
 
-// AllocateVersion mirrors postgres's artifactRepo.AllocateVersion: "next" is
-// computed from the highest version already claimed for (ownerID, kind)
-// across both real artifacts and prior allocations, so an
+// completePublish mirrors postgres's artifactRepo.completePublish: the
+// publishing -> published transition against an EXISTING row.
+func (r *Registry) completePublish(existing, a repository.Artifact, contains []repository.ContainedImageInput) (*repository.Artifact, error) {
+	updated := existing
+	updated.Digest = a.Digest
+	if a.BuildID != "" {
+		updated.BuildID = a.BuildID
+	}
+	updated.PublishedAt = a.PublishedAt
+	if updated.PublishedAt.IsZero() {
+		updated.PublishedAt = timeNow()
+	}
+	updated.State = repository.ArtifactStatePublished
+	updated.StateChangedAt = timeNow()
+
+	if updated.Kind == repository.ArtifactKindChart {
+		links, err := r.linkContains(contains)
+		if err != nil {
+			return nil, err
+		}
+		updated.Contains = links
+	}
+
+	r.state.Artifacts[updated.ArtifactID] = updated
+	out := updated
+	out.Promotability = r.derivePromotability(updated)
+	return &out, nil
+}
+
+// linkContains mirrors postgres's artifactRepo.linkContains: resolves each
+// contains entry to an already-PUBLISHED image artifact, building the
+// ArtifactLink slice a chart artifact carries. Unlike postgres this fake
+// has no separate artifact_link table to write to -- Contains is stored
+// directly on the chart's Artifact struct (see models.go).
+func (r *Registry) linkContains(contains []repository.ContainedImageInput) ([]repository.ArtifactLink, error) {
+	links := make([]repository.ArtifactLink, 0, len(contains))
+	for _, ci := range contains {
+		img, err := r.findImageByDigest(ci.Digest)
+		if err != nil {
+			return nil, err
+		}
+		links = append(links, repository.ArtifactLink{
+			ImageArtifactID: img.ArtifactID,
+			AppID:           img.AppID,
+			Repository:      ci.Repository,
+			Version:         ci.Version,
+			Digest:          ci.Digest,
+		})
+	}
+	return links, nil
+}
+
+// AllocateVersion mirrors postgres's artifactRepo.AllocateVersion. As of
+// AR-7b this writes the ∅ -> allocated `artifact` row directly (via
+// insertArtifact) instead of to a separate version_allocation map -- "next"
+// is computed from the highest version already claimed for (ownerID, kind)
+// against r.state.Artifacts alone, which now covers both already-published
+// versions and reserved-but-not-yet-published ones in one place, so an
 // allocated-but-not-yet-recorded version is never handed out twice.
-func (r *Registry) AllocateVersion(ctx context.Context, kind repository.ArtifactKind, owner, increment, explicitVersion string) (*repository.VersionAllocation, error) {
+func (r *Registry) AllocateVersion(ctx context.Context, kind repository.ArtifactKind, owner, repo, increment, explicitVersion string) (*repository.VersionAllocation, error) {
 	var hasPrevious bool
 	var previous semver.Version
 	var previousText string
@@ -407,12 +481,6 @@ func (r *Registry) AllocateVersion(ctx context.Context, kind repository.Artifact
 	for _, a := range r.state.Artifacts {
 		if a.Kind == kind && owner == ownerID(a) {
 			consider(a.Version)
-		}
-	}
-	prefix := owner + "/" + string(kind) + "/"
-	for key, alloc := range r.state.VersionAllocations {
-		if len(key) >= len(prefix) && key[:len(prefix)] == prefix {
-			consider(alloc.Version)
 		}
 	}
 
@@ -436,21 +504,99 @@ func (r *Registry) AllocateVersion(ctx context.Context, kind repository.Artifact
 	}
 
 	versionStr := next.String()
-	key := prefix + versionStr
-	if _, exists := r.state.VersionAllocations[key]; exists {
-		return nil, fmt.Errorf("%w: version %s is already allocated or recorded for this owner", repository.ErrAlreadyExists, versionStr)
-	}
-	if _, found := r.findByOwnerKindVersion(syntheticOwnerArtifact(kind, owner, versionStr)); found {
+	if _, found := r.findByOwnerKindVersion(kind, owner, versionStr); found {
 		return nil, fmt.Errorf("%w: version %s is already allocated or recorded for this owner", repository.ErrAlreadyExists, versionStr)
 	}
 
-	r.state.VersionAllocations[key] = repository.VersionAllocation{Version: versionStr, PreviousVersion: previousText}
+	a := repository.Artifact{Kind: kind, Repository: repo, Version: versionStr}
+	if kind == repository.ArtifactKindImage {
+		a.AppID = owner
+	} else {
+		a.ChartID = owner
+	}
+	if _, err := r.insertArtifact(a, nil, repository.ArtifactStateAllocated, repository.VersionSourceRegistry); err != nil {
+		return nil, err
+	}
+
 	return &repository.VersionAllocation{Version: versionStr, PreviousVersion: previousText}, nil
+}
+
+// ============================================================================
+// BeginPublish / FailPublish / ExpireStale (AR-7b)
+// ============================================================================
+
+// BeginPublish mirrors postgres's artifactRepo.BeginPublish -- the
+// ∅|allocated|failed -> publishing transition.
+func (r *Registry) BeginPublish(ctx context.Context, kind repository.ArtifactKind, owner, version, buildID, repositoryHint string, versionSource repository.VersionSource) (*repository.Artifact, error) {
+	existing, found := r.findByOwnerKindVersion(kind, owner, version)
+	if !found {
+		if repositoryHint == "" {
+			return nil, fmt.Errorf("%w: repository is required to begin publishing %s %s with no prior allocation", repository.ErrInvalidArgument, string(kind), version)
+		}
+		a := repository.Artifact{Kind: kind, Repository: repositoryHint, Version: version, BuildID: buildID}
+		if kind == repository.ArtifactKindImage {
+			a.AppID = owner
+		} else {
+			a.ChartID = owner
+		}
+		return r.insertArtifact(a, nil, repository.ArtifactStatePublishing, versionSource)
+	}
+
+	if existing.State != repository.ArtifactStateAllocated && existing.State != repository.ArtifactStateFailed {
+		return nil, fmt.Errorf("%w: artifact %s %s is %q, not \"allocated\" or \"failed\" -- BeginPublish cannot start from here",
+			repository.ErrFailedPrecondition, r.ownerFullName(existing), version, existing.State)
+	}
+
+	existing.BuildID = buildID
+	existing.State = repository.ArtifactStatePublishing
+	existing.StateChangedAt = timeNow()
+	existing.FailReason = ""
+	r.state.Artifacts[existing.ArtifactID] = existing
+	out := existing
+	out.Promotability = r.derivePromotability(existing)
+	return &out, nil
+}
+
+// FailPublish mirrors postgres's artifactRepo.FailPublish -- the
+// publishing -> failed transition.
+func (r *Registry) FailPublish(ctx context.Context, kind repository.ArtifactKind, owner, version, reason string) (*repository.Artifact, error) {
+	existing, found := r.findByOwnerKindVersion(kind, owner, version)
+	if !found {
+		return nil, fmt.Errorf("%w: no artifact found for %s %s %s", repository.ErrFailedPrecondition, string(kind), owner, version)
+	}
+	if existing.State != repository.ArtifactStatePublishing {
+		return nil, fmt.Errorf("%w: artifact %s %s is %q, not \"publishing\" -- FailPublish cannot start from here",
+			repository.ErrFailedPrecondition, r.ownerFullName(existing), version, existing.State)
+	}
+	existing.State = repository.ArtifactStateFailed
+	existing.StateChangedAt = timeNow()
+	existing.FailReason = reason
+	r.state.Artifacts[existing.ArtifactID] = existing
+	out := existing
+	out.Promotability = r.derivePromotability(existing)
+	return &out, nil
+}
+
+// ExpireStale mirrors postgres's artifactRepo.ExpireStale -- the reaper's
+// sweep.
+func (r *Registry) ExpireStale(ctx context.Context, olderThan time.Duration) (int, error) {
+	cutoff := timeNow().Add(-olderThan)
+	n := 0
+	for id, a := range r.state.Artifacts {
+		if (a.State == repository.ArtifactStateAllocated || a.State == repository.ArtifactStatePublishing) && a.StateChangedAt.Before(cutoff) {
+			a.State = repository.ArtifactStateFailed
+			a.StateChangedAt = timeNow()
+			a.FailReason = "stale"
+			r.state.Artifacts[id] = a
+			n++
+		}
+	}
+	return n, nil
 }
 
 func (r *Registry) findImageByDigest(digest string) (*repository.Artifact, error) {
 	for _, a := range r.state.Artifacts {
-		if a.Digest == digest && a.Kind == repository.ArtifactKindImage {
+		if a.Digest == digest && a.Kind == repository.ArtifactKindImage && a.State == repository.ArtifactStatePublished {
 			return &a, nil
 		}
 	}

--- a/tools/app_registry/server/repository/models.go
+++ b/tools/app_registry/server/repository/models.go
@@ -153,7 +153,56 @@ type ArtifactLink struct {
 	Digest          string
 }
 
-// Artifact is a published, digest-addressable image or chart.
+// ArtifactState is the AR-7b artifact lifecycle -- see ARCHITECTURE.md
+// "Artifact lifecycle: allocated -> publishing -> published" and migration
+// 007. Legal transitions, enforced server-side in
+// server/repository/postgres/artifact.go and mirrored in
+// server/repository/fake/fake.go: ∅ -> allocated (AllocateVersion), ∅ ->
+// publishing (BeginPublish with no prior allocation -- the pre-cutover
+// path), allocated -> publishing (BeginPublish), publishing -> published
+// (RecordArtifact), publishing -> failed (FailPublish, or the reaper),
+// failed -> publishing (a later run retrying the same version). published
+// is terminal; anything else is FailedPrecondition.
+type ArtifactState string
+
+const (
+	ArtifactStateAllocated  ArtifactState = "allocated"
+	ArtifactStatePublishing ArtifactState = "publishing"
+	ArtifactStatePublished  ArtifactState = "published"
+	ArtifactStateFailed     ArtifactState = "failed"
+)
+
+// ArtifactProvenance mirrors artifact.provenance (migration 007):
+// "observed" (the normal case -- the registry watched this get published)
+// vs "adopted" (AR-7e's AdoptArtifact, not implemented in this phase --
+// see PLAN.md's AR-7e). Every row this phase writes is "observed"; the
+// column exists now so migration 007 doesn't need a second pass later.
+type ArtifactProvenance string
+
+const (
+	ArtifactProvenanceObserved ArtifactProvenance = "observed"
+	ArtifactProvenanceAdopted  ArtifactProvenance = "adopted"
+)
+
+// VersionSource mirrors artifact.version_source (migration 007): which
+// path authored this row's version. "registry" means AllocateVersion (AR-5)
+// reserved it; "tag" means the pre-cutover git-tag path in
+// tools/release_helper_go chose it and the registry is merely recording the
+// intent -- see ARCHITECTURE.md "The run log" and PLAN.md's AR-5 parity
+// exit criterion, which this column turns into a query.
+type VersionSource string
+
+const (
+	VersionSourceRegistry VersionSource = "registry"
+	VersionSourceTag      VersionSource = "tag"
+)
+
+// Artifact is a published, digest-addressable image or chart -- or, as of
+// AR-7b, the record of an in-flight or failed attempt to publish one. See
+// ArtifactState's doc comment for the lifecycle. Digest/BuildID/PublishedAt
+// are empty/zero until State reaches the point migration 007's
+// artifact_state_shape CHECK constraint requires them (BuildID from
+// "publishing" onward, Digest/PublishedAt only once "published").
 type Artifact struct {
 	ArtifactID  string
 	Kind        ArtifactKind
@@ -161,9 +210,19 @@ type Artifact struct {
 	ChartID     string // set when Kind == ArtifactKindChart
 	Repository  string
 	Version     string
-	Digest      string
-	BuildID     string
+	Digest      string // empty until State == ArtifactStatePublished
+	BuildID     string // empty while State == ArtifactStateAllocated
 	PublishedAt time.Time
+
+	State          ArtifactState
+	Provenance     ArtifactProvenance
+	VersionSource  VersionSource
+	StateChangedAt time.Time
+	// FailReason is set by FailPublish (caller-supplied) or the reaper
+	// (hardcoded "stale" -- see ARCHITECTURE.md "The reaper is not
+	// optional"). Free text for operator diagnosis; empty outside
+	// State == ArtifactStateFailed.
+	FailReason string
 
 	// Promotability is DERIVED — computed at read time from the owner's
 	// DeployUnit, never persisted. Populated by repository read methods.

--- a/tools/app_registry/server/repository/postgres/artifact.go
+++ b/tools/app_registry/server/repository/postgres/artifact.go
@@ -92,8 +92,12 @@ type artifactRepo struct{ ex dbtx }
 // artifactRow is what every artifact SELECT returns: the artifact plus the
 // owning app's/chart's deploy_unit, which is all repository.DerivePromotability
 // needs. Promotability is never persisted — see ARCHITECTURE.md "Promotability".
+// digest/build_id/published_at are nullable as of migration 007 (AR-7b) —
+// an "allocated" row has neither, a "publishing" row has a build but no
+// digest — so they scan into pointers and get zero-valued below.
 const artifactSelectBase = `
 	SELECT a.artifact_id, a.kind, a.app_id, a.chart_id, a.repository, a.version, a.digest, a.build_id, a.published_at,
+	       a.state, a.provenance, a.version_source, a.state_changed_at, a.fail_reason,
 	       COALESCE(app.deploy_unit, chart.deploy_unit) AS owner_deploy_unit
 	FROM artifact a
 	LEFT JOIN app ON a.app_id = app.app_id
@@ -101,18 +105,35 @@ const artifactSelectBase = `
 
 func scanArtifact(row pgx.Row) (repository.Artifact, error) {
 	var a repository.Artifact
-	var kind string
-	var appID, chartID *string
+	var kind, state, provenance, versionSource string
+	var appID, chartID, digest, buildID *string
+	var publishedAt *time.Time
 	var ownerDeployUnit *string
-	if err := row.Scan(&a.ArtifactID, &kind, &appID, &chartID, &a.Repository, &a.Version, &a.Digest, &a.BuildID, &a.PublishedAt, &ownerDeployUnit); err != nil {
+	if err := row.Scan(
+		&a.ArtifactID, &kind, &appID, &chartID, &a.Repository, &a.Version, &digest, &buildID, &publishedAt,
+		&state, &provenance, &versionSource, &a.StateChangedAt, &a.FailReason,
+		&ownerDeployUnit,
+	); err != nil {
 		return repository.Artifact{}, err
 	}
 	a.Kind = repository.ArtifactKind(kind)
+	a.State = repository.ArtifactState(state)
+	a.Provenance = repository.ArtifactProvenance(provenance)
+	a.VersionSource = repository.VersionSource(versionSource)
 	if appID != nil {
 		a.AppID = *appID
 	}
 	if chartID != nil {
 		a.ChartID = *chartID
+	}
+	if digest != nil {
+		a.Digest = *digest
+	}
+	if buildID != nil {
+		a.BuildID = *buildID
+	}
+	if publishedAt != nil {
+		a.PublishedAt = *publishedAt
 	}
 	var du appmetapb.DeployUnit
 	if ownerDeployUnit != nil {
@@ -122,7 +143,15 @@ func scanArtifact(row pgx.Row) (repository.Artifact, error) {
 	return a, nil
 }
 
-func (r *artifactRepo) RecordArtifact(ctx context.Context, a repository.Artifact, contains []repository.ContainedImageInput) (*repository.Artifact, bool, error) {
+// RecordArtifact implements repository.ArtifactRepository.RecordArtifact —
+// the publishing -> published transition, plus (at adoption stage
+// "observe" only) the backward-compatible direct-create path. See the
+// interface doc comment for the full state-machine contract.
+func (r *artifactRepo) RecordArtifact(ctx context.Context, a repository.Artifact, contains []repository.ContainedImageInput, domainStage repository.DomainAdoptionStage) (*repository.Artifact, bool, error) {
+	// 1. Idempotent replay: an existing row with this EXACT digest. Only a
+	// "published" row can ever match here (digest is NULL on every other
+	// state, per migration 007's artifact_state_shape CHECK), so this is
+	// unambiguously "already recorded", regardless of adoption stage.
 	row := r.ex.QueryRow(ctx, artifactSelectBase+` WHERE a.digest = $1`, a.Digest)
 	if existing, err := scanArtifact(row); err == nil {
 		if existing.Kind == repository.ArtifactKindChart {
@@ -137,8 +166,78 @@ func (r *artifactRepo) RecordArtifact(ctx context.Context, a repository.Artifact
 		return nil, false, err
 	}
 
+	// 2. No row shares this digest. Look for one by (owner, kind, version)
+	// instead — the state machine's completion/conflict path.
+	existing, everr := r.findByOwnerKindVersion(ctx, a.Kind, ownerIDOf(a), a.Version)
+	switch {
+	case errors.Is(everr, pgx.ErrNoRows):
+		// No row at all for this (owner, kind, version). Creating directly
+		// as "published" is the pre-AR-7b behaviour, kept only for domains
+		// still at adoption stage "observe" -- see ARCHITECTURE.md
+		// "Backward compatibility during rollout" and the interface doc
+		// comment. At any later stage BeginPublish must have run first.
+		if domainStage != repository.DomainAdoptionStageObserve {
+			return nil, false, fmt.Errorf("%w: no publishing artifact found for %s %s -- BeginPublish must run before RecordArtifact once a domain has left adoption stage \"observe\"",
+				repository.ErrFailedPrecondition, r.ownerFullName(ctx, a), a.Version)
+		}
+		out, _, err := r.insertArtifact(ctx, a, contains, repository.ArtifactStatePublished, repository.VersionSourceTag)
+		return out, false, err
+	case everr != nil:
+		return nil, false, everr
+	}
+
+	switch existing.State {
+	case repository.ArtifactStatePublishing:
+		out, err := r.completePublish(ctx, existing, a, contains)
+		return out, false, err
+	case repository.ArtifactStatePublished:
+		// Reached only when the digest lookup in step 1 missed -- i.e. a
+		// DIFFERENT digest than what is already published for this
+		// (owner, kind, version). A real conflict, not a retry.
+		return nil, false, fmt.Errorf("%w: artifact %s %s already published with digest %s",
+			repository.ErrAlreadyExists, r.ownerFullName(ctx, existing), a.Version, existing.Digest)
+	default: // allocated, failed
+		return nil, false, fmt.Errorf("%w: artifact %s %s is %q -- BeginPublish must transition it to \"publishing\" before RecordArtifact can complete it",
+			repository.ErrFailedPrecondition, r.ownerFullName(ctx, existing), a.Version, existing.State)
+	}
+}
+
+// findByOwnerKindVersion looks up the artifact row for (kind, ownerID,
+// version) regardless of state, matching the real artifact_version_idx
+// UNIQUE (owner_id, kind, version) index (migration 001) -- the same
+// identity BeginPublish/FailPublish/RecordArtifact all key off of. Returns
+// pgx.ErrNoRows (unwrapped) when no row exists, so callers can
+// errors.Is(err, pgx.ErrNoRows) directly.
+func (r *artifactRepo) findByOwnerKindVersion(ctx context.Context, kind repository.ArtifactKind, ownerID, version string) (repository.Artifact, error) {
+	row := r.ex.QueryRow(ctx, artifactSelectBase+`
+		WHERE a.kind = $1 AND a.version = $2 AND a.owner_id = $3`,
+		string(kind), version, ownerID)
+	return scanArtifact(row)
+}
+
+func ownerIDOf(a repository.Artifact) string {
+	if a.Kind == repository.ArtifactKindImage {
+		return a.AppID
+	}
+	return a.ChartID
+}
+
+// insertArtifact writes a brand-new artifact row directly in state, with
+// versionSource and Provenance "observed" (the only provenance this phase
+// ever writes -- see ArtifactProvenance's doc comment). digest/build_id/
+// published_at are written NULL when the corresponding field on a is empty
+// -- correct for "allocated" (neither) and "publishing" (build_id only);
+// contains is only consulted when state == published (RecordArtifact's
+// direct-create path); BeginPublish and AllocateVersion always pass nil.
+// Shared by RecordArtifact's direct-create path, BeginPublish's ∅ ->
+// publishing branch, and AllocateVersion's ∅ -> allocated write.
+func (r *artifactRepo) insertArtifact(ctx context.Context, a repository.Artifact, contains []repository.ContainedImageInput, state repository.ArtifactState, versionSource repository.VersionSource) (*repository.Artifact, bool, error) {
 	a.ArtifactID = uuid.NewString()
-	if a.PublishedAt.IsZero() {
+	a.State = state
+	a.Provenance = repository.ArtifactProvenanceObserved
+	a.VersionSource = versionSource
+	a.StateChangedAt = time.Now().UTC()
+	if state == repository.ArtifactStatePublished && a.PublishedAt.IsZero() {
 		a.PublishedAt = time.Now().UTC()
 	}
 
@@ -148,6 +247,17 @@ func (r *artifactRepo) RecordArtifact(ctx context.Context, a repository.Artifact
 	} else {
 		chartID = a.ChartID
 	}
+	var digest, buildID, publishedAt any
+	if a.Digest != "" {
+		digest = a.Digest
+	}
+	if a.BuildID != "" {
+		buildID = a.BuildID
+	}
+	if !a.PublishedAt.IsZero() {
+		publishedAt = a.PublishedAt
+	}
+
 	// Resolve the owner's display name *before* the insert. A constraint
 	// violation aborts the surrounding transaction, so any query issued
 	// afterwards fails too and ownerFullName would degrade to the raw UUID —
@@ -156,9 +266,11 @@ func (r *artifactRepo) RecordArtifact(ctx context.Context, a repository.Artifact
 	versionMajor, versionMinor, versionPatch := parseVersionTriple(a.Version)
 
 	if _, err := r.ex.Exec(ctx, `
-		INSERT INTO artifact (artifact_id, kind, app_id, chart_id, repository, version, digest, build_id, published_at, version_major, version_minor, version_patch)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`,
-		a.ArtifactID, string(a.Kind), appID, chartID, a.Repository, a.Version, a.Digest, a.BuildID, a.PublishedAt, versionMajor, versionMinor, versionPatch); err != nil {
+		INSERT INTO artifact (artifact_id, kind, app_id, chart_id, repository, version, digest, build_id, published_at,
+		                       version_major, version_minor, version_patch, state, provenance, version_source, state_changed_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)`,
+		a.ArtifactID, string(a.Kind), appID, chartID, a.Repository, a.Version, digest, buildID, publishedAt,
+		versionMajor, versionMinor, versionPatch, string(a.State), string(a.Provenance), string(a.VersionSource), a.StateChangedAt); err != nil {
 		msg := fmt.Sprintf("artifact %s %s already recorded", ownerName, a.Version)
 		if de, ok := translatePgError(err, msg); ok {
 			return nil, false, de
@@ -166,38 +278,10 @@ func (r *artifactRepo) RecordArtifact(ctx context.Context, a repository.Artifact
 		return nil, false, fmt.Errorf("record artifact %s: %w", a.Digest, err)
 	}
 
-	if a.Kind == repository.ArtifactKindChart {
-		links := make([]repository.ArtifactLink, 0, len(contains))
-		for _, ci := range contains {
-			imgRow := r.ex.QueryRow(ctx, `SELECT artifact_id, app_id FROM artifact WHERE digest = $1 AND kind = 'image'`, ci.Digest)
-			var imgArtifactID string
-			var imgAppID *string
-			if err := imgRow.Scan(&imgArtifactID, &imgAppID); err != nil {
-				if errors.Is(err, pgx.ErrNoRows) {
-					return nil, false, fmt.Errorf("%w: chart pins unrecorded image digest %s", repository.ErrInvalidArgument, ci.Digest)
-				}
-				return nil, false, err
-			}
-			imgApp := ""
-			if imgAppID != nil {
-				imgApp = *imgAppID
-			}
-			if _, err := r.ex.Exec(ctx, `
-				INSERT INTO artifact_link (chart_artifact_id, image_artifact_id, app_id, repository, version, digest)
-				VALUES ($1, $2, $3, $4, $5, $6)`,
-				a.ArtifactID, imgArtifactID, imgApp, ci.Repository, ci.Version, ci.Digest); err != nil {
-				msg := fmt.Sprintf("artifact %s already pins image digest %s", a.Digest, ci.Digest)
-				if de, ok := translatePgError(err, msg); ok {
-					return nil, false, de
-				}
-				return nil, false, fmt.Errorf("link chart artifact %s to image %s: %w", a.ArtifactID, ci.Digest, err)
-			}
-			links = append(links, repository.ArtifactLink{
-				ImageArtifactID: imgArtifactID, AppID: imgApp,
-				Repository: ci.Repository, Version: ci.Version, Digest: ci.Digest,
-			})
+	if a.Kind == repository.ArtifactKindChart && state == repository.ArtifactStatePublished {
+		if err := r.linkContains(ctx, a.ArtifactID, a.Digest, contains); err != nil {
+			return nil, false, err
 		}
-		a.Contains = links
 	}
 
 	// Re-derive promotability against the freshly-read owner deploy_unit,
@@ -207,6 +291,160 @@ func (r *artifactRepo) RecordArtifact(ctx context.Context, a repository.Artifact
 		return nil, false, err
 	}
 	return out, false, nil
+}
+
+// completePublish is the publishing -> published transition RecordArtifact
+// performs against an EXISTING row: stamps digest/build_id/published_at,
+// flips state, and (for a chart) links contains -- exactly the work
+// insertArtifact's direct-create path does, just as an UPDATE instead of an
+// INSERT because the row (and its artifact_id) already exists.
+func (r *artifactRepo) completePublish(ctx context.Context, existing, a repository.Artifact, contains []repository.ContainedImageInput) (*repository.Artifact, error) {
+	publishedAt := a.PublishedAt
+	if publishedAt.IsZero() {
+		publishedAt = time.Now().UTC()
+	}
+	buildID := existing.BuildID
+	if a.BuildID != "" {
+		buildID = a.BuildID
+	}
+	now := time.Now().UTC()
+	if _, err := r.ex.Exec(ctx, `
+		UPDATE artifact SET digest = $1, build_id = $2, published_at = $3, state = 'published', state_changed_at = $4
+		WHERE artifact_id = $5`,
+		a.Digest, buildID, publishedAt, now, existing.ArtifactID); err != nil {
+		msg := fmt.Sprintf("artifact %s already recorded", a.Digest)
+		if de, ok := translatePgError(err, msg); ok {
+			return nil, de
+		}
+		return nil, fmt.Errorf("complete publish for artifact %s: %w", existing.ArtifactID, err)
+	}
+
+	if existing.Kind == repository.ArtifactKindChart {
+		if err := r.linkContains(ctx, existing.ArtifactID, a.Digest, contains); err != nil {
+			return nil, err
+		}
+	}
+
+	return r.GetArtifact(ctx, repository.ArtifactLookup{ArtifactID: existing.ArtifactID})
+}
+
+// linkContains inserts one artifact_link row per entry in contains,
+// pinning chartArtifactID to each already-PUBLISHED image digest. A chart
+// may not pin an image that either doesn't exist or hasn't reached
+// "published" yet (an allocated/publishing/failed image row has no digest
+// to pin in the first place) -- see ARCHITECTURE.md "The problem: four
+// cross-run orderings" #3.
+func (r *artifactRepo) linkContains(ctx context.Context, chartArtifactID, chartDigest string, contains []repository.ContainedImageInput) error {
+	for _, ci := range contains {
+		imgRow := r.ex.QueryRow(ctx, `SELECT artifact_id, app_id FROM artifact WHERE digest = $1 AND kind = 'image' AND state = 'published'`, ci.Digest)
+		var imgArtifactID string
+		var imgAppID *string
+		if err := imgRow.Scan(&imgArtifactID, &imgAppID); err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return fmt.Errorf("%w: chart pins unrecorded image digest %s", repository.ErrInvalidArgument, ci.Digest)
+			}
+			return err
+		}
+		imgApp := ""
+		if imgAppID != nil {
+			imgApp = *imgAppID
+		}
+		if _, err := r.ex.Exec(ctx, `
+			INSERT INTO artifact_link (chart_artifact_id, image_artifact_id, app_id, repository, version, digest)
+			VALUES ($1, $2, $3, $4, $5, $6)`,
+			chartArtifactID, imgArtifactID, imgApp, ci.Repository, ci.Version, ci.Digest); err != nil {
+			msg := fmt.Sprintf("artifact %s already pins image digest %s", chartDigest, ci.Digest)
+			if de, ok := translatePgError(err, msg); ok {
+				return de
+			}
+			return fmt.Errorf("link chart artifact %s to image %s: %w", chartArtifactID, ci.Digest, err)
+		}
+	}
+	return nil
+}
+
+// ============================================================================
+// BeginPublish / FailPublish / ExpireStale (AR-7b)
+// ============================================================================
+
+// BeginPublish implements repository.ArtifactRepository.BeginPublish -- the
+// ∅|allocated|failed -> publishing transition. See the interface doc
+// comment for the full contract.
+func (r *artifactRepo) BeginPublish(ctx context.Context, kind repository.ArtifactKind, ownerID, version, buildID, repositoryHint string, versionSource repository.VersionSource) (*repository.Artifact, error) {
+	existing, everr := r.findByOwnerKindVersion(ctx, kind, ownerID, version)
+	switch {
+	case errors.Is(everr, pgx.ErrNoRows):
+		// ∅ -> publishing: the pre-cutover path (no prior AllocateVersion
+		// call for this version) -- see ARCHITECTURE.md "Backward
+		// compatibility during rollout".
+		if repositoryHint == "" {
+			return nil, fmt.Errorf("%w: repository is required to begin publishing %s %s with no prior allocation", repository.ErrInvalidArgument, string(kind), version)
+		}
+		a := repository.Artifact{Kind: kind, Repository: repositoryHint, Version: version, BuildID: buildID}
+		if kind == repository.ArtifactKindImage {
+			a.AppID = ownerID
+		} else {
+			a.ChartID = ownerID
+		}
+		out, _, err := r.insertArtifact(ctx, a, nil, repository.ArtifactStatePublishing, versionSource)
+		return out, err
+	case everr != nil:
+		return nil, everr
+	}
+
+	if existing.State != repository.ArtifactStateAllocated && existing.State != repository.ArtifactStateFailed {
+		return nil, fmt.Errorf("%w: artifact %s %s is %q, not \"allocated\" or \"failed\" -- BeginPublish cannot start from here",
+			repository.ErrFailedPrecondition, r.ownerFullName(ctx, existing), version, existing.State)
+	}
+
+	now := time.Now().UTC()
+	if _, err := r.ex.Exec(ctx, `
+		UPDATE artifact SET build_id = $1, state = 'publishing', state_changed_at = $2, fail_reason = ''
+		WHERE artifact_id = $3`,
+		buildID, now, existing.ArtifactID); err != nil {
+		return nil, fmt.Errorf("begin publish for artifact %s: %w", existing.ArtifactID, err)
+	}
+	return r.GetArtifact(ctx, repository.ArtifactLookup{ArtifactID: existing.ArtifactID})
+}
+
+// FailPublish implements repository.ArtifactRepository.FailPublish -- the
+// publishing -> failed transition.
+func (r *artifactRepo) FailPublish(ctx context.Context, kind repository.ArtifactKind, ownerID, version, reason string) (*repository.Artifact, error) {
+	existing, everr := r.findByOwnerKindVersion(ctx, kind, ownerID, version)
+	if errors.Is(everr, pgx.ErrNoRows) {
+		return nil, fmt.Errorf("%w: no artifact found for %s %s %s", repository.ErrFailedPrecondition, string(kind), ownerID, version)
+	}
+	if everr != nil {
+		return nil, everr
+	}
+	if existing.State != repository.ArtifactStatePublishing {
+		return nil, fmt.Errorf("%w: artifact %s %s is %q, not \"publishing\" -- FailPublish cannot start from here",
+			repository.ErrFailedPrecondition, r.ownerFullName(ctx, existing), version, existing.State)
+	}
+
+	now := time.Now().UTC()
+	if _, err := r.ex.Exec(ctx, `
+		UPDATE artifact SET state = 'failed', state_changed_at = $1, fail_reason = $2
+		WHERE artifact_id = $3`,
+		now, reason, existing.ArtifactID); err != nil {
+		return nil, fmt.Errorf("fail publish for artifact %s: %w", existing.ArtifactID, err)
+	}
+	return r.GetArtifact(ctx, repository.ArtifactLookup{ArtifactID: existing.ArtifactID})
+}
+
+// ExpireStale implements repository.ArtifactRepository.ExpireStale -- the
+// reaper's sweep. Backed by artifact_state_idx (migration 007), a partial
+// index on exactly the (state, state_changed_at) this WHERE clause filters
+// on.
+func (r *artifactRepo) ExpireStale(ctx context.Context, olderThan time.Duration) (int, error) {
+	cutoff := time.Now().UTC().Add(-olderThan)
+	tag, err := r.ex.Exec(ctx, `
+		UPDATE artifact SET state = 'failed', state_changed_at = NOW(), fail_reason = 'stale'
+		WHERE state IN ('allocated', 'publishing') AND state_changed_at < $1`, cutoff)
+	if err != nil {
+		return 0, fmt.Errorf("expire stale artifacts: %w", err)
+	}
+	return int(tag.RowsAffected()), nil
 }
 
 // ownerFullName resolves a.AppID/a.ChartID to "domain-name" for error
@@ -368,31 +606,29 @@ func (r *artifactRepo) ResolveArtifact(ctx context.Context, lookup repository.Ar
 }
 
 // ============================================================================
-// AllocateVersion (AR-5a)
+// AllocateVersion (AR-5a; AR-7b re-homed storage into `artifact` itself)
 // ============================================================================
 
 // AllocateVersion implements repository.ArtifactRepository.AllocateVersion.
-// See that interface's doc comment and migration 004's comments for why this
-// writes to `version_allocation` rather than `artifact`, and
-// server/handlers/artifact.go's AllocateVersion for the retry loop this is
-// designed to be called from (a unique-constraint collision here aborts the
-// surrounding transaction; the caller must retry in a fresh one).
-func (r *artifactRepo) AllocateVersion(ctx context.Context, kind repository.ArtifactKind, ownerID, increment, explicitVersion string) (*repository.VersionAllocation, error) {
+// As of migration 007 (AR-7b) this writes the ∅ -> allocated `artifact` row
+// directly, rather than to the now-dropped `version_allocation` table --
+// see ARCHITECTURE.md "Artifact lifecycle" and migration 007's comments.
+// See server/handlers/artifact.go's AllocateVersion for the retry loop this
+// is designed to be called from (a unique-constraint collision here aborts
+// the surrounding transaction; the caller must retry in a fresh one).
+func (r *artifactRepo) AllocateVersion(ctx context.Context, kind repository.ArtifactKind, ownerID, repo, increment, explicitVersion string) (*repository.VersionAllocation, error) {
 	// "Next" is computed from the highest version already claimed for this
-	// owner+kind, across BOTH the real artifact table (already-published
-	// versions) and version_allocation (reserved but not yet published) --
-	// a version reserved a moment ago by a concurrent caller must not be
-	// handed out again just because RecordArtifact hasn't run yet.
+	// owner+kind against `artifact` alone -- this used to be a UNION with
+	// the separate version_allocation table (AR-5a); now that an
+	// "allocated" row IS an artifact row, one query covers both
+	// already-published versions and reserved-but-not-yet-published ones,
+	// so a version reserved a moment ago by a concurrent caller is still
+	// never handed out twice.
 	row := r.ex.QueryRow(ctx, `
-		SELECT version, version_major, version_minor, version_patch FROM (
-			SELECT version, version_major, version_minor, version_patch
-			  FROM artifact WHERE owner_id = $1 AND kind = $2
-			UNION ALL
-			SELECT version, version_major, version_minor, version_patch
-			  FROM version_allocation WHERE owner_id = $1 AND kind = $2
-		) claimed
-		ORDER BY version_major DESC, version_minor DESC, version_patch DESC
-		LIMIT 1`, ownerID, string(kind))
+		SELECT version, version_major, version_minor, version_patch
+		  FROM artifact WHERE owner_id = $1 AND kind = $2
+		 ORDER BY version_major DESC, version_minor DESC, version_patch DESC
+		 LIMIT 1`, ownerID, string(kind))
 
 	var previousVersion string
 	var curMajor, curMinor, curPatch int
@@ -424,16 +660,14 @@ func (r *artifactRepo) AllocateVersion(ctx context.Context, kind repository.Arti
 	}
 
 	versionStr := next.String()
-	allocationID := uuid.NewString()
-	if _, err := r.ex.Exec(ctx, `
-		INSERT INTO version_allocation (version_allocation_id, owner_id, kind, version, version_major, version_minor, version_patch)
-		VALUES ($1, $2, $3, $4, $5, $6, $7)`,
-		allocationID, ownerID, string(kind), versionStr, next.Major, next.Minor, next.Patch); err != nil {
-		msg := fmt.Sprintf("version %s is already allocated or recorded for this owner", versionStr)
-		if de, ok := translatePgError(err, msg); ok {
-			return nil, de
-		}
-		return nil, fmt.Errorf("allocate version %s: %w", versionStr, err)
+	a := repository.Artifact{Kind: kind, Repository: repo, Version: versionStr}
+	if kind == repository.ArtifactKindImage {
+		a.AppID = ownerID
+	} else {
+		a.ChartID = ownerID
+	}
+	if _, _, err := r.insertArtifact(ctx, a, nil, repository.ArtifactStateAllocated, repository.VersionSourceRegistry); err != nil {
+		return nil, err
 	}
 
 	return &repository.VersionAllocation{Version: versionStr, PreviousVersion: previousVersion}, nil

--- a/tools/app_registry/server/repository/postgres/postgres_integration_test.go
+++ b/tools/app_registry/server/repository/postgres/postgres_integration_test.go
@@ -118,14 +118,20 @@ func seedBuild(t *testing.T, pool *pgxpool.Pool, workflowRunID string) string {
 // recordArtifactTx runs RecordArtifact inside a real WithTx transaction,
 // exactly as handlers.runIdempotent does in production -- the postgres
 // repository methods rely on their caller providing transactional scope,
-// they do not open one themselves.
+// they do not open one themselves. domainStage is
+// repository.DomainAdoptionStageObserve, matching every domain's implicit
+// default (no domain_adoption row) -- every pre-AR-7b test in this file
+// relies on RecordArtifact's create-directly-as-published backward-compat
+// path, which is legal only at "observe" (see ARCHITECTURE.md "Backward
+// compatibility during rollout"); AR-7b's own tests call
+// r.Artifacts().RecordArtifact directly when they need a different stage.
 func recordArtifactTx(t *testing.T, reg *Registry, a repository.Artifact, contains []repository.ContainedImageInput) (*repository.Artifact, bool, error) {
 	t.Helper()
 	var out *repository.Artifact
 	var already bool
 	err := reg.WithTx(context.Background(), func(ctx context.Context, r repository.Registry) error {
 		var ferr error
-		out, already, ferr = r.Artifacts().RecordArtifact(ctx, a, contains)
+		out, already, ferr = r.Artifacts().RecordArtifact(ctx, a, contains, repository.DomainAdoptionStageObserve)
 		return ferr
 	})
 	return out, already, err
@@ -180,7 +186,7 @@ func TestRecordArtifact_ChartLinkFailureRollsBackTransaction(t *testing.T) {
 	}
 
 	err := reg.WithTx(ctx, func(ctx context.Context, r repository.Registry) error {
-		_, _, ferr := r.Artifacts().RecordArtifact(ctx, chart, contains)
+		_, _, ferr := r.Artifacts().RecordArtifact(ctx, chart, contains, repository.DomainAdoptionStageObserve)
 		return ferr
 	})
 
@@ -280,7 +286,7 @@ func TestRecordArtifact_DuplicateOwnerKindVersionRejectedByRealIndex(t *testing.
 	second.Digest = "sha256:second"
 
 	err := reg.WithTx(ctx, func(ctx context.Context, r repository.Registry) error {
-		_, _, ferr := r.Artifacts().RecordArtifact(ctx, second, nil)
+		_, _, ferr := r.Artifacts().RecordArtifact(ctx, second, nil, repository.DomainAdoptionStageObserve)
 		return ferr
 	})
 	if err == nil {
@@ -503,12 +509,18 @@ func TestPromotion_CurrentIdxRejectsConcurrentCurrentRows(t *testing.T) {
 
 // seedArtifact inserts a minimal image artifact row directly, for tests that
 // only need a valid artifact_id to hang a promotion off of.
+// seedArtifact inserts a minimal, already-PUBLISHED image artifact row
+// directly (bypassing the repository layer), for tests that only need a
+// valid artifact_id to hang a promotion off of. state/provenance/
+// version_source are NOT NULL as of migration 007 (AR-7b) -- state and
+// version_source have no safe default (see that migration's comments), so
+// every raw INSERT in this file must set them explicitly.
 func seedArtifact(t *testing.T, pool *pgxpool.Pool, appID, buildID, digest, version string) string {
 	t.Helper()
 	var artifactID string
 	err := pool.QueryRow(context.Background(), `
-		INSERT INTO artifact (kind, app_id, repository, version, digest, build_id)
-		VALUES ('image', $1, 'ghcr.io/acme/widget', $2, $3, $4)
+		INSERT INTO artifact (kind, app_id, repository, version, digest, build_id, state, provenance, version_source)
+		VALUES ('image', $1, 'ghcr.io/acme/widget', $2, $3, $4, 'published', 'observed', 'tag')
 		RETURNING artifact_id`, appID, version, digest, buildID).Scan(&artifactID)
 	if err != nil {
 		t.Fatalf("seed artifact %s: %v", digest, err)
@@ -978,13 +990,15 @@ func setDomainAdoptionStage(t *testing.T, pool *pgxpool.Pool, domain, stage stri
 // allocateVersionTx runs Artifacts().AllocateVersion inside a real WithTx
 // transaction, exactly as handlers.ArtifactServer.AllocateVersion's retry
 // loop does in production -- the postgres repository method relies on its
-// caller providing transactional scope.
-func allocateVersionTx(t *testing.T, reg *Registry, kind repository.ArtifactKind, ownerID, increment, explicitVersion string) (*repository.VersionAllocation, error) {
+// caller providing transactional scope. repo is the "ghcr.io/..." value
+// AllocateVersion (AR-7b) now stamps onto the allocated artifact row's
+// NOT-NULL repository column.
+func allocateVersionTx(t *testing.T, reg *Registry, kind repository.ArtifactKind, ownerID, repo, increment, explicitVersion string) (*repository.VersionAllocation, error) {
 	t.Helper()
 	var out *repository.VersionAllocation
 	err := reg.WithTx(context.Background(), func(ctx context.Context, r repository.Registry) error {
 		var ferr error
-		out, ferr = r.Artifacts().AllocateVersion(ctx, kind, ownerID, increment, explicitVersion)
+		out, ferr = r.Artifacts().AllocateVersion(ctx, kind, ownerID, repo, increment, explicitVersion)
 		return ferr
 	})
 	return out, err
@@ -1025,7 +1039,7 @@ func TestAllocateVersion_OrderingIsNumericNotLexical(t *testing.T) {
 		t.Fatalf("seed v1.9.0: %v", err)
 	}
 
-	alloc, err := allocateVersionTx(t, reg, repository.ArtifactKindImage, appID, "patch", "")
+	alloc, err := allocateVersionTx(t, reg, repository.ArtifactKindImage, appID, "ghcr.io/acme/widget", "patch", "")
 	if err != nil {
 		t.Fatalf("AllocateVersion: %v", err)
 	}
@@ -1063,7 +1077,7 @@ func TestAllocateVersion_ConcurrentCallsNeverCollide(t *testing.T) {
 			// a unique-violation aborts the transaction, so each retry opens
 			// a FRESH one via allocateVersionTx.
 			for attempt := 0; attempt < 20; attempt++ {
-				alloc, err := allocateVersionTx(t, reg, repository.ArtifactKindImage, appID, "patch", "")
+				alloc, err := allocateVersionTx(t, reg, repository.ArtifactKindImage, appID, "ghcr.io/acme/widget", "patch", "")
 				if err == nil {
 					versions[idx] = alloc.Version
 					return
@@ -1094,12 +1108,20 @@ func TestAllocateVersion_ConcurrentCallsNeverCollide(t *testing.T) {
 		t.Fatalf("expected %d distinct versions from %d concurrent allocations, got %d: %v", workers, workers, len(seen), versions)
 	}
 
+	// AR-7b: version_allocation is gone -- a successful allocation is now an
+	// `artifact` row in state 'allocated' (see migration 007 and
+	// postgres/artifact.go's AllocateVersion). The assertion this test
+	// exists for is otherwise UNCHANGED: exactly one row per successful
+	// concurrent allocation, proving the unique constraint backing
+	// AllocateVersion (now artifact_version_idx alone, doing double duty --
+	// see migration 007's comments) survived the storage move with no
+	// double-writes from retries.
 	var allocationRows int
-	if err := pool.QueryRow(context.Background(), `SELECT count(*) FROM version_allocation WHERE owner_id = $1`, appID).Scan(&allocationRows); err != nil {
-		t.Fatalf("count version_allocation rows: %v", err)
+	if err := pool.QueryRow(context.Background(), `SELECT count(*) FROM artifact WHERE owner_id = $1 AND state = 'allocated'`, appID).Scan(&allocationRows); err != nil {
+		t.Fatalf("count allocated artifact rows: %v", err)
 	}
 	if allocationRows != workers {
-		t.Fatalf("expected exactly %d version_allocation rows (one per successful allocation, no double-writes from retries), found %d", workers, allocationRows)
+		t.Fatalf("expected exactly %d allocated artifact rows (one per successful allocation, no double-writes from retries), found %d", workers, allocationRows)
 	}
 }
 
@@ -1139,12 +1161,16 @@ func TestAllocateVersion_IdempotencyKeyReplay(t *testing.T) {
 		t.Fatalf("expected already_allocated=true on the replayed call")
 	}
 
+	// AR-7b: a successful allocation is an `artifact` row in state
+	// 'allocated' (migration 007) -- see
+	// TestAllocateVersion_ConcurrentCallsNeverCollide's comment for why this
+	// query changed from version_allocation.
 	var allocationRows int
-	if err := pool.QueryRow(ctx, `SELECT count(*) FROM version_allocation`).Scan(&allocationRows); err != nil {
-		t.Fatalf("count version_allocation rows: %v", err)
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM artifact WHERE state = 'allocated'`).Scan(&allocationRows); err != nil {
+		t.Fatalf("count allocated artifact rows: %v", err)
 	}
 	if allocationRows != 1 {
-		t.Fatalf("idempotency replay double-wrote: expected exactly 1 version_allocation row, found %d", allocationRows)
+		t.Fatalf("idempotency replay double-wrote: expected exactly 1 allocated artifact row, found %d", allocationRows)
 	}
 }
 
@@ -2055,5 +2081,400 @@ func TestReconcile_DomainQualifiedAppRefsResolveUnambiguously_Postgres(t *testin
 	}
 	if resp.CreatedCharts[0].AppIds[0] != domainBApp.AppID {
 		t.Fatalf("expected the chart to resolve to domain-b's app (id=%s), got %+v", domainBApp.AppID, resp.CreatedCharts[0].AppIds)
+	}
+}
+
+// --- 9. artifact lifecycle (AR-7b, issue #558) --------------------------
+//
+// See ARCHITECTURE.md "Artifact lifecycle: allocated -> publishing ->
+// published" for the legal-transition table these tests exercise against
+// real Postgres (not just server/repository/fake): ∅ -> allocated
+// (AllocateVersion), ∅ -> publishing / allocated -> publishing / failed ->
+// publishing (BeginPublish), publishing -> published (RecordArtifact),
+// publishing -> failed (FailPublish). published is terminal.
+
+// beginPublishTx runs Artifacts().BeginPublish inside a real WithTx
+// transaction, exactly as handlers.ArtifactServer.BeginPublish does in
+// production.
+func beginPublishTx(t *testing.T, reg *Registry, kind repository.ArtifactKind, ownerID, version, buildID, repositoryHint string, versionSource repository.VersionSource) (*repository.Artifact, error) {
+	t.Helper()
+	var out *repository.Artifact
+	err := reg.WithTx(context.Background(), func(ctx context.Context, r repository.Registry) error {
+		var ferr error
+		out, ferr = r.Artifacts().BeginPublish(ctx, kind, ownerID, version, buildID, repositoryHint, versionSource)
+		return ferr
+	})
+	return out, err
+}
+
+// failPublishTx runs Artifacts().FailPublish inside a real WithTx
+// transaction, exactly as handlers.ArtifactServer.FailPublish does in
+// production.
+func failPublishTx(t *testing.T, reg *Registry, kind repository.ArtifactKind, ownerID, version, reason string) (*repository.Artifact, error) {
+	t.Helper()
+	var out *repository.Artifact
+	err := reg.WithTx(context.Background(), func(ctx context.Context, r repository.Registry) error {
+		var ferr error
+		out, ferr = r.Artifacts().FailPublish(ctx, kind, ownerID, version, reason)
+		return ferr
+	})
+	return out, err
+}
+
+// artifactStateRow reads back state/fail_reason/digest/build_id for one
+// artifact row directly -- assertions the repository.Artifact struct a
+// call returns doesn't need to carry every raw column for.
+func artifactStateRow(t *testing.T, pool *pgxpool.Pool, artifactID string) (state, failReason string, hasDigest, hasBuildID bool) {
+	t.Helper()
+	var digest, buildID *string
+	if err := pool.QueryRow(context.Background(), `
+		SELECT state, fail_reason, digest, build_id FROM artifact WHERE artifact_id = $1`, artifactID).
+		Scan(&state, &failReason, &digest, &buildID); err != nil {
+		t.Fatalf("read artifact state row %s: %v", artifactID, err)
+	}
+	return state, failReason, digest != nil, buildID != nil
+}
+
+// TestArtifactLifecycle_LegalTransitions walks EVERY legal transition in
+// ARCHITECTURE.md's "Artifact lifecycle" table against real Postgres, in
+// one continuous sequence for the same (owner, kind, version): ∅ ->
+// allocated (AllocateVersion), allocated -> publishing (BeginPublish),
+// publishing -> failed (FailPublish), failed -> publishing (BeginPublish
+// retry), publishing -> published (RecordArtifact). A second, independent
+// (owner, kind, version) proves the ∅ -> publishing branch (BeginPublish
+// with no prior allocation, the pre-cutover path) -- and, by coexisting
+// with the first sequence's NULL-digest rows at the same instant, proves
+// artifact_digest_idx's partial `WHERE digest IS NOT NULL` uniqueness
+// doesn't collide multiple digest-less rows.
+func TestArtifactLifecycle_LegalTransitions(t *testing.T) {
+	reg, pool := newTestRegistry(t)
+	appID := seedApp(t, pool, "acme", "lifecycle", "image")
+	buildID := seedBuild(t, pool, "run-lifecycle")
+	setDomainAdoptionStage(t, pool, "acme", "allocate")
+
+	// ∅ -> allocated
+	alloc, err := allocateVersionTx(t, reg, repository.ArtifactKindImage, appID, "ghcr.io/acme/lifecycle", "patch", "")
+	if err != nil {
+		t.Fatalf("AllocateVersion (∅ -> allocated): %v", err)
+	}
+	version := alloc.Version
+
+	allocated, err := reg.Artifacts().GetArtifact(context.Background(), repository.ArtifactLookup{
+		OwnerFullName: "acme-lifecycle", Kind: repository.ArtifactKindImage, Version: version,
+	})
+	if err != nil {
+		t.Fatalf("GetArtifact after allocation: %v", err)
+	}
+	if allocated.State != repository.ArtifactStateAllocated {
+		t.Fatalf("expected state allocated, got %q", allocated.State)
+	}
+	if state, _, hasDigest, hasBuildID := artifactStateRow(t, pool, allocated.ArtifactID); state != "allocated" || hasDigest || hasBuildID {
+		t.Fatalf("expected allocated row with NULL digest/build_id, got state=%s hasDigest=%v hasBuildID=%v", state, hasDigest, hasBuildID)
+	}
+
+	// allocated -> publishing
+	publishing, err := beginPublishTx(t, reg, repository.ArtifactKindImage, appID, version, buildID, "", repository.VersionSourceTag)
+	if err != nil {
+		t.Fatalf("BeginPublish (allocated -> publishing): %v", err)
+	}
+	if publishing.State != repository.ArtifactStatePublishing {
+		t.Fatalf("expected state publishing, got %q", publishing.State)
+	}
+	if publishing.VersionSource != repository.VersionSourceRegistry {
+		t.Fatalf("expected version_source to stay REGISTRY from AllocateVersion (BeginPublish's own versionSource arg is ignored on this branch), got %q", publishing.VersionSource)
+	}
+	if state, _, hasDigest, hasBuildID := artifactStateRow(t, pool, publishing.ArtifactID); state != "publishing" || hasDigest || !hasBuildID {
+		t.Fatalf("expected publishing row with NULL digest and a build_id, got state=%s hasDigest=%v hasBuildID=%v", state, hasDigest, hasBuildID)
+	}
+
+	// publishing -> failed
+	failed, err := failPublishTx(t, reg, repository.ArtifactKindImage, appID, version, "push failed")
+	if err != nil {
+		t.Fatalf("FailPublish (publishing -> failed): %v", err)
+	}
+	if failed.State != repository.ArtifactStateFailed {
+		t.Fatalf("expected state failed, got %q", failed.State)
+	}
+	if failed.FailReason != "push failed" {
+		t.Fatalf("expected fail_reason recorded, got %q", failed.FailReason)
+	}
+
+	// failed -> publishing (retry)
+	retried, err := beginPublishTx(t, reg, repository.ArtifactKindImage, appID, version, buildID, "", repository.VersionSourceTag)
+	if err != nil {
+		t.Fatalf("BeginPublish (failed -> publishing): %v", err)
+	}
+	if retried.State != repository.ArtifactStatePublishing {
+		t.Fatalf("expected state publishing after retry, got %q", retried.State)
+	}
+	if retried.FailReason != "" {
+		t.Fatalf("expected fail_reason cleared after a successful retry, got %q", retried.FailReason)
+	}
+
+	// ∅ -> publishing, a SEPARATE (owner, kind, version) -- coexists with
+	// the retried row above, both currently digest-less, while the ORIGINAL
+	// sequence continues below.
+	freshPublishing, err := beginPublishTx(t, reg, repository.ArtifactKindImage, appID, "v9.9.9", buildID, "ghcr.io/acme/lifecycle", repository.VersionSourceTag)
+	if err != nil {
+		t.Fatalf("BeginPublish (∅ -> publishing): %v", err)
+	}
+	if freshPublishing.State != repository.ArtifactStatePublishing {
+		t.Fatalf("expected state publishing for the ∅ -> publishing branch, got %q", freshPublishing.State)
+	}
+	if freshPublishing.VersionSource != repository.VersionSourceTag {
+		t.Fatalf("expected version_source TAG for the ∅ -> publishing branch, got %q", freshPublishing.VersionSource)
+	}
+
+	// publishing -> published
+	published, _, err := recordArtifactTx(t, reg, repository.Artifact{
+		Kind: repository.ArtifactKindImage, AppID: appID,
+		Repository: "ghcr.io/acme/lifecycle", Version: version,
+		Digest: "sha256:lifecycle-final", BuildID: buildID,
+	}, nil)
+	if err != nil {
+		t.Fatalf("RecordArtifact (publishing -> published): %v", err)
+	}
+	if published.State != repository.ArtifactStatePublished {
+		t.Fatalf("expected state published, got %q", published.State)
+	}
+	if published.Digest != "sha256:lifecycle-final" {
+		t.Fatalf("expected digest stamped, got %q", published.Digest)
+	}
+	if state, _, hasDigest, hasBuildID := artifactStateRow(t, pool, published.ArtifactID); state != "published" || !hasDigest || !hasBuildID {
+		t.Fatalf("expected published row with digest and build_id set, got state=%s hasDigest=%v hasBuildID=%v", state, hasDigest, hasBuildID)
+	}
+}
+
+// TestArtifactLifecycle_IllegalTransitionsRejected proves every state that
+// is NOT a legal starting point for BeginPublish/FailPublish/RecordArtifact
+// is rejected against real Postgres (not just server/repository/fake) --
+// FailedPrecondition for an out-of-order transition, AlreadyExists for
+// RecordArtifact's specific different-digest-on-an-already-published-
+// version conflict.
+func TestArtifactLifecycle_IllegalTransitionsRejected(t *testing.T) {
+	reg, pool := newTestRegistry(t)
+	appID := seedApp(t, pool, "acme", "illegal", "image")
+	buildID := seedBuild(t, pool, "run-illegal")
+	setDomainAdoptionStage(t, pool, "acme", "allocate")
+
+	t.Run("BeginPublish rejects an already-published row", func(t *testing.T) {
+		if _, _, err := recordArtifactTx(t, reg, repository.Artifact{
+			Kind: repository.ArtifactKindImage, AppID: appID,
+			Repository: "ghcr.io/acme/illegal", Version: "v1.0.0",
+			Digest: "sha256:illegal-published", BuildID: buildID,
+		}, nil); err != nil {
+			t.Fatalf("seed published artifact: %v", err)
+		}
+		_, err := beginPublishTx(t, reg, repository.ArtifactKindImage, appID, "v1.0.0", buildID, "", repository.VersionSourceTag)
+		if !errors.Is(err, repository.ErrFailedPrecondition) {
+			t.Fatalf("expected ErrFailedPrecondition for BeginPublish against a published row, got %v", err)
+		}
+	})
+
+	t.Run("FailPublish rejects an allocated row", func(t *testing.T) {
+		alloc, err := allocateVersionTx(t, reg, repository.ArtifactKindImage, appID, "ghcr.io/acme/illegal", "minor", "")
+		if err != nil {
+			t.Fatalf("AllocateVersion: %v", err)
+		}
+		_, err = failPublishTx(t, reg, repository.ArtifactKindImage, appID, alloc.Version, "should be rejected")
+		if !errors.Is(err, repository.ErrFailedPrecondition) {
+			t.Fatalf("expected ErrFailedPrecondition for FailPublish against an allocated row, got %v", err)
+		}
+	})
+
+	t.Run("RecordArtifact rejects an allocated row with no prior BeginPublish, at a non-observe stage", func(t *testing.T) {
+		alloc, err := allocateVersionTx(t, reg, repository.ArtifactKindImage, appID, "ghcr.io/acme/illegal", "major", "")
+		if err != nil {
+			t.Fatalf("AllocateVersion: %v", err)
+		}
+		err = reg.WithTx(context.Background(), func(ctx context.Context, r repository.Registry) error {
+			_, _, ferr := r.Artifacts().RecordArtifact(ctx, repository.Artifact{
+				Kind: repository.ArtifactKindImage, AppID: appID,
+				Repository: "ghcr.io/acme/illegal", Version: alloc.Version,
+				Digest: "sha256:illegal-skip-publish", BuildID: buildID,
+			}, nil, repository.DomainAdoptionStageAllocate)
+			return ferr
+		})
+		if !errors.Is(err, repository.ErrFailedPrecondition) {
+			t.Fatalf("expected ErrFailedPrecondition for RecordArtifact against an allocated row at domainStage=allocate, got %v", err)
+		}
+	})
+
+	t.Run("RecordArtifact rejects a different digest for an already-published version", func(t *testing.T) {
+		// v9.9.9: distinct from any version the earlier subtests in this
+		// function may have allocated on the same appID (they share `reg`
+		// and run sequentially), so this subtest's own collision is the
+		// only one in play.
+		if _, _, err := recordArtifactTx(t, reg, repository.Artifact{
+			Kind: repository.ArtifactKindImage, AppID: appID,
+			Repository: "ghcr.io/acme/illegal", Version: "v9.9.9",
+			Digest: "sha256:illegal-conflict-original", BuildID: buildID,
+		}, nil); err != nil {
+			t.Fatalf("seed published artifact: %v", err)
+		}
+		_, _, err := recordArtifactTx(t, reg, repository.Artifact{
+			Kind: repository.ArtifactKindImage, AppID: appID,
+			Repository: "ghcr.io/acme/illegal", Version: "v9.9.9",
+			Digest: "sha256:illegal-conflict-different", BuildID: buildID,
+		}, nil)
+		if !errors.Is(err, repository.ErrAlreadyExists) {
+			t.Fatalf("expected ErrAlreadyExists for a different digest on an already-published version, got %v", err)
+		}
+	})
+}
+
+// seedRawArtifact inserts an artifact row directly in the given state,
+// bypassing the repository layer -- for the reaper test below, which needs
+// to control state_changed_at independently of wall-clock time.
+func seedRawArtifact(t *testing.T, pool *pgxpool.Pool, appID string, state repository.ArtifactState, version, buildID string) string {
+	t.Helper()
+	var artifactID string
+	var buildIDArg any
+	if buildID != "" {
+		buildIDArg = buildID
+	}
+	err := pool.QueryRow(context.Background(), `
+		INSERT INTO artifact (kind, app_id, repository, version, build_id, state, provenance, version_source)
+		VALUES ('image', $1, 'ghcr.io/acme/reaper', $2, $3, $4, 'observed', 'tag')
+		RETURNING artifact_id`, appID, version, buildIDArg, string(state)).Scan(&artifactID)
+	if err != nil {
+		t.Fatalf("seed raw artifact %s %s: %v", version, state, err)
+	}
+	return artifactID
+}
+
+// backdateStateChangedAt moves artifactID's state_changed_at back by ago,
+// simulating a row that has been sitting in its current state for a while
+// -- without a real sleep.
+func backdateStateChangedAt(t *testing.T, pool *pgxpool.Pool, artifactID string, ago time.Duration) {
+	t.Helper()
+	// Compute the target timestamp in Go and set it directly, rather than
+	// subtracting a Go time.Duration from state_changed_at in SQL -- pgx
+	// has no implicit conversion from time.Duration to Postgres INTERVAL.
+	target := time.Now().UTC().Add(-ago)
+	if _, err := pool.Exec(context.Background(), `
+		UPDATE artifact SET state_changed_at = $1 WHERE artifact_id = $2`,
+		target, artifactID); err != nil {
+		t.Fatalf("backdate state_changed_at for %s: %v", artifactID, err)
+	}
+}
+
+// TestExpireStale_ReaperTimeout proves ExpireStale (the AR-7b stale-row
+// reaper's sweep) moves BOTH a stale "allocated" row and a stale
+// "publishing" row to "failed" with reason "stale" once their
+// state_changed_at exceeds the timeout, and leaves a FRESH row (well within
+// the timeout) untouched -- see ARCHITECTURE.md "The reaper is not
+// optional": a cancelled release run would otherwise hold a version number
+// in the (owner_id, kind, version) unique index forever.
+func TestExpireStale_ReaperTimeout(t *testing.T) {
+	reg, pool := newTestRegistry(t)
+	appID := seedApp(t, pool, "acme", "reaper", "image")
+	buildID := seedBuild(t, pool, "run-reaper")
+
+	staleAllocatedID := seedRawArtifact(t, pool, appID, repository.ArtifactStateAllocated, "v1.0.0", "")
+	stalePublishingID := seedRawArtifact(t, pool, appID, repository.ArtifactStatePublishing, "v1.1.0", buildID)
+	freshAllocatedID := seedRawArtifact(t, pool, appID, repository.ArtifactStateAllocated, "v1.2.0", "")
+
+	backdateStateChangedAt(t, pool, staleAllocatedID, 2*time.Hour)
+	backdateStateChangedAt(t, pool, stalePublishingID, 2*time.Hour)
+	// freshAllocatedID is left at its just-inserted (NOW()) state_changed_at.
+
+	n, err := reg.Artifacts().ExpireStale(context.Background(), time.Hour)
+	if err != nil {
+		t.Fatalf("ExpireStale: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("expected exactly 2 rows expired, got %d", n)
+	}
+
+	if state, reason, _, _ := artifactStateRow(t, pool, staleAllocatedID); state != "failed" || reason != "stale" {
+		t.Fatalf("expected the stale allocated row to be failed/stale, got state=%s reason=%s", state, reason)
+	}
+	if state, reason, _, _ := artifactStateRow(t, pool, stalePublishingID); state != "failed" || reason != "stale" {
+		t.Fatalf("expected the stale publishing row to be failed/stale, got state=%s reason=%s", state, reason)
+	}
+	if state, _, _, _ := artifactStateRow(t, pool, freshAllocatedID); state != "allocated" {
+		t.Fatalf("expected the fresh allocated row to be left alone, got state=%s", state)
+	}
+
+	// A second sweep with nothing newly stale finds nothing left to expire.
+	n2, err := reg.Artifacts().ExpireStale(context.Background(), time.Hour)
+	if err != nil {
+		t.Fatalf("second ExpireStale: %v", err)
+	}
+	if n2 != 0 {
+		t.Fatalf("expected the second sweep to find nothing left to expire, got %d", n2)
+	}
+}
+
+// TestMigration007FoldsVersionAllocationIntoArtifact proves migration 007's
+// fold-in: a pre-existing version_allocation row (inserted directly via
+// SQL, as it would have existed before this migration ran -- see AR-5a)
+// becomes an `artifact` row in state 'allocated', provenance 'observed',
+// version_source 'registry', with its repository DERIVED from the owning
+// app's image_repository (version_allocation itself carried no repository
+// column), and version_allocation itself is dropped afterward.
+func TestMigration007FoldsVersionAllocationIntoArtifact(t *testing.T) {
+	ctx := context.Background()
+	db := dbtest.NewPostgres(ctx, t, dbtest.Options{})
+
+	sqlDB, err := sql.Open("pgx", db.ConnString)
+	if err != nil {
+		t.Fatalf("open database/sql handle: %v", err)
+	}
+	defer sqlDB.Close()
+
+	runner := migrate.NewRunner(sqlDB, schema.Migrations, schema.Dir)
+	if err := runner.Steps(6); err != nil {
+		t.Fatalf("apply migrations 001-006: %v", err)
+	}
+
+	appID := seedApp(t, db.Pool, "acme", "folded", "image")
+	if _, err := db.Pool.Exec(ctx, `UPDATE app SET image_repository = $1 WHERE app_id = $2`, "ghcr.io/acme/folded", appID); err != nil {
+		t.Fatalf("set image_repository: %v", err)
+	}
+
+	var allocationID string
+	if err := db.Pool.QueryRow(ctx, `
+		INSERT INTO version_allocation (owner_id, kind, version, version_major, version_minor, version_patch)
+		VALUES ($1, 'image', 'v3.4.5', 3, 4, 5)
+		RETURNING version_allocation_id`, appID).Scan(&allocationID); err != nil {
+		t.Fatalf("seed pre-migration-007 version_allocation row: %v", err)
+	}
+
+	if err := runner.Up(); err != nil {
+		t.Fatalf("apply migration 007: %v", err)
+	}
+
+	var state, provenance, versionSource, repo string
+	var digest, buildID *string
+	if err := db.Pool.QueryRow(ctx, `
+		SELECT state, provenance, version_source, repository, digest, build_id
+		FROM artifact WHERE artifact_id = $1`, allocationID).
+		Scan(&state, &provenance, &versionSource, &repo, &digest, &buildID); err != nil {
+		t.Fatalf("read back folded artifact row (expected artifact_id == the old version_allocation_id): %v", err)
+	}
+	if state != "allocated" {
+		t.Fatalf("expected folded row state 'allocated', got %q", state)
+	}
+	if provenance != "observed" {
+		t.Fatalf("expected folded row provenance 'observed', got %q", provenance)
+	}
+	if versionSource != "registry" {
+		t.Fatalf("expected folded row version_source 'registry', got %q", versionSource)
+	}
+	if repo != "ghcr.io/acme/folded" {
+		t.Fatalf("expected folded row repository derived from the owning app's image_repository, got %q", repo)
+	}
+	if digest != nil || buildID != nil {
+		t.Fatalf("expected folded row to carry no digest/build_id, got digest=%v build_id=%v", digest, buildID)
+	}
+
+	var tableExists bool
+	if err := db.Pool.QueryRow(ctx, `SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'version_allocation')`).Scan(&tableExists); err != nil {
+		t.Fatalf("check version_allocation table existence: %v", err)
+	}
+	if tableExists {
+		t.Fatalf("expected version_allocation to be dropped by migration 007")
 	}
 }

--- a/tools/app_registry/server/repository/repository.go
+++ b/tools/app_registry/server/repository/repository.go
@@ -111,15 +111,34 @@ type BuildRepository interface {
 	GetBuild(ctx context.Context, buildID string) (*Build, error)
 }
 
-// ArtifactRepository covers `artifact` and `artifact_link`.
+// ArtifactRepository covers `artifact` and `artifact_link`. As of AR-7b
+// (migration 007), `artifact` rows carry the allocated -> publishing ->
+// published -> failed lifecycle described in ArtifactState's doc comment —
+// every method below that writes a row must enforce the legal-transition
+// table there, translating any other starting state into
+// ErrFailedPrecondition.
 type ArtifactRepository interface {
-	// RecordArtifact inserts an artifact, or — if one with the same digest
-	// already exists — returns it unchanged with alreadyRecorded=true (the
-	// digest is the natural key; this mirrors BuildRepository.RecordBuild).
-	// For kind == chart, every entry in contains must already be recorded
+	// RecordArtifact is the publishing -> published transition: it looks
+	// for an existing row by digest first (the natural key — a repeat with
+	// the SAME digest is an idempotent success, alreadyRecorded=true,
+	// mirroring BuildRepository.RecordBuild), then by (owner, kind,
+	// version). A "publishing" row there is completed (digest/published_at
+	// set, state -> published). A "published" row there with a DIFFERENT
+	// digest is a real conflict (ErrAlreadyExists) — a different digest for
+	// an already-published version is rejected, not merged. A "publishing"
+	// row is not found and there is no existing row at all: creating
+	// directly in "published" is allowed only when domainStage ==
+	// DomainAdoptionStageObserve (ARCHITECTURE.md "Backward compatibility
+	// during rollout" — this is what lets CI adopt BeginPublish per domain
+	// instead of in one cutover); any other stage rejects with
+	// ErrFailedPrecondition, since BeginPublish must have run first. An
+	// "allocated" or "failed" row found by (owner, kind, version) is also
+	// ErrFailedPrecondition — those need BeginPublish (allocated/failed ->
+	// publishing) before RecordArtifact can complete them. For kind ==
+	// chart, every entry in contains must already be a PUBLISHED artifact
 	// (matched by digest) or the call fails with ErrInvalidArgument — a
-	// chart may not pin an unknown artifact.
-	RecordArtifact(ctx context.Context, a Artifact, contains []ContainedImageInput) (artifact *Artifact, alreadyRecorded bool, err error)
+	// chart may not pin an unknown or not-yet-published artifact.
+	RecordArtifact(ctx context.Context, a Artifact, contains []ContainedImageInput, domainStage DomainAdoptionStage) (artifact *Artifact, alreadyRecorded bool, err error)
 
 	ListArtifacts(ctx context.Context, filter ArtifactListFilter) ([]Artifact, error)
 	GetArtifact(ctx context.Context, lookup ArtifactLookup) (*Artifact, error)
@@ -132,16 +151,53 @@ type ArtifactRepository interface {
 	// AllocateVersion reserves the next version for (kind, ownerID) per
 	// ARCHITECTURE.md's version model (AR-5) and PLAN.md's AR-5 addendum:
 	// increment is "major"|"minor"|"patch" and is ignored when
-	// explicitVersion is set. Implementations must perform this as a
-	// transactional INSERT against a unique (owner, kind, version)
-	// constraint so concurrent callers cannot be handed the same version —
-	// see ARCHITECTURE.md and postgres/errors.go's doc comment on
-	// ErrAlreadyExists. Must be called inside Registry.WithTx: a
+	// explicitVersion is set. As of AR-7b (migration 007) this writes an
+	// `artifact` row in state "allocated" directly — the ∅ -> allocated
+	// transition — rather than to the now-retired version_allocation
+	// table; repository is the owning app's/chart's stored
+	// image_repository/chart_repository (required because artifact.repository
+	// is NOT NULL even for a digest-less allocated row). Implementations
+	// must perform this as a transactional INSERT against a unique (owner,
+	// kind, version) constraint so concurrent callers cannot be handed the
+	// same version — see ARCHITECTURE.md and postgres/errors.go's doc
+	// comment on ErrAlreadyExists. Must be called inside Registry.WithTx: a
 	// unique-constraint collision aborts the whole transaction (the
 	// "transaction abort" hazard PLAN.md flags), so a caller retrying on
 	// ErrAlreadyExists MUST do so in a FRESH WithTx call, not the same one —
 	// see server/handlers/artifact.go's AllocateVersion for the retry loop.
-	AllocateVersion(ctx context.Context, kind ArtifactKind, ownerID, increment, explicitVersion string) (*VersionAllocation, error)
+	AllocateVersion(ctx context.Context, kind ArtifactKind, ownerID, repository, increment, explicitVersion string) (*VersionAllocation, error)
+
+	// BeginPublish is the ∅|allocated|failed -> publishing transition (see
+	// ArtifactState's doc comment), identified by (kind, ownerID, version).
+	// buildID is stamped on the row. repositoryHint is used only for the
+	// ∅ -> publishing branch (no prior row exists — the pre-cutover path,
+	// or a domain that never called AllocateVersion for this version):
+	// artifact.repository is NOT NULL, so a fresh row needs one from
+	// somewhere, and an existing allocated/failed row already carries its
+	// own from when it was created. versionSource is likewise only used on
+	// the fresh-create branch; an existing row keeps whatever
+	// AllocateVersion (or a prior BeginPublish) already gave it. Any other
+	// starting state (publishing, published) is ErrFailedPrecondition.
+	// Must be called inside Registry.WithTx — same transactional-write
+	// shape as every other write method here.
+	BeginPublish(ctx context.Context, kind ArtifactKind, ownerID, version, buildID, repositoryHint string, versionSource VersionSource) (*Artifact, error)
+
+	// FailPublish is the publishing -> failed transition, identified by
+	// (kind, ownerID, version). reason is stored on FailReason. Any other
+	// starting state is ErrFailedPrecondition. Must be called inside
+	// Registry.WithTx.
+	FailPublish(ctx context.Context, kind ArtifactKind, ownerID, version, reason string) (*Artifact, error)
+
+	// ExpireStale moves every row in state "allocated" or "publishing"
+	// whose state_changed_at is older than olderThan to "failed" with
+	// FailReason "stale" — see ARCHITECTURE.md "The reaper is not
+	// optional": a cancelled release run would otherwise hold a version
+	// number in the (owner, kind, version) unique index forever. Returns
+	// the number of rows moved. Called by app-registry-worker's periodic
+	// reaper loop against the bare pool, NOT inside Registry.WithTx — same
+	// pattern as WritebackRepository.ClaimBatch, a standalone maintenance
+	// sweep with no other write to be atomic with.
+	ExpireStale(ctx context.Context, olderThan time.Duration) (int, error)
 }
 
 // DomainAdoptionRepository covers the `domain_adoption` table (migration

--- a/tools/app_registry/worker/BUILD.bazel
+++ b/tools/app_registry/worker/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//tools/app_registry/protos:appregistrypb",
         "//tools/app_registry/server/repository/postgres",
         "//tools/app_registry/worker/outbox",
+        "//tools/app_registry/worker/reaper",
         "//tools/app_registry/worker/writeback",
         "@io_temporal_go_sdk//activity",
         "@io_temporal_go_sdk//worker",

--- a/tools/app_registry/worker/README.md
+++ b/tools/app_registry/worker/README.md
@@ -28,10 +28,14 @@ the same promotion's workflow more than once harmless.
 worker/
   main.go               # bootstrap: DB pool, gRPC client to the API, Temporal
                          # client/worker (libs/go/temporal), activity/workflow
-                         # registration, outbox drain loop, graceful shutdown
+                         # registration, outbox drain loop, artifact reaper
+                         # loop, graceful shutdown
   outbox/
     drain.go             # Drainer: ClaimBatch -> ExecuteWorkflow -> MarkDone/MarkFailed
     drain_test.go
+  reaper/
+    reaper.go             # AR-7b (issue #558): periodic sweep of stale
+                           # allocated/publishing artifact rows to failed
   writeback/
     workflow.go          # WritebackWorkflow, the Writeback activity interface,
                           # WritebackInput/RenderedState/PublishResult, task queue
@@ -123,10 +127,35 @@ merely harmless — see `stub_test.go`'s
 `TestStubActivities_Publish_SkipsNoOpWrite`, verified to fail when the check
 is deliberately removed (see the phase report for the transcript).
 
+## Stale-row reaper (AR-7b, issue #558)
+
+A third loop, alongside the outbox drain loop, in this same process:
+`reaper.Reaper` calls `ArtifactRepository.ExpireStale` on a timer, moving
+every `artifact` row still `allocated` or `publishing` after
+`ARTIFACT_REAPER_TIMEOUT` (measured from `state_changed_at`) to `failed`
+with `fail_reason = 'stale'`. See `../ARCHITECTURE.md` "Artifact lifecycle:
+allocated -> publishing -> published" and "The reaper is not optional".
+
+This exists because AR-7b's release plan step writes an `allocated`
+artifact row *before anything is pushed*, at every adoption stage — the
+`UNIQUE (owner_id, kind, version)` index that makes concurrent
+`AllocateVersion` calls collision-safe is the same index that would
+otherwise let a cancelled or crashed release run hold a version number
+forever, permanently blocking that owner's next release. The reaper is what
+turns that hold into a bounded one.
+
+Same shape as `outbox.Drainer`: connects to Postgres directly (not through
+the gRPC API), sweeps once immediately on startup so a worker restart
+doesn't leave an already-stale row idle for a full poll interval, then
+again on every `ARTIFACT_REAPER_POLL_INTERVAL` tick until the process is
+asked to shut down. A sweep error is logged and retried on the next tick,
+never fatal — the worker's dependencies being briefly unreachable must not
+crash-loop the process.
+
 ## Configuration
 
-See [`../ENV.md`](../ENV.md) "Worker (`app-registry-worker`, AR-4b)" for
-every environment variable.
+See [`../ENV.md`](../ENV.md) "Worker (`app-registry-worker`, AR-4b)" and
+"Artifact reaper (AR-7b, issue #558)" for every environment variable.
 
 ## Testing
 

--- a/tools/app_registry/worker/main.go
+++ b/tools/app_registry/worker/main.go
@@ -25,6 +25,7 @@ import (
 	pb "github.com/whale-net/everything/tools/app_registry/protos"
 	"github.com/whale-net/everything/tools/app_registry/server/repository/postgres"
 	"github.com/whale-net/everything/tools/app_registry/worker/outbox"
+	"github.com/whale-net/everything/tools/app_registry/worker/reaper"
 	"github.com/whale-net/everything/tools/app_registry/worker/writeback"
 )
 
@@ -114,7 +115,17 @@ func run() error {
 		Logger:       logger,
 	}
 
-	done := make(chan error, 2)
+	// Stale-artifact reaper (AR-7b, issue #558), running alongside the
+	// outbox drain loop in this same process -- see reaper.Reaper and
+	// ARCHITECTURE.md "The reaper is not optional".
+	artifactReaper := &reaper.Reaper{
+		Store:        repo.Artifacts(),
+		Timeout:      getEnvDuration("ARTIFACT_REAPER_TIMEOUT", 30*time.Minute),
+		PollInterval: getEnvDuration("ARTIFACT_REAPER_POLL_INTERVAL", 5*time.Minute),
+		Logger:       logger,
+	}
+
+	done := make(chan error, 3)
 	go func() {
 		if err := w.Run(worker.InterruptCh()); err != nil {
 			done <- fmt.Errorf("temporal worker: %w", err)
@@ -125,6 +136,13 @@ func run() error {
 	go func() {
 		if err := drainer.Run(ctx); err != nil && ctx.Err() == nil {
 			done <- fmt.Errorf("outbox drainer: %w", err)
+			return
+		}
+		done <- nil
+	}()
+	go func() {
+		if err := artifactReaper.Run(ctx); err != nil && ctx.Err() == nil {
+			done <- fmt.Errorf("artifact reaper: %w", err)
 			return
 		}
 		done <- nil

--- a/tools/app_registry/worker/reaper/BUILD.bazel
+++ b/tools/app_registry/worker/reaper/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "reaper",
+    srcs = ["reaper.go"],
+    importpath = "github.com/whale-net/everything/tools/app_registry/worker/reaper",
+    visibility = ["//visibility:public"],
+    deps = ["//tools/app_registry/server/repository"],
+)

--- a/tools/app_registry/worker/reaper/reaper.go
+++ b/tools/app_registry/worker/reaper/reaper.go
@@ -1,0 +1,84 @@
+// Package reaper implements the AR-7b (issue #558) stale-artifact sweep: a
+// periodic loop, run alongside outbox.Drainer in app-registry-worker, that
+// expires stale "allocated" and "publishing" artifact rows to "failed" with
+// reason "stale". See ARCHITECTURE.md "The reaper is not optional" and
+// PLAN.md's AR-7b scope.
+//
+// This ships in the SAME phase as the allocated/publishing states
+// themselves, not later: an "allocated" row is written up front by the
+// release plan step, before anything is pushed, at every adoption stage --
+// a cancelled or killed run would otherwise hold a version number in the
+// (owner_id, kind, version) unique index forever, permanently blocking that
+// owner's next release.
+package reaper
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/whale-net/everything/tools/app_registry/server/repository"
+)
+
+// Reaper periodically calls repository.ArtifactRepository.ExpireStale
+// against a direct Postgres connection -- mirroring outbox.Drainer's Store
+// field, this is deliberately not routed through the gRPC API, so the
+// reaper keeps sweeping even if the app-registry-api process itself is
+// down.
+type Reaper struct {
+	// Store is the artifact repository, backed by the same Postgres
+	// database the App Registry API writes to (see
+	// server/repository/postgres).
+	Store repository.ArtifactRepository
+	// Timeout is how long a row may sit in "allocated" or "publishing"
+	// (measured from state_changed_at) before the next sweep moves it to
+	// "failed" with reason "stale". See ENV.md's ARTIFACT_REAPER_TIMEOUT.
+	Timeout time.Duration
+	// PollInterval is the delay between sweep passes. See ENV.md's
+	// ARTIFACT_REAPER_POLL_INTERVAL.
+	PollInterval time.Duration
+	// Logger receives per-pass and per-error events. If nil, slog.Default()
+	// is used.
+	Logger *slog.Logger
+}
+
+func (rp *Reaper) logger() *slog.Logger {
+	if rp.Logger != nil {
+		return rp.Logger
+	}
+	return slog.Default()
+}
+
+// Run sweeps once immediately -- so a worker restart doesn't leave an
+// already-stale row idle for a full PollInterval, mirroring
+// outbox.Drainer.Run's same reasoning -- then again on every PollInterval
+// tick until ctx is cancelled. A sweep error is logged, not fatal: the next
+// tick tries again, matching ARCHITECTURE.md's "the registry can be down
+// without blocking a deploy" posture applied to the worker's own
+// dependencies.
+func (rp *Reaper) Run(ctx context.Context) error {
+	ticker := time.NewTicker(rp.PollInterval)
+	defer ticker.Stop()
+
+	rp.sweepOnce(ctx)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			rp.sweepOnce(ctx)
+		}
+	}
+}
+
+func (rp *Reaper) sweepOnce(ctx context.Context) {
+	n, err := rp.Store.ExpireStale(ctx, rp.Timeout)
+	if err != nil {
+		rp.logger().Error("artifact reaper sweep failed", "error", err)
+		return
+	}
+	if n > 0 {
+		rp.logger().Info("expired stale artifacts", "count", n, "timeout", rp.Timeout)
+	}
+}


### PR DESCRIPTION
Implements **AR-7b — Artifact lifecycle states** from `tools/app_registry/PLAN.md`. Design merged in #559 (docs only); this is the code. Top of a 2-PR stack — **stacked on #561 (AR-7a)**, review that one first.

Fixes ordering 3: charts pin digests resolved from GHCR *by tag*, so a chart-only release pins images published by earlier runs. One unrecorded image therefore breaks every future chart release containing that app, permanently — a re-run doesn't fix it and reconcile doesn't fix it. The registry stops learning about an artifact after the fact and instead records the intent to publish *before* the push.

## What changed

**Migration `007_artifact_lifecycle`.** `artifact.state` (`allocated`/`publishing`/`published`/`failed`), `provenance` (`observed`/`adopted`), `version_source` (`registry`/`tag`), `state_changed_at`, and `fail_reason` — the last not in the original scope, added so `FailPublish`'s reason and the reaper's `"stale"` are actually stored. `digest`/`build_id`/`published_at` become nullable, guarded by a table-level `artifact_state_shape` CHECK tying `state` to which of them may be non-NULL. `artifact_digest_idx` becomes `UNIQUE ... WHERE digest IS NOT NULL`.

`version_allocation` folds into `artifact` as `allocated` rows and **the table is dropped** — this phase removes a table rather than adding one. `version_allocation` only ever existed because `digest`/`build_id` were `NOT NULL`; it already *was* the `allocated` state, stored elsewhere. `UNIQUE (owner_id, kind, version)` is unchanged and now spans every state, which is strictly stronger than the old two-table arrangement, and "next version" collapses to one query.

Numbering note: PLAN.md said `007` and `007` is correct — `006_reconcile_watermark` (#545) landed between the design session and this implementation, so there was no free slot below it.

**`BeginPublish` / `FailPublish`**, with transitions enforced server-side and anything else `FailedPrecondition`: `∅→allocated`, `∅→publishing`, `allocated→publishing`, `publishing→published`, `publishing→failed`, `failed→publishing`. `published` is terminal — re-recording the same digest is an idempotent success, a *different* digest for an already-published version is rejected. `RecordArtifact` keeps its create-directly-as-`published` path for domains at stage `observe`, which is what allows per-domain rollout instead of one cutover. Implemented in both the postgres repository and the in-memory fake, wired to `RoleBuilder`, exposed as `artifacts begin-publish` / `fail-publish`.

**Stale-row reaper** — a new `worker/reaper` package running as a third loop in `app-registry-worker` alongside the outbox drainer. It expires both stale `allocated` and stale `publishing` rows to `failed` with reason `stale`. Not optional and not deferrable: `allocated` rows hold a version number in `UNIQUE (owner_id, kind, version)`, so a cancelled run would otherwise hold it forever. `ARTIFACT_REAPER_TIMEOUT` / `ARTIFACT_REAPER_POLL_INTERVAL`, documented in ENV.md.

**`release.yml`** calls `BeginPublish` before each image/chart push and `FailPublish` on the error path, via two new composite actions. The opt-in gate and `continue-on-error` semantics are unchanged — the per-stage tightening lives server-side in `RecordArtifact`'s stage gate, not in workflow YAML.

## Known narrowing — worth a look during review

The plan asked for the release **plan step** to write the whole intent set — one `allocated` row per target — before the run fans out. This PR writes intent via `BeginPublish` at the start of each matrix leg instead: still before that target's own push, but it does not satisfy AR-7d's "a run killed *before* reaching an app still reports that app as incomplete". No third RPC was specified for it and `AllocateVersion`'s stage gate can't serve `observe`/`promote` domains. Documented as an explicit, reasoned gap in both PLAN.md and ARCHITECTURE.md, deferred to AR-7d. Reviewers who want the full run log semantics now should say so.

## Tests

Postgres integration tests cover every legal transition, every illegal one rejected, the reaper timeout (including a fresh row *not* being reaped), and the folded `version_allocation` data. Handler and fake unit tests cover the state machine and the same-digest-idempotent / different-digest-rejected rule.

`AllocateVersion`'s concurrency test (8 goroutines, zero collisions) is unchanged except its final assertion, which now counts `artifact WHERE state='allocated'` instead of the dropped table — that regression is the one that matters most here. Four behaviors were verified by deliberately breaking them and confirming the guarding test failed, then reverting.

## Verification status

`bazel build //tools/...` and `bazel test //tools/...` are green, and the Docker-backed `postgres_integration_test` passes on the combined stack tip (83.9s, real Postgres via `libs/go/dbtest`) — every lifecycle transition test, the reaper timeout test, and the `version_allocation` fold-in test included. The two workflow YAMLs were syntax-validated only; they cannot be executed without a deployed registry.

Ref: #558, #559
