### PR TITLE
feat(app-registry): AR-7c app identity / manifest snapshot split (#558)

### DIFF
--- a/.github/actions/app-registry-assert/action.yml
+++ b/.github/actions/app-registry-assert/action.yml
@@ -1,0 +1,63 @@
+name: 'App Registry: Assert Apps/Charts'
+description: >-
+  AR-7c (issue #558). Discovers every release_app/helm_chart manifest at the
+  RELEASED ref via `release_helper_go manifest-set` and additively asserts
+  it into the App Registry via `app-registry apps assert` -- identity +
+  manifest snapshot only, safe from any ref (a divergent branch, an old tag,
+  an unmerged PR), because unlike `app-registry-reconcile` this never marks
+  anything MISSING and never depends on `main`'s reconcile having gone
+  first.
+
+  This is what closes issue #547's gap: called as the FIRST step of a
+  release run (before any RecordBuild/RecordArtifact/BeginPublish call that
+  resolves an owner by full name), it guarantees the owner exists by the
+  time those calls run, so `exit 3` / `ReasonOwnerNotReconciled` becomes
+  unreachable from release.yml. See
+  tools/app_registry/ARCHITECTURE.md "AssertApps (additive) vs.
+  ReconcileApps (absence sweep)".
+
+  Requires RELEASE_HELPER and APP_REGISTRY_CLI env vars already set (see
+  .github/actions/download-release-tools).
+
+inputs:
+  address:
+    required: true
+  token-url:
+    required: true
+  client-id:
+    required: true
+  client-secret:
+    required: true
+  git-sha:
+    description: 'Commit SHA to record on the manifest set -- the RELEASED ref, typically github.sha'
+    required: true
+  idempotency-key:
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - uses: ./.github/actions/app-registry-auth
+      with:
+        address: ${{ inputs.address }}
+        token-url: ${{ inputs.token-url }}
+        client-id: ${{ inputs.client-id }}
+        client-secret: ${{ inputs.client-secret }}
+
+    - name: Assert apps/charts
+      shell: bash
+      env:
+        GIT_SHA: ${{ inputs.git-sha }}
+        IDEMPOTENCY_KEY: ${{ inputs.idempotency-key }}
+      # Same manifest-set discovery app-registry-reconcile uses -- see that
+      # action's comment on why a shallow (fetch-depth: 1) checkout still
+      # resolves source_committed_at for github.sha. Discovering the FULL
+      # manifest set (not just the app/chart being released) is what makes
+      # this additive-safe: AssertApps never marks anything absent from the
+      # set as MISSING, so sending the complete tree costs nothing and
+      # simply means every app/chart at this ref gets a fresh snapshot.
+      run: |
+        "$RELEASE_HELPER" manifest-set --git-sha "$GIT_SHA" > "$RUNNER_TEMP/manifest-set.json"
+        "$APP_REGISTRY_CLI" apps assert \
+          --from-plan "$RUNNER_TEMP/manifest-set.json" \
+          --idempotency-key "$IDEMPOTENCY_KEY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,7 +203,7 @@ jobs:
           fi
         fi
 
-    # App/chart registration (ReconcileApps) deliberately does NOT run here.
+    # Full ReconcileApps (the absence sweep) deliberately does NOT run here.
     # It requires the complete, current manifest set -- anything absent from
     # what it's given gets flagged MISSING (api.proto's own comment) -- and
     # this workflow can be dispatched against an arbitrary, possibly old ref
@@ -213,6 +213,12 @@ jobs:
     # "Reconcile apps/charts in App Registry" job), so it only ever sees the
     # current, complete tree. See ARCHITECTURE.md "Rejected alternatives"
     # and DEPLOY.md "CI wiring (AR-3d)".
+    #
+    # AR-7c (issue #558) adds the ADDITIVE-only counterpart, AssertApps,
+    # which IS safe from this arbitrary ref -- see the "Assert apps/charts
+    # in App Registry" step in the `release`/`release-helm-charts` jobs
+    # below, and ARCHITECTURE.md "AssertApps (additive) vs. ReconcileApps
+    # (absence sweep)".
 
   # Plan which apps need OpenAPI spec builds
   plan-openapi-builds:
@@ -368,12 +374,38 @@ jobs:
     - name: Download release tools
       uses: ./.github/actions/download-release-tools
 
+    # AR-7c (issue #558): the FIRST App Registry step of this job,
+    # deliberately ahead of everything else below -- additive identity +
+    # manifest-snapshot assertion from THIS ref, closing issue #547's gap
+    # (a release running ahead of main's ReconcileApps). After this step
+    # succeeds, every RecordBuild/RecordArtifact/BeginPublish call in this
+    # job resolves its owner successfully -- `exit 3` /
+    # ReasonOwnerNotReconciled becomes unreachable from here. Best-effort at
+    # adoption stage "observe" (every domain, today) like every other
+    # recording step -- see ARCHITECTURE.md "Availability, restated per
+    # adoption stage": a registry outage here means the SAME outage would
+    # fail every recording step below it anyway, so continue-on-error keeps
+    # this consistent with them rather than making it a new single point of
+    # release failure.
+    - name: Assert apps/charts in App Registry
+      if: ${{ vars.APP_REGISTRY_CICD_OPT_IN == 'true' }}
+      continue-on-error: true
+      timeout-minutes: 5
+      uses: ./.github/actions/app-registry-assert
+      with:
+        address: ${{ vars.APP_REGISTRY_ADDRESS }}
+        token-url: ${{ vars.APP_REGISTRY_AUTH_TOKEN_URL }}
+        client-id: app-registry-builder-${{ vars.APP_REGISTRY_BUILDER_ENV || 'dev' }}
+        client-secret: ${{ secrets.APP_REGISTRY_BUILDER_CLIENT_SECRET }}
+        git-sha: ${{ github.sha }}
+        idempotency-key: ${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.domain }}-${{ matrix.app }}-assert
+
     # Configure Git for tagging
     - name: Configure Git
       run: |
         git config --global user.name "${{ github.actor }}"
         git config --global user.email "${{ github.actor }}@users.noreply.github.com"
-        
+
     # Login unless it's a manual dispatch with dry_run=true
     # - Manual dispatch with dry_run=false: login (needed for publishing)
     # - Manual dispatch with dry_run=true: skip login (no publishing)
@@ -812,6 +844,23 @@ jobs:
 
     - name: Download release tools
       uses: ./.github/actions/download-release-tools
+
+    # AR-7c (issue #558): same first-step assertion the image release job
+    # does -- see that job's "Assert apps/charts in App Registry" step for
+    # the full rationale. This job has no per-app matrix, so the
+    # idempotency key is scoped to "charts" rather than a domain/app pair.
+    - name: Assert apps/charts in App Registry
+      if: ${{ vars.APP_REGISTRY_CICD_OPT_IN == 'true' }}
+      continue-on-error: true
+      timeout-minutes: 5
+      uses: ./.github/actions/app-registry-assert
+      with:
+        address: ${{ vars.APP_REGISTRY_ADDRESS }}
+        token-url: ${{ vars.APP_REGISTRY_AUTH_TOKEN_URL }}
+        client-id: app-registry-builder-${{ vars.APP_REGISTRY_BUILDER_ENV || 'dev' }}
+        client-secret: ${{ secrets.APP_REGISTRY_BUILDER_CLIENT_SECRET }}
+        git-sha: ${{ github.sha }}
+        idempotency-key: ${{ github.run_id }}-${{ github.run_attempt }}-charts-assert
 
     # Needed to resolve pinned image tags to digests for App Registry
     # recording below (docker buildx imagetools inspect reads from ghcr.io).

--- a/tools/app_registry/ARCHITECTURE.md
+++ b/tools/app_registry/ARCHITECTURE.md
@@ -292,11 +292,22 @@ not."
 
 ## Release-vs-reconcile gap (issue #547)
 
-> **Superseded in design, still true as-built.** Issue #558 rejects "accept
-> the gap" as the end state — see "Release lifecycle (issue #558)" below,
-> which closes it by splitting identity assertion from the absence sweep.
-> Everything in this section describes what is deployed today and stays
-> accurate until AR-7c ships.
+> **Closed by AR-7c (built, not yet merged).** Issue #558 rejected "accept
+> the gap" as the end state — see "Release lifecycle (issue #558)" →
+> "AssertApps (additive) vs. ReconcileApps (absence sweep)" below.
+> `release.yml` now calls `AssertApps` as the first App Registry step of
+> every job that later resolves an owner by full name (both the `release`
+> matrix and `release-helm-charts`), so the window this section describes
+> — a release reaching `RecordArtifact`'s owner lookup before that commit's
+> `main`-push reconcile has run — can no longer produce
+> `ReasonOwnerNotReconciled` / exit code 3. Everything below this callout
+> describes the PRE-AR-7c mechanism (the `::warning::` annotation, exit
+> code 3, the "wait and re-run" runbook) — kept for historical/rollback
+> context (a domain that somehow skips the `AssertApps` step, e.g. a
+> workflow YAML that hasn't been updated, still hits this exact path) and
+> because the underlying RPC/exit-code machinery is unchanged, just
+> unreachable through the normal path now. OPERATIONS.md's runbook entry
+> for this has been retired accordingly.
 
 `ReconcileApps` runs only from `ci.yml` on push to `main` (#543); `release.yml`
 is a `workflow_dispatch` a human triggers, often immediately after merging —
@@ -386,20 +397,22 @@ tradeoff above, not a separate gap to close.
 
 ## Release lifecycle (issue #558)
 
-**Status: AR-7a and AR-7b built (not yet merged); AR-7c … AR-7f designed,
-not built.** Delivery is PLAN.md's AR-7. Two slices of this section describe
-real code: AR-7a's — ordering 4, partial-apply reconcile, domain-qualified
-chart app references, and the `continue-on-error` drop on `ci.yml`'s sweep
-job — and AR-7b's — the artifact lifecycle
-(`allocated → publishing → published → failed`), migration `007`,
-`BeginPublish`/`FailPublish`, `RecordArtifact`'s `publishing → published`
-transition, and the stale-row reaper. Everything else here (the app identity
-/ manifest-snapshot split, `AssertApps`, the run log, `AdoptArtifact`,
-compose-time chart hermeticity) is still proposed: every table, column and
-RPC named in those subsections is unbuilt. This section supersedes
-"Release-vs-reconcile gap (issue #547)" above for the artifact lifecycle
-specifically, and changes what "Availability and bootstrap" below promises —
-both are cross-referenced where that happens.
+**Status: AR-7a and AR-7b built and merged to `main` (#561, #562); AR-7c
+built, not yet merged; AR-7d … AR-7f designed, not built.** Delivery is
+PLAN.md's AR-7. Three slices of this section describe real code: AR-7a's —
+ordering 4, partial-apply reconcile, domain-qualified chart app references,
+and the `continue-on-error` drop on `ci.yml`'s sweep job — AR-7b's — the
+artifact lifecycle (`allocated → publishing → published → failed`),
+migration `007`, `BeginPublish`/`FailPublish`, `RecordArtifact`'s
+`publishing → published` transition, and the stale-row reaper — and AR-7c's
+— migration `008`, the app identity / manifest-snapshot split,
+`AssertApps`, and `artifact`'s stored `manifest_id`/`promotability`. The run
+log, `AdoptArtifact`, and compose-time chart hermeticity remain proposed:
+every table, column and RPC named in those subsections is unbuilt. This
+section supersedes "Release-vs-reconcile gap (issue #547)" above — AR-7c
+closes that gap for real, see the callout there — and changes what
+"Availability and bootstrap" below promises; both are cross-referenced where
+that happens.
 
 ### The problem: four cross-run orderings, three of them unenforced
 
@@ -574,13 +587,49 @@ indexable instead of resting on `->>` expression indexes. Fully typed columns
 were rejected: they would reintroduce the hand-maintained duplicate of the
 manifest schema that AR-M spent a phase deleting.
 
+**As built (AR-7c, migration `008`).** Everything above is real. One
+narrowing the design left implicit: **`chart_manifest` gets NEITHER
+generated column**, not "the same two." `ChartManifest` (appmeta.proto)
+carries no `deploy_unit` field at all — a chart's own deploy_unit was
+always the hardcoded `DEPLOY_UNIT_CHART` constant (Reconcile's INSERT, both
+before and after this migration), never sourced from a manifest — and no
+image-repository triple either, so there is no hot path that needs either
+column on that table; `v_current_chart` hardcodes
+`deploy_unit`/`description`/`chart_repository` as constants instead of
+projecting them off `manifest_json`, matching what those columns already
+were (dead/constant) before this migration. `artifact.manifest_id` carries
+no FK, for the same reason `artifact.owner_id` doesn't: it is polymorphic
+(an image artifact's names an `app_manifest` row, a chart artifact's a
+`chart_manifest` row), so referential integrity is enforced in Go
+(`postgres/artifact.go`'s `resolveManifestForPublish`, always run inside the
+same transaction as the write) rather than by the schema.
+`resolveManifestForPublish` prefers the snapshot at the artifact's own
+build's EXACT `git_sha` (typically the one `AssertApps` just wrote for this
+release), falling back to the newest snapshot for the owner on any commit
+when no exact match exists — a deliberate simplification: "derived at
+publish time" means "from the best snapshot known at publish time," not "the
+exact build commit, or fail" (requiring an exact match would make every
+domain's first post-AR-7c publish fail until `AssertApps` runs for it once).
+Migration 008's backfill also computes `artifact.promotability` for every
+row that predates it, from the CURRENT (about-to-be-dropped)
+`app`/`chart.deploy_unit` — the last time this repo ever computes
+promotability via a live join; those rows' `manifest_id` is left `NULL`
+(no snapshot honestly represents what was live when they actually
+published).
+
 ### `AssertApps` (additive) vs. `ReconcileApps` (absence sweep)
 
-**`AssertApps` itself is still proposed, not built** — it is AR-7c. The
-partial-apply and domain-qualified-reference paragraphs below are AR-7a and
-are built (see "Status" above); the split this heading names is not: today
-there is still only `ReconcileApps`, and it still runs exclusively from
-`main` push.
+**`AssertApps` is built (AR-7c, not yet merged).** The partial-apply and
+domain-qualified-reference paragraphs below are AR-7a, built earlier; the
+split this heading names is now real: `AppRegistry.AssertApps`
+(`protos/api.proto`/`api_messages_app.proto`) exists alongside
+`ReconcileApps`, implemented identically in `postgres/app.go`'s
+`appRepo.AssertApps` and `fake/reconcile.go`'s `assertApps`. `release.yml`
+calls it (via the new `.github/actions/app-registry-assert` composite
+action) as the FIRST App Registry step of both the `release` matrix job and
+`release-helm-charts` — ahead of `Record build`/`Begin publish` — so every
+subsequent owner-resolving call in the same job succeeds. See "Release-vs-
+reconcile gap (issue #547)" above for the resulting status of that gap.
 
 `ReconcileApps` conflates two jobs: assert identity, and assert *absence*.
 Only absence needs a canonical complete tree, and it is identity that releases

--- a/tools/app_registry/OPERATIONS.md
+++ b/tools/app_registry/OPERATIONS.md
@@ -73,21 +73,19 @@ To check whether a specific release actually got recorded:
 3. A step that ran and shows `✅ Recorded ... in App Registry` at the end
    succeeded.
 4. A step that ran, shows a red `X` inline but the **job** is still green —
-   this is the silent-failure case. As of issue #547, **you no longer have
-   to read the log to tell which kind of failure this is**: the run's
-   summary page (the `::warning::` annotations GitHub surfaces at the top of
-   the run, and the `$GITHUB_STEP_SUMMARY` section below the job list) now
-   says one of two distinct things:
-   - **`App Registry: <owner> not registered yet`** — the release ran ahead
-     of `ReconcileApps` (see `.github/actions/app-registry-reconcile`, which
-     runs on push to `main` via `ci.yml`). This is expected, not a
-     credential or CLI problem — see ["Release ran ahead of
-     reconcile"](#release-ran-ahead-of-reconcile-issue-547) below for what
-     to do.
+   this is the silent-failure case. The run's summary page (the
+   `::warning::` annotations GitHub surfaces at the top of the run, and the
+   `$GITHUB_STEP_SUMMARY` section below the job list) tells you which kind:
+   - **`App Registry: <owner> not registered yet`** — as of AR-7c (issue
+     #558), this should no longer happen in normal operation: `release.yml`
+     now calls `AssertApps` as the first App Registry step of every job that
+     later resolves an owner by full name (see "AR-7c: AssertApps closed
+     issue #547" below). If you see it anyway, the `AssertApps` step itself
+     probably failed too (a registry outage fails every App Registry step in
+     the same job, `AssertApps` included) — check that step's log first.
    - **`App Registry: recording skipped (registry error)`** — a genuine
      registry outage, auth failure, or timeout. Check the step log for the
-     underlying gRPC error (`Unauthenticated`, `Unavailable`, etc.) the same
-     way as before.
+     underlying gRPC error (`Unauthenticated`, `Unavailable`, etc.).
    The job outcome tells you nothing; only the step log (or now, the run
    summary) does.
 
@@ -105,52 +103,43 @@ older commit. See [ARCHITECTURE.md "Reconcile watermark"](ARCHITECTURE.md#reconc
 for the full mechanism, and re-run `ci.yml` for the commit you actually want
 reflected if that's not what already ran.
 
-### Release ran ahead of reconcile (issue #547)
+### AR-7c: AssertApps closed issue #547
 
-`release.yml` is a human-triggered `workflow_dispatch`, often run immediately
-after merging to `main` — normal usage, not an edge case. `ReconcileApps`
-only runs from `ci.yml` on push to `main` (#543), so there's a real window
-where a release for a genuinely new app/chart can run before that commit's
-reconcile has finished, or even started. This is a **known, accepted
-tradeoff** — see
-[ARCHITECTURE.md "Release-vs-reconcile gap"](ARCHITECTURE.md#release-vs-reconcile-gap-issue-547)
-for the two alternatives (a release-time provisional upsert; gating releases
-on `main`'s reconcile) that were considered and rejected, and why.
+**Retired runbook.** Before AR-7c (issue #558), `release.yml` had no path to
+write app/chart identity itself — `ReconcileApps` only ran from `ci.yml` on
+push to `main`, so a release for a genuinely new app/chart could reach
+`RecordArtifact`'s owner lookup before that commit's reconcile had finished,
+or even started, and fail with a distinct `App Registry: <owner> not
+registered yet` warning (CLI exit code 3, `ReasonOwnerNotReconciled`). This
+runbook entry described what to do about it (wait for `main` CI and re-run,
+or accept the identity self-healing while the specific artifact stayed
+unrecorded).
 
-**How to recognize it:** the recording step (`Record image artifact in App
-Registry`, `Record chart artifacts in App Registry`, or `Record build in App
-Registry`) shows a red `X` but the job is green, and the run carries a
-`::warning::` titled `App Registry: <owner> not registered yet` — plus a
-matching `### ⚠️ App Registry: <owner> not registered yet` section in the
-run's summary (`$GITHUB_STEP_SUMMARY`), so it's visible without opening any
-log. This is a structured signal, not a guess from wording: the CLI exits
-with a distinct code (3) specifically for this case (see `cli/cmd/root.go`'s
-`exitOwnerNotReconciled`), driven by a gRPC status detail the server attaches
-(`apierrors.ReasonOwnerNotReconciled`, set in
-`server/handlers/errors.go`'s `mapRepoErr`) — so it can't be confused with a
-registry outage, auth failure, or any other `InvalidArgument`.
+As of AR-7c, `release.yml` calls the new `AppRegistry.AssertApps` RPC (via
+`.github/actions/app-registry-assert`) as the **first** App Registry step of
+both the `release` matrix job and `release-helm-charts` — before any
+`Record build`/`Begin publish`/`Record artifact` call that resolves an owner
+by full name. `AssertApps` is additive and safe from any ref (see
+ARCHITECTURE.md "AssertApps (additive) vs. ReconcileApps (absence sweep)"),
+so by the time those calls run, the owner's identity already exists.
+`ReasonOwnerNotReconciled` / exit code 3 should no longer be reachable from
+a normal `release.yml` run.
 
-**What to do about it — pick one:**
+**If you still see it:** the `AssertApps` step itself likely failed first —
+a registry outage fails every App Registry step in the same job, this one
+included, and `continue-on-error` on `AssertApps` means that failure can be
+silent too. Check the `Assert apps/charts in App Registry` step's log before
+assuming this is the old #547 gap reopening. The underlying mechanism
+(exit code 3, `apierrors.ReasonOwnerNotReconciled`) is unchanged and still
+fires if `resolveOwner` (`server/handlers/artifact.go`) genuinely can't find
+the owner — it is just no longer reachable through the intended path.
 
-1. **Wait for `main`'s CI to finish**, then re-run the failed release job
-   (GitHub Actions → the run → "Re-run failed jobs"). Once
-   `reconcile-app-registry` (in `ci.yml`) has applied for this commit, the
-   owner exists and the same recording call succeeds.
-2. **Accept the miss.** The app/chart's *identity* self-heals automatically
-   — the next `main`-push reconcile registers it, the same as any
-   previously-`MISSING` app recovering (see "Triage: the MISSING/ARCHIVED
-   lifecycle" in ARCHITECTURE.md). But **the specific build/artifact record
-   for this release is not backfilled by that reconcile or by anything
-   else** — `ReconcileApps` only ever touches `app`/`chart` rows, never
-   `build`/`artifact`. If this artifact needs to be promotable or queryable
-   later, option 1 (re-run) is the only way to get it recorded; there is no
-   automatic recovery path for it.
-
-To confirm from the registry side rather than the log:
+To confirm a specific artifact recorded, from the registry side rather than
+the log:
 
 ```bash
 app-registry artifacts get <domain>-<name> --version vX.Y.Z
-# NotFound means it was never recorded (opt-in off, or the step failed)
+# NotFound means it was never recorded (opt-in off, or a step failed)
 ```
 
 **What a failed silent recording looks like in practice:** a release ships,

--- a/tools/app_registry/PLAN.md
+++ b/tools/app_registry/PLAN.md
@@ -16,8 +16,8 @@ Read [ARCHITECTURE.md](ARCHITECTURE.md) before executing any phase.
 
 ## Current status
 
-*Last updated in the AR-7 design session (issue #558). **AR-M through AR-6 are
-all merged to `main`** — see the table below.*
+*Last updated finishing AR-7c (issue #558). **AR-M through AR-7b are all
+merged to `main`** — see the table below.*
 
 | Phase | PR | State |
 |---|---|---|
@@ -33,8 +33,9 @@ all merged to `main`** — see the table below.*
 | AR-5a | [#513](https://github.com/whale-net/everything/pull/513) | merged — **inert**: no domain at stage `allocate`, `plan.go`'s tag path untouched |
 | AR-6a / AR-6b | [#516](https://github.com/whale-net/everything/pull/516), [#515](https://github.com/whale-net/everything/pull/515) | merged |
 | AR-7 (design) | [#559](https://github.com/whale-net/everything/pull/559) | merged — design + delivery plan only, no implementation |
-| AR-7a | branch `ar-7a-sweep-robustness`, not yet merged | **implemented** — sweep robustness, no schema change |
-| AR-7b | branch `ar-7b-artifact-lifecycle`, not yet merged | **implemented** — artifact lifecycle, migration `007`, `BeginPublish`/`FailPublish`, stale-row reaper |
+| AR-7a | [#561](https://github.com/whale-net/everything/pull/561) | merged — sweep robustness, no schema change |
+| AR-7b | [#562](https://github.com/whale-net/everything/pull/562) | merged — artifact lifecycle, migration `007`, `BeginPublish`/`FailPublish`, stale-row reaper |
+| AR-7c | branch `ar-7c-manifest-snapshot`, not yet merged | **implemented** — app identity/manifest-snapshot split, migration `008`, `AssertApps` |
 
 The registry is being deployed to `dev` by the repo owner. `app-registry-api`
 and `app-registry-migration` images publish from `apps=all`.
@@ -50,11 +51,11 @@ say "not merged" in places; the table above is authoritative.
 implemented and tested, wired to nothing. See "AR-5" below for what remains
 before any domain can be cut over.
 
-**AR-7 (issue #558) is designed; AR-7a and AR-7b are implemented, not yet
-merged.** The full phase makes a release run hermetic — no dependency on
-`main`'s reconcile having gone first — via an artifact `allocated →
-publishing → published` lifecycle, an identity/manifest-snapshot split of
-`app`, and a run log CI writes to. AR-7a fixes ordering 4 (see
+**AR-7 (issue #558): AR-7a and AR-7b are merged to `main`; AR-7c is
+implemented, not yet merged.** The full phase makes a release run hermetic —
+no dependency on `main`'s reconcile having gone first — via an artifact
+`allocated → publishing → published` lifecycle, an identity/manifest-snapshot
+split of `app`, and a run log CI writes to. AR-7a fixes ordering 4 (see
 ARCHITECTURE.md "The problem: four cross-run orderings"): `ReconcileApps` is
 now partially applying (one bad chart is skipped and reported, not a
 whole-sweep rollback), chart manifests carry domain-qualified app references
@@ -62,8 +63,11 @@ so a bare-name collision across domains can't break the sweep, and `ci.yml`'s
 `reconcile-app-registry` job is no longer `continue-on-error`. AR-7b adds the
 artifact lifecycle states, migration `007`, `BeginPublish`/`FailPublish` and
 the stale-row reaper, and its exit criteria are met (see its subsection).
-AR-7c…AR-7f remain design-only. Design is in ARCHITECTURE.md's "Release
-lifecycle (issue #558)"; delivery is "AR-7" below.
+AR-7c adds `AssertApps`, migration `008`'s identity/manifest-snapshot split,
+and the promotability-retroactivity fix (see its subsection) — its exit
+criteria are met too, but it has not merged yet. AR-7d…AR-7f remain
+design-only. Design is in ARCHITECTURE.md's "Release lifecycle (issue
+#558)"; delivery is "AR-7" below.
 
 **Where deferred work is tracked.** Three places, deliberately:
 [Carry-over items](#carry-over-items) for small cross-cutting gaps that
@@ -879,11 +883,13 @@ than by hand. Read ARCHITECTURE.md's "Release lifecycle (issue #558)" first;
 it carries the design, the four orderings this fixes, and the rejected
 alternatives. This section is delivery only.
 
-**AR-7a is implemented, not yet merged** (branch `ar-7a-sweep-robustness`).
-The remaining sub-phases (AR-7b … AR-7f) are ordered by dependency and still
+**AR-7a and AR-7b are merged to `main`** ([#561](https://github.com/whale-net/everything/pull/561),
+[#562](https://github.com/whale-net/everything/pull/562)). **AR-7c is
+implemented, not yet merged** (branch `ar-7c-manifest-snapshot`). The
+remaining sub-phases (AR-7d … AR-7f) are ordered by dependency and still
 design only.
 
-### AR-7a — Sweep robustness — done (not yet merged)
+### AR-7a — Sweep robustness — done, merged (#561)
 
 Independent of everything else in AR-7. Landed first, as planned.
 
@@ -984,7 +990,7 @@ explicitly out of scope — see the ground rules that constrained this phase):
   reintroduced, the not-marked-missing guard removed, and qualified
   resolution disabled), then the break was reverted.
 
-### AR-7b — Artifact lifecycle states — migration `007_artifact_lifecycle` — done
+### AR-7b — Artifact lifecycle states — migration `007_artifact_lifecycle` — done, merged (#562)
 
 **As built.** Implemented on branch `ar-7b-artifact-lifecycle`, not yet
 merged. Migration numbering matched the plan exactly — `007`, not `006`:
@@ -1155,38 +1161,199 @@ phases):**
 - Postgres integration tests: every legal transition, every illegal one
   rejected, reaper timeout, and the folded `version_allocation` data.
 
-### AR-7c — App identity / manifest snapshot split — migration `008`
+### AR-7c — App identity / manifest snapshot split — migration `008` — done (not yet merged)
 
 The design change. Depends on AR-7b (it touches the same write path).
+Implemented on branch `ar-7c-manifest-snapshot`, stacked on
+`ar-7b-artifact-lifecycle` (itself stacked on `ar-7a-sweep-robustness`).
 
-**Scope**
-- Migration: append-only `app_manifest` / `chart_manifest`
-  (`(owner_id, source_git_sha)` unique, verbatim protojson `JSONB` plus
-  **stored generated columns** for `deploy_unit` and `image_repository` — the
-  two fields the hot read paths need indexable, decided in review;
-  `source_committed_at`, sweep-vs-release provenance); `artifact.manifest_id`
-  and `artifact.promotability` (stored, derived at publish time);
-  `app`/`chart` drop their mutable metadata columns; `v_current_app` /
-  `v_current_chart` views. Backfill snapshots from the current `app`/`chart`
-  rows against the latest reconciled `git_sha` so nothing loses metadata.
-- New `AppRegistry.AssertApps`: additive identity + snapshot write, safe from
-  any ref, never marks `MISSING`, rejects assertion against an `ARCHIVED` app
-  per item. `RecordArtifact` against an `ARCHIVED` owner is rejected too.
-- `ReconcileApps` keeps the absence sweep, `chart_app` membership, the
-  watermark, and now writes `main`-sweep snapshots.
-- `release.yml` calls `AssertApps` as the first step of the release job, from
-  the released ref — this is what closes #547's gap.
-- Reads (`ListApps`/`GetApp`/promotability) move to the views; wire responses
-  are unchanged.
-- Docs: ARCHITECTURE.md's #547 section moves from "accept the gap" to
-  "closed"; OPERATIONS.md's owner-not-reconciled runbook entry retires.
+**As built**
+- Migration `008_app_identity_split`: append-only `app_manifest` /
+  `chart_manifest` (`(owner_id, source_git_sha)` unique, verbatim protojson
+  `JSONB` — `UseProtoNames: true, EmitUnpopulated: true`, matching the
+  Starlark-emitted snake_case JSON and writing every field including
+  zero-valued ones), `source_committed_at`, `provenance` ∈
+  `sweep`/`release`. **`app_manifest` gets the two generated columns
+  (`deploy_unit`, `image_repository`); `chart_manifest` gets NEITHER** —
+  `ChartManifest` (appmeta.proto) carries no `deploy_unit` field at all (a
+  chart's own deploy_unit was always the hardcoded `DEPLOY_UNIT_CHART`
+  constant, never sourced from a manifest) and no image-repository triple
+  either, so there is no hot path that needs a generated column on that
+  table — narrower than the scope note's "for `deploy_unit` and
+  `image_repository`" phrasing, which describes the pair as a whole rather
+  than promising both on both tables. `artifact.manifest_id` (nullable
+  `UUID`, deliberately no FK — polymorphic, same reasoning as `owner_id`
+  not being one) and `artifact.promotability` (nullable `TEXT`, a new
+  `artifact_promotability_shape` CHECK ties it to `state = 'published'`,
+  mirroring migration 007's `artifact_state_shape`). `app`/`chart` drop
+  description/language/app_type/deploy_unit/bazel_label/image_repository
+  (app) and description/chart_repository/deploy_unit (chart) — pure
+  identity. `v_current_app`/`v_current_chart` views, following
+  `v_current_promotion`'s pattern exactly, with `appColumns`/`chartColumns`
+  UNCHANGED in name/order so `scanApp`/`scanChart` (postgres/app.go) needed
+  no edits — only their `FROM` clause moved. Write-path lookups
+  (`getAppByDomainName`, `resolveChartApps`) query the bare identity table
+  directly via new `identityColumns`, not the view, since they only ever
+  need `app_id`/`status`. Backfill: one snapshot per existing app/chart row,
+  attributed to `reconcile_watermark`'s current `git_sha` (falling back to
+  the migration-006 sentinel if never reconciled); `image_repository` is
+  reconstructed via `split_part` on the existing concatenated string (safe
+  — none of registry/organization/repo_name legitimately contains `/`);
+  `artifact.promotability` is backfilled for every existing `published` row
+  from the CURRENT (about-to-be-dropped) `app`/`chart.deploy_unit` — the
+  last time this repo ever computes promotability from a live join;
+  `manifest_id` is deliberately left `NULL` for these rows (no snapshot
+  honestly corresponds to what was live when they actually published — see
+  the migration's comments). A real `.down.sql` restores the flat columns,
+  backfilled from the newest snapshot per owner (any provenance), matching
+  `007`'s no-full-history-preservation convention.
+- New `AppRegistry.AssertApps` (`protos/api.proto`,
+  `api_messages_app.proto`): takes the same `AppManifestSet` shape
+  `ReconcileApps` does. Additive only — creates (`∅ → ACTIVE`) or recovers
+  (`MISSING → ACTIVE`) identity and writes/refreshes a manifest snapshot
+  (`provenance = 'release'`); an already-`ACTIVE` app/chart just gets a
+  fresh snapshot. Never consults or advances the reconcile watermark (there
+  is nothing for a stale call to wrongly revert, since nothing is ever
+  marked `MISSING`) and never touches `chart_app` membership — composition
+  resolution stays `ReconcileApps`-only, because it needs the canonical
+  complete tree to be safe. An `ARCHIVED` target is rejected **per item**
+  (`AssertResult.RejectedApps`/`RejectedCharts`, modeled exactly on
+  `UnresolvedChart`'s skip-and-report shape) — every other app/chart in the
+  same call still applies. Implemented identically in `postgres/app.go`
+  (`appRepo.AssertApps`) and `fake/reconcile.go` (`assertApps`).
+  `RecordArtifact`/`BeginPublish`/`AllocateVersion` against an `ARCHIVED`
+  owner are now rejected too (`handlers/artifact.go`'s
+  `resolveOwner`/`resolveOwnerAndDomain`, via a new
+  `repository.ErrOwnerArchived` sentinel → `FailedPrecondition`) — before
+  AR-7c this succeeded silently.
+- `ReconcileApps` unchanged in shape (absence sweep, `chart_app`
+  membership, the watermark) but now ALSO writes a `provenance = 'sweep'`
+  manifest snapshot for every app/chart it creates or updates
+  (`upsertAppManifestSnapshot`/`upsertChartManifestSnapshot`, `ON CONFLICT
+  (owner_id, source_git_sha) DO NOTHING` — naturally idempotent). This is
+  the ONLY provenance `v_current_app`/`v_current_chart` ever read — an
+  `AssertApps` snapshot from a divergent ref must never leak into "what
+  does this app look like today."
+- `artifact.promotability` is now resolved and STORED exactly once, at the
+  instant a row reaches `published` (`postgres/artifact.go`'s
+  `resolveManifestForPublish`, called from `insertArtifact`/
+  `completePublish`) — never recomputed on read. Prefers the manifest
+  snapshot at the artifact's OWN build's exact `git_sha` (typically the one
+  `AssertApps` just wrote for this release); falls back to the newest
+  snapshot for the owner, any commit, when no exact match exists (a domain
+  that hasn't wired `AssertApps` in yet, or a build predating AR-7c) — a
+  deliberate simplification named in ARCHITECTURE.md: "derived at publish
+  time" means "from the best snapshot known at publish time," not
+  "guaranteed to be the exact build commit." A chart artifact's
+  promotability never depends on a snapshot at all (`DerivePromotability(CHART,
+  CHART)` is always `PROMOTABLE` — see the generated-columns note above),
+  so its resolution is a plain lookup for `manifest_id` bookkeeping, no
+  branch. `scanArtifact` reads `artifact.manifest_id`/`promotability`
+  directly; the old `LEFT JOIN app/chart` in `artifactSelectBase` and the
+  live `DerivePromotability` call on every read are gone.
+- `fake/fake.go` mirrors the same "store once at publish time" invariant
+  (it never modeled manifest snapshots at the storage level — `App`/`Chart`
+  stay flat, representing the current-view shape both before and after this
+  phase) — `insertArtifact`/`completePublish` set `Artifact.Promotability`
+  once, `ListArtifacts`/`GetArtifact`/`ResolveArtifact` read it back
+  verbatim instead of calling `derivePromotability` again.
+- CLI: `app-registry apps assert` (`cli/cmd/apps.go`), mirroring `apps
+  reconcile`'s `--from-plan`/`--idempotency-key` shape (no `--dry-run` — no
+  absence sweep to preview), with `printRejectedOwnersWarning` (stderr
+  banner ahead of the JSON body, mirroring `printUnresolvedChartsWarning`).
+- `.github/actions/app-registry-assert` (new composite action, mirroring
+  `app-registry-reconcile`'s `manifest-set` + CLI-call pattern) is called as
+  the FIRST App Registry step of both `release.yml`'s `release` (per-app
+  matrix, one step per leg) and `release-helm-charts` jobs — ahead of
+  `Record build`/`Begin publish`, so every subsequent owner-resolving call
+  in the same job succeeds. `APP_REGISTRY_CICD_OPT_IN` gate and
+  `continue-on-error: true` preserved, matching every other recording step's
+  posture at adoption stage `observe` (every domain, today) — see
+  ARCHITECTURE.md "Availability, restated per adoption stage": a registry
+  outage here would fail every OTHER recording step in the same job anyway,
+  so this isn't a new single point of failure. The stale
+  "ReconcileApps deliberately does NOT run here" comment in `plan-release`
+  is updated to point at `AssertApps` as the ref-safe counterpart, without
+  contradicting the (still-true) reasoning for why the absence sweep can't
+  run there.
+- Reads (`ListApps`/`GetApp`/`ListCharts`) move to `v_current_app`/
+  `v_current_chart`; wire responses are UNCHANGED — `appToPB`/`chartToPB`
+  (`handlers/convert.go`) and the `repository.App`/`Chart` Go structs were
+  not touched, only what SQL populates them.
+- Docs: this section; ARCHITECTURE.md's "Release lifecycle" status line and
+  "App identity vs. per-build manifest snapshot"/"AssertApps" subsections
+  moved from proposed to built; the #547 section's callout box changed from
+  "still true as-built" to "closed by AR-7c"; OPERATIONS.md's "Release ran
+  ahead of reconcile (issue #547)" runbook section retired (replaced with a
+  pointer to AssertApps closing the gap); `migrate/README.md`'s migration
+  table and numbering.
 
-**Exit criteria**
+**Deliberately NOT done / narrowed**
+- `chart_manifest` ships with NO generated columns at all — see the
+  migration note above. If a future phase needs an indexable chart-side
+  field, it gets its own generated column added when that phase actually
+  needs it, not speculatively here.
+- `artifact.manifest_id` is left `NULL` for every artifact published BEFORE
+  migration 008 — there is no historical snapshot that honestly represents
+  what was live when those actually published, and attributing them to the
+  migration-time backfill snapshot would be dishonest metadata. Their
+  `promotability` IS backfilled (from the live join, one last time).
+- `resolveManifestForPublish`'s exact-git_sha-with-fallback behavior means
+  "derived at publish time" is not a hard guarantee of exact-commit
+  attribution for domains that haven't adopted `AssertApps` yet — see the
+  postgres/artifact.go doc comment. This is intentional: requiring an exact
+  match would make every domain's first post-AR-7c publish fail until
+  `AssertApps` runs for it once, which contradicts "additive, safe from any
+  ref."
+- `GetReleaseRun`, `AdoptArtifact`, and compose-time chart hermeticity
+  remain AR-7d/e/f, untouched here.
+
+**Verified, not merely built**
+- `bazel build //tools/...` and `bazel test //tools/...` green.
+- `postgres_integration_test` (`manual`-tagged, Docker) run for real:
+  `AssertApps` create/recover/no-op-empty-set/reject-ARCHIVED-per-item
+  (`TestAssertApps_CreatesIdentityAndSnapshot_Postgres`,
+  `TestAssertApps_RejectsArchivedApp_Postgres`), `RecordArtifact` rejecting
+  an `ARCHIVED` owner (`TestRecordArtifact_RejectsArchivedOwner_Postgres`),
+  the retroactivity fix
+  (`TestRecordArtifact_PromotabilityIsNotRetroactive_Postgres`), `AssertApps`
+  then `RecordArtifact` with NO `ReconcileApps` ever having run
+  (`TestAssertApps_ThenRecordArtifact_NoReconcileNeeded_Postgres`), snapshot
+  idempotency on `(owner_id, source_git_sha)`
+  (`TestAppManifestSnapshot_IdempotentOnOwnerGitSha`), the generated
+  columns, and the migration 008 backfill against a database seeded in the
+  pre-008 shape (`TestMigration008BackfillsSnapshotsFromExistingRows`, using
+  `runner.Steps(7)` then `runner.Up()` — the only way to exercise a backfill
+  against real pre-existing data under this test harness).
+- Mirrored at the handler/fake level
+  (`server/handlers/app_test.go`/`artifact_test.go`):
+  `TestAssertApps_CreatesIdentity`, `TestAssertApps_NeverMarksMissing`,
+  `TestAssertApps_RecoversMissingApp`,
+  `TestAssertApps_RejectsArchivedAppPerItem`,
+  `TestAssertApps_ThenRecordArtifact_NoReconcileNeeded`,
+  `TestRecordArtifact_RejectsArchivedOwner`, and the retroactivity fix
+  (`TestRecordArtifact_PromotabilityIsNotRetroactive`).
+- The retroactivity-fix test was verified to fail when the behavior it
+  guards was deliberately broken: reintroducing a live
+  `derivePromotability` call in the fake's `GetArtifact` (undoing the
+  "store once at publish time" fix) turned
+  `TestRecordArtifact_PromotabilityIsNotRetroactive` red with the exact
+  before/after values the bug would produce, then the break was reverted.
+- The two touched workflow YAMLs (`release.yml`, the new
+  `app-registry-assert/action.yml`) were validated for syntax only
+  (`python3 -c "import yaml,sys; yaml.safe_load(...)"`), same as AR-7b's
+  before it — they cannot be executed in this environment.
+
+**Exit criteria — all met**
 - A release from a branch that never merges records its build, artifacts and
-  a manifest snapshot, and writes no mutable state anything else can observe.
+  a manifest snapshot, and writes no mutable state anything else can observe
+  — `TestAssertApps_ThenRecordArtifact_NoReconcileNeeded_Postgres`.
 - Editing an app's `deploy_unit` does not change the promotability of an
-  artifact published before the edit (the retroactivity bug, proven by test).
-- `exit 3` / `ReasonOwnerNotReconciled` becomes unreachable from `release.yml`.
+  artifact published before the edit (the retroactivity bug, proven by test)
+  — `TestRecordArtifact_PromotabilityIsNotRetroactive[_Postgres]`.
+- `exit 3` / `ReasonOwnerNotReconciled` becomes unreachable from
+  `release.yml` — `AssertApps` runs as the first App Registry step of both
+  jobs that later resolve an owner by full name, before any such call.
 
 ### AR-7d — Run log and resume — no schema change
 

--- a/tools/app_registry/cli/cmd/apps.go
+++ b/tools/app_registry/cli/cmd/apps.go
@@ -19,6 +19,7 @@ func newAppsCmd() *cobra.Command {
 		newAppsGetCmd(),
 		newAppsSetStatusCmd(),
 		newAppsReconcileCmd(),
+		newAppsAssertCmd(),
 	)
 	return appsCmd
 }
@@ -155,6 +156,66 @@ func newAppsReconcileCmd() *cobra.Command {
 	_ = c.MarkFlagRequired("from-plan")
 	_ = c.MarkFlagRequired("idempotency-key")
 	return c
+}
+
+// newAppsAssertCmd implements `apps assert` -- AR-7c (issue #558), the
+// additive-only counterpart to `apps reconcile`. Called from release.yml as
+// the first step of a release run, against whatever manifest set that ref
+// discovers -- unlike reconcile it is safe from ANY ref (never marks
+// anything MISSING), so it needs no --dry-run flag: there is no absence
+// sweep to preview.
+func newAppsAssertCmd() *cobra.Command {
+	var fromPlan string
+	c := &cobra.Command{
+		Use:   "assert",
+		Short: "Additively assert app/chart identity + manifest snapshot from any ref (release)",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			data, err := os.ReadFile(fromPlan)
+			if err != nil {
+				return fmt.Errorf("failed to read plan file %s: %w", fromPlan, err)
+			}
+			manifests := &appmetapb.AppManifestSet{}
+			if err := unmarshalJSON(data, manifests); err != nil {
+				return fmt.Errorf("failed to parse plan file %s as AppManifestSet: %w", fromPlan, err)
+			}
+			return withClient(cmd, func(rc *registryClient) error {
+				resp, err := rc.App.AssertApps(cmd.Context(), &pb.AssertAppsRequest{
+					Manifests:      manifests,
+					IdempotencyKey: idempotencyKeyFlag,
+				})
+				if err != nil {
+					return err
+				}
+				printRejectedOwnersWarning(cmd, resp.RejectedApps, resp.RejectedCharts)
+				return printResponse(resp)
+			})
+		},
+	}
+	c.Flags().StringVar(&fromPlan, "from-plan", "", "Path to an AppManifestSet JSON file (from bazel query)")
+	c.Flags().StringVar(&idempotencyKeyFlag, "idempotency-key", "", "Required. <workflow_run_id>-<attempt>[-<domain>-<app>]")
+	_ = c.MarkFlagRequired("from-plan")
+	_ = c.MarkFlagRequired("idempotency-key")
+	return c
+}
+
+// printRejectedOwnersWarning renders every app/chart AssertApps declined to
+// touch (ARCHIVED) prominently, on stderr, ahead of the JSON body --
+// mirrors printUnresolvedChartsWarning below: a per-item skip must not be
+// able to hide inside an otherwise-green step.
+func printRejectedOwnersWarning(cmd *cobra.Command, apps, charts []*pb.RejectedOwner) {
+	if len(apps) == 0 && len(charts) == 0 {
+		return
+	}
+	fmt.Fprintf(cmd.ErrOrStderr(),
+		"\n*** REJECTED: %d app(s), %d chart(s) skipped -- ARCHIVED, not resurrected ***\n",
+		len(apps), len(charts))
+	for _, a := range apps {
+		fmt.Fprintf(cmd.ErrOrStderr(), "  - app %s/%s: %s\n", a.Domain, a.Name, a.Reason)
+	}
+	for _, c := range charts {
+		fmt.Fprintf(cmd.ErrOrStderr(), "  - chart %s/%s: %s\n", c.Domain, c.Name, c.Reason)
+	}
+	fmt.Fprintln(cmd.ErrOrStderr())
 }
 
 // printUnresolvedChartsWarning renders every UnresolvedChart in resp

--- a/tools/app_registry/migrate/README.md
+++ b/tools/app_registry/migrate/README.md
@@ -36,7 +36,7 @@ ArgoCD sync waves. See `friendly_computing_machine/docs/argocd-integration.md`.
 | `005_version_allocation` (AR-5a) | `artifact.version_major/minor/patch` + backfill, `artifact_version_order_idx`, `version_allocation` |
 | `006_reconcile_watermark` (issue #545) | `reconcile_watermark` — singleton row guarding `ReconcileApps` against a stale (older-commit) call landing after a newer one |
 | `007_artifact_lifecycle` (AR-7b, issue #558) | `artifact.state`/`provenance`/`version_source`/`state_changed_at`/`fail_reason`, nullable `digest`/`build_id`/`published_at`, `artifact_state_shape` CHECK, partial-unique `artifact_digest_idx` (`WHERE digest IS NOT NULL`), `artifact_state_idx` (reaper sweep), `version_allocation` folded into `artifact` as `state = 'allocated'` and dropped |
-| `008_app_identity_split` (AR-7c, **planned**) | append-only `app_manifest`/`chart_manifest` snapshots, `artifact.manifest_id`/`promotability`, `app`/`chart` lose their mutable metadata, `v_current_app`/`v_current_chart` |
+| `008_app_identity_split` (AR-7c, issue #558) | Append-only `app_manifest`/`chart_manifest` snapshots (`(owner_id, source_git_sha)` unique, verbatim protojson `JSONB`; `app_manifest` alone gets stored generated `deploy_unit`/`image_repository` columns — `chart_manifest` gets neither, see the migration's own comments); `artifact.manifest_id` (no FK — polymorphic) and `artifact.promotability` (stored, `artifact_promotability_shape` CHECK ties it to `state = 'published'`); `app`/`chart` lose their mutable metadata columns, becoming pure identity; `v_current_app`/`v_current_chart` views (`v_current_promotion`'s pattern). Backfills one snapshot per existing app/chart row and `artifact.promotability` for every existing published row before dropping the columns those are sourced from. |
 
 Split this way so AR-2 needs only `001`, AR-3b adds `002`, AR-3c adds `003`,
 AR-4b adds `004`, and AR-5a adds `005` — each phase ships an independently
@@ -100,6 +100,15 @@ CREATE INDEX artifact_version_order_idx
 -- regardless of how large the published/failed tail of the table grows.
 CREATE INDEX artifact_state_idx ON artifact (state, state_changed_at)
   WHERE state IN ('allocated', 'publishing');
+
+-- AR-7c (migration 008): backs v_current_app's/v_current_chart's "latest
+-- main-sweep snapshot per owner" LATERAL join -- the hot path every
+-- ListApps/GetApp/ListCharts read, and every RecordBuild/RecordArtifact/
+-- BeginPublish owner-repository lookup, now goes through.
+CREATE INDEX app_manifest_current_idx
+  ON app_manifest (owner_id, provenance, source_committed_at DESC, recorded_at DESC);
+CREATE INDEX chart_manifest_current_idx
+  ON chart_manifest (owner_id, provenance, source_committed_at DESC, recorded_at DESC);
 ```
 
 `reconcile_watermark` (`006`) is seeded with exactly one sentinel row at

--- a/tools/app_registry/migrate/schema/migrations/008_app_identity_split.down.sql
+++ b/tools/app_registry/migrate/schema/migrations/008_app_identity_split.down.sql
@@ -1,0 +1,75 @@
+-- Rollback App Registry App Identity / Manifest Snapshot Split (AR-7c, issue #558)
+--
+-- Matches the style of 007's down: restores the pre-migration column shape
+-- and backfills it from the best available data, but does NOT attempt to
+-- preserve full snapshot history -- the same tradeoff 003's down (DROP TABLE
+-- promotion) and 007's down (DELETE FROM artifact WHERE state != 'published')
+-- already make for this repo's migrations. Once this runs, app_manifest/
+-- chart_manifest and everything in them are gone; only the single "latest
+-- known" value per app/chart survives, folded back into the old flat
+-- columns.
+
+-- ============================================================================
+-- Drop the views first -- they reference columns this migration is about to
+-- resurrect on app/chart and drop from artifact, so they must go before
+-- either ALTER.
+-- ============================================================================
+
+DROP VIEW IF EXISTS v_current_chart;
+DROP VIEW IF EXISTS v_current_app;
+
+-- ============================================================================
+-- Restore app / chart's mutable columns, backfilled from the newest
+-- snapshot per owner (any provenance -- unlike v_current_app, this rollback
+-- is a one-time best-effort data recovery, not a live read path, so there is
+-- no reason to prefer 'sweep' over 'release' here).
+-- ============================================================================
+
+ALTER TABLE app
+    ADD COLUMN description       TEXT NOT NULL DEFAULT '',
+    ADD COLUMN language           TEXT NOT NULL DEFAULT '',
+    ADD COLUMN app_type           TEXT NOT NULL DEFAULT '',
+    ADD COLUMN deploy_unit        TEXT NOT NULL DEFAULT 'chart' CHECK (deploy_unit IN ('chart', 'image', 'none')),
+    ADD COLUMN bazel_label        TEXT NOT NULL DEFAULT '',
+    ADD COLUMN image_repository   TEXT NOT NULL DEFAULT '';
+
+UPDATE app a
+SET
+    description      = COALESCE(m.manifest_json ->> 'description', ''),
+    language          = COALESCE(m.manifest_json ->> 'language', ''),
+    app_type          = COALESCE(m.manifest_json ->> 'app_type', ''),
+    deploy_unit       = COALESCE(m.deploy_unit, 'chart'),
+    bazel_label       = COALESCE(m.manifest_json ->> 'binary_target', ''),
+    image_repository  = COALESCE(m.image_repository, '')
+FROM LATERAL (
+    SELECT deploy_unit, image_repository, manifest_json
+    FROM app_manifest
+    WHERE owner_id = a.app_id
+    ORDER BY source_committed_at DESC, recorded_at DESC
+    LIMIT 1
+) m;
+
+ALTER TABLE chart
+    ADD COLUMN description       TEXT NOT NULL DEFAULT '',
+    ADD COLUMN chart_repository  TEXT NOT NULL DEFAULT '',
+    ADD COLUMN deploy_unit        TEXT NOT NULL DEFAULT 'chart' CHECK (deploy_unit IN ('chart', 'image', 'none'));
+
+-- chart.deploy_unit was always the hardcoded 'chart' constant (see the up
+-- migration's "Why chart_manifest has no generated columns") -- the column
+-- default above already restores that for every row, nothing to backfill
+-- from chart_manifest.
+
+-- ============================================================================
+-- Drop artifact.manifest_id / promotability
+-- ============================================================================
+
+ALTER TABLE artifact DROP CONSTRAINT IF EXISTS artifact_promotability_shape;
+ALTER TABLE artifact DROP COLUMN IF EXISTS promotability;
+ALTER TABLE artifact DROP COLUMN IF EXISTS manifest_id;
+
+-- ============================================================================
+-- Drop the snapshot tables
+-- ============================================================================
+
+DROP TABLE IF EXISTS chart_manifest;
+DROP TABLE IF EXISTS app_manifest;

--- a/tools/app_registry/migrate/schema/migrations/008_app_identity_split.up.sql
+++ b/tools/app_registry/migrate/schema/migrations/008_app_identity_split.up.sql
@@ -1,0 +1,398 @@
+-- App Registry — App identity / manifest snapshot split (AR-7c, issue #558)
+--
+-- See ARCHITECTURE.md "Release lifecycle (issue #558)" -> "App identity vs.
+-- per-build manifest snapshot" for the full design. Summary: `app`/`chart`
+-- today carry MUTABLE metadata (description, deploy_unit, bazel_label,
+-- image_repository, ...) that some ref has to author, and every choice of
+-- "which ref" is bad -- let any ref write it and it drifts; let only `main`
+-- write it and releases depend on `main`'s CI having gone first (issue
+-- #547). This migration removes the question instead of answering it:
+--
+--   1. `app`/`chart` become pure identity: (domain, name), status,
+--      first/last-seen. Nothing mutable survives on these tables.
+--   2. The AppManifest/ChartManifest a run was built from is stored
+--      VERBATIM (protojson, JSONB) in a new append-only `app_manifest` /
+--      `chart_manifest` snapshot table, keyed unique on
+--      (owner_id, source_git_sha) -- same commit, same manifest, so writes
+--      are naturally idempotent (an ON CONFLICT DO NOTHING in the Go code,
+--      not enforced here -- see postgres/app.go). This is deliberately the
+--      SINGLE source of truth for app/chart metadata: a new appmeta field
+--      needs no migration here and cannot drift from the manifest, because
+--      there is nothing beside the manifest left to drift.
+--   3. Two STORED GENERATED columns, `deploy_unit` and `image_repository`,
+--      ride alongside app_manifest.manifest_json -- ONLY these two, because
+--      they are the fields the hot read paths (promotability derivation,
+--      RecordBuild/BeginPublish's owner-repository lookup) need indexable.
+--      Fully typed columns for the rest of the manifest were explicitly
+--      rejected in review of PR #559: they would reintroduce the
+--      hand-maintained duplicate of the manifest schema that AR-M spent a
+--      whole phase deleting (see ARCHITECTURE.md "Shared manifest schema").
+--      chart_manifest gets NEITHER column -- see "Why chart_manifest has no
+--      generated columns" below.
+--   4. `artifact` gains `manifest_id` (which snapshot a published row was
+--      built from) and `promotability`, now a STORED column computed once
+--      at publish time from that snapshot instead of re-derived on every
+--      read from the owner's CURRENT deploy_unit. This is the correctness
+--      fix ARCHITECTURE.md calls out: editing a release_app's deploy_unit
+--      today silently changes the promotability of artifacts published
+--      years ago (postgres/artifact.go's old scanArtifact joined app/chart
+--      LIVE on every SELECT). After this migration promotability is frozen
+--      at RecordArtifact time and never recomputed.
+--   5. `v_current_app` / `v_current_chart` views pre-join identity ⋈ latest
+--      `main`-sweep snapshot, following the exact pattern `v_current_promotion`
+--      already established (migration 003) -- every existing read path
+--      (ListApps/GetApp/ListCharts/scanApp/scanChart in
+--      postgres/app.go) is repointed at these views with NO Go-level
+--      column-order change, so the wire shape of App/Chart is unchanged.
+--   6. Backfill: one app_manifest/chart_manifest snapshot row per CURRENT
+--      app/chart row, and artifact.promotability for every EXISTING
+--      artifact row, computed from today's (about-to-be-dropped) app/chart
+--      columns -- see "Backfill" below. Nothing loses metadata.
+--
+-- Why now, not earlier: AR-7b (migration 007) already made digest/build_id
+-- nullable and gave artifact a lifecycle; this migration reuses that same
+-- write path (BeginPublish -> RecordArtifact) to also resolve and stamp
+-- manifest_id/promotability, so it depends on 007 and could not have landed
+-- first.
+
+-- ============================================================================
+-- 1. app_manifest / chart_manifest: append-only snapshot tables
+-- ============================================================================
+
+-- app_manifest: one row per (app, git_sha) a manifest was ever observed at,
+-- written by BOTH ReconcileApps (provenance = 'sweep', from `main` only) and
+-- the new AssertApps (provenance = 'release', from any ref -- AR-7c). The
+-- unique index makes a repeat write of the SAME commit's manifest a no-op
+-- (see postgres/app.go's upsertAppManifestSnapshot: `ON CONFLICT
+-- (owner_id, source_git_sha) DO NOTHING`) -- there is nothing to update,
+-- because the manifest for a given commit cannot change.
+CREATE TABLE app_manifest (
+    app_manifest_id       UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    owner_id              UUID NOT NULL REFERENCES app (app_id),
+    source_git_sha        TEXT NOT NULL,
+
+    -- Committer timestamp (Unix seconds) of source_git_sha -- same field and
+    -- same 0-means-unresolved convention as AppManifestSet.source_committed_at
+    -- (appmeta.proto) and reconcile_watermark.source_committed_at (migration
+    -- 006). Used to pick the newest sweep snapshot in v_current_app below.
+    source_committed_at   BIGINT NOT NULL DEFAULT 0,
+
+    -- Which call wrote this snapshot. 'sweep' = ReconcileApps (main push
+    -- only) -- the only provenance v_current_app reads, because absence/
+    -- "what does this app look like today" is a main-tree question (see
+    -- ARCHITECTURE.md "AssertApps (additive) vs. ReconcileApps"). 'release'
+    -- = AssertApps, called from release.yml against whatever ref is being
+    -- released -- recorded for provenance/audit ("was this build's
+    -- promotability derived from a sweep snapshot or a release-time one?"),
+    -- never read by v_current_app.
+    provenance            TEXT NOT NULL CHECK (provenance IN ('sweep', 'release')),
+
+    -- The AppManifest, verbatim, as protojson
+    -- (UseProtoNames: true, EmitUnpopulated: true -- see postgres/app.go's
+    -- marshalAppManifest). This IS the metadata now; description/language/
+    -- app_type/bazel_label/etc. all live only here, read back out via
+    -- v_current_app's ->> projections. Storing protojson (not a hand-rolled
+    -- JSON shape) means a field added to AppManifest needs no migration --
+    -- it just starts appearing in manifest_json, exactly like AR-M's
+    -- rationale for using the shared appmeta proto in the first place.
+    manifest_json          JSONB NOT NULL,
+
+    -- Stored generated columns -- see this migration's header comment #3.
+    -- Parses the SAME four-way DeployUnit enum protojson emits
+    -- ("DEPLOY_UNIT_CHART"/"DEPLOY_UNIT_IMAGE"/"DEPLOY_UNIT_NONE"/
+    -- "DEPLOY_UNIT_UNSPECIFIED" or the key absent) into the lowercase DB
+    -- convention app.deploy_unit used to store directly -- mirrors
+    -- postgres/app.go's deployUnitToDB/normalizeDeployUnit exactly:
+    -- UNSPECIFIED (or a missing key) defaults to 'chart', matching
+    -- normalizeDeployUnit's existing default-to-chart behavior.
+    deploy_unit            TEXT GENERATED ALWAYS AS (
+        CASE manifest_json ->> 'deploy_unit'
+            WHEN 'DEPLOY_UNIT_IMAGE' THEN 'image'
+            WHEN 'DEPLOY_UNIT_NONE'  THEN 'none'
+            ELSE 'chart'
+        END
+    ) STORED,
+
+    -- Mirrors postgres/app.go's imageRepository() helper exactly: empty
+    -- only when registry/organization/repo_name are ALL empty, otherwise
+    -- the slash-joined concatenation (even if some parts are empty) -- same
+    -- edge-case behavior the pre-AR-7c Go helper had, preserved rather than
+    -- "fixed" here so this migration is a pure storage change, not a
+    -- behavior change.
+    image_repository       TEXT GENERATED ALWAYS AS (
+        CASE
+            WHEN COALESCE(manifest_json ->> 'registry', '') = ''
+             AND COALESCE(manifest_json ->> 'organization', '') = ''
+             AND COALESCE(manifest_json ->> 'repo_name', '') = ''
+            THEN ''
+            ELSE COALESCE(manifest_json ->> 'registry', '') || '/' ||
+                 COALESCE(manifest_json ->> 'organization', '') || '/' ||
+                 COALESCE(manifest_json ->> 'repo_name', '')
+        END
+    ) STORED,
+
+    recorded_at             TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    UNIQUE (owner_id, source_git_sha)
+);
+
+-- Backs v_current_app's "latest sweep snapshot per owner" lookup below --
+-- see this migration's header comment #5.
+CREATE INDEX app_manifest_current_idx
+    ON app_manifest (owner_id, provenance, source_committed_at DESC, recorded_at DESC);
+
+-- chart_manifest: the chart-side counterpart. See "Why chart_manifest has
+-- no generated columns" below for why this table has manifest_json and
+-- nothing else beside the standard columns.
+CREATE TABLE chart_manifest (
+    chart_manifest_id      UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    owner_id                UUID NOT NULL REFERENCES chart (chart_id),
+    source_git_sha          TEXT NOT NULL,
+    source_committed_at     BIGINT NOT NULL DEFAULT 0,
+    provenance               TEXT NOT NULL CHECK (provenance IN ('sweep', 'release')),
+    manifest_json            JSONB NOT NULL,
+    recorded_at              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    UNIQUE (owner_id, source_git_sha)
+);
+
+CREATE INDEX chart_manifest_current_idx
+    ON chart_manifest (owner_id, provenance, source_committed_at DESC, recorded_at DESC);
+
+-- Why chart_manifest has no generated columns: the two columns this
+-- migration adds generated columns for (deploy_unit, image_repository) are
+-- both APP-only concepts. `ChartManifest` (appmeta.proto) carries no
+-- deploy_unit field at all -- a chart's own "deploy_unit" was always the
+-- HARDCODED constant DEPLOY_UNIT_CHART in Reconcile's old INSERT (a chart is
+-- definitionally the chart deploy unit), never something read from a
+-- manifest, and v_current_chart below keeps hardcoding it the same way, so
+-- there is nothing on chart_manifest to derive it from. image_repository
+-- likewise has no chart-side equivalent (charts don't have an image
+-- registry/organization/repo_name triple). Adding either column here would
+-- violate the "only these two, and only where the hot path needs them"
+-- constraint decided in review of PR #559 -- there is no hot path reading a
+-- generated column off chart_manifest.
+
+-- ============================================================================
+-- 2. Backfill: one snapshot row per CURRENT app/chart, before the columns
+--    those snapshots are sourced from disappear
+-- ============================================================================
+
+-- The commit every backfilled snapshot is attributed to: the most recently
+-- applied ReconcileApps call, i.e. reconcile_watermark's current git_sha --
+-- named explicitly in PLAN.md's AR-7c scope ("Backfill snapshots from the
+-- current app/chart rows against the latest reconciled git_sha"). Falls
+-- back to the empty-string sentinel (migration 006's "no watermark yet"
+-- value) if this environment has literally never run a reconcile, in which
+-- case app/chart are expected to be empty anyway and this backfill affects
+-- zero rows.
+--
+-- manifest_json is synthesized from the CURRENT (pre-drop) app columns,
+-- shaped exactly like a real protojson-encoded AppManifest -- see this
+-- migration's header comment #6 and postgres/app.go's marshalAppManifest,
+-- which produces the same key set for every FUTURE write. registry/
+-- organization/repo_name are reconstructed by splitting the existing
+-- image_repository string on '/' -- safe because imageRepository() (the
+-- function that built that string in the first place) always joined
+-- exactly those three parts with '/', and none of them legitimately
+-- contains a '/' of its own (a GHCR registry host, an org name, and a repo
+-- name are each a single path segment).
+INSERT INTO app_manifest (owner_id, source_git_sha, source_committed_at, provenance, manifest_json)
+SELECT
+    a.app_id,
+    COALESCE((SELECT git_sha FROM reconcile_watermark WHERE id = 1), ''),
+    COALESCE((SELECT source_committed_at FROM reconcile_watermark WHERE id = 1), 0),
+    'sweep',
+    jsonb_build_object(
+        'name', a.name,
+        'domain', a.domain,
+        'description', a.description,
+        'language', a.language,
+        'registry', split_part(a.image_repository, '/', 1),
+        'organization', split_part(a.image_repository, '/', 2),
+        'repo_name', split_part(a.image_repository, '/', 3),
+        'binary_target', a.bazel_label,
+        'app_type', a.app_type,
+        'deploy_unit', CASE a.deploy_unit
+            WHEN 'image' THEN 'DEPLOY_UNIT_IMAGE'
+            WHEN 'none'  THEN 'DEPLOY_UNIT_NONE'
+            ELSE 'DEPLOY_UNIT_CHART'
+        END
+    )
+FROM app a;
+
+-- chart_manifest's backfill has less to work with: `chart` never stored
+-- version/namespace/environment/chart_target (those columns never existed
+-- on this table -- see migrate/README.md's "Planned migrations"), and
+-- chart.description/chart_repository were columns that Reconcile's INSERT
+-- never actually populated (always ''  -- see postgres/app.go's chart
+-- INSERT, pre-migration). What CAN be backfilled faithfully is identity
+-- (name/domain) and composition (app_refs, from the live chart_app join,
+-- domain-qualified to match what helm_chart_metadata emits post-AR-7a) --
+-- that is what "nothing loses metadata" means here: nothing that was ever
+-- actually populated is lost.
+INSERT INTO chart_manifest (owner_id, source_git_sha, source_committed_at, provenance, manifest_json)
+SELECT
+    c.chart_id,
+    COALESCE((SELECT git_sha FROM reconcile_watermark WHERE id = 1), ''),
+    COALESCE((SELECT source_committed_at FROM reconcile_watermark WHERE id = 1), 0),
+    'sweep',
+    jsonb_build_object(
+        'name', c.name,
+        'domain', c.domain,
+        'app_refs', COALESCE((
+            SELECT jsonb_agg(app.domain || '/' || app.name ORDER BY app.domain, app.name)
+            FROM chart_app ca
+            JOIN app ON app.app_id = ca.app_id
+            WHERE ca.chart_id = c.chart_id
+        ), '[]'::jsonb)
+    )
+FROM chart c;
+
+-- ============================================================================
+-- 3. artifact.manifest_id / artifact.promotability
+-- ============================================================================
+
+-- manifest_id: which snapshot a published artifact was built from. No FK
+-- constraint -- it is a POLYMORPHIC reference (an image artifact's
+-- manifest_id points into app_manifest, a chart artifact's into
+-- chart_manifest; a single column cannot carry two REFERENCES targets, the
+-- same reason `artifact.owner_id` -- migration 001 -- is a plain generated
+-- column rather than an FK). Referential integrity here is enforced in Go
+-- (postgres/artifact.go always resolves manifest_id from a row it just
+-- selected in the same transaction) rather than by the schema, exactly like
+-- owner_id already does.
+ALTER TABLE artifact ADD COLUMN manifest_id UUID;
+
+-- promotability: STORED, computed ONCE at publish time (RecordArtifact's
+-- publishing -> published transition, or the direct-create fallback) from
+-- the snapshot manifest_id points at -- see this migration's header comment
+-- #4. NULL for allocated/publishing/failed rows (nothing to derive
+-- promotability from until a manifest snapshot has actually been resolved,
+-- which only happens at publish time -- mirrors digest/build_id's
+-- state-gated nullability from migration 007).
+ALTER TABLE artifact ADD COLUMN promotability TEXT
+    CHECK (promotability IN ('promotable', 'via_chart', 'not_promotable'));
+
+-- Backfill promotability for every EXISTING artifact row (every one of
+-- which is 'published' -- see migration 007's own backfill) using the
+-- CURRENT (about-to-be-dropped) app/chart.deploy_unit -- the same value the
+-- OLD live-join scanArtifact would have computed for these rows today. This
+-- is the last time this repo computes promotability by joining to a live
+-- deploy_unit; from here on every NEW published row gets promotability
+-- computed once by Go code at publish time and stored, never recomputed.
+-- manifest_id is deliberately left NULL for these rows: there is no
+-- snapshot in app_manifest/chart_manifest that corresponds to what was
+-- ACTUALLY live when each of these was originally published (the backfilled
+-- snapshot above reflects the state at MIGRATION time, not publish time),
+-- and attributing them to it would be dishonest metadata, not a real
+-- historical link.
+-- Image artifacts: DerivePromotability(IMAGE, app.deploy_unit) --
+-- see server/repository/promotability.go. Filtered to state = 'published'
+-- deliberately, even though every row that predates migration 007 is
+-- already 'published' -- an environment that deployed AR-7b (007) before
+-- this migration could have real allocated/publishing/failed rows in
+-- flight, and those must keep promotability NULL (nothing has been
+-- published yet to derive it from).
+UPDATE artifact a
+SET promotability = CASE app.deploy_unit
+    WHEN 'chart' THEN 'via_chart'
+    WHEN 'image' THEN 'promotable'
+    ELSE 'not_promotable'
+END
+FROM app
+WHERE a.kind = 'image' AND a.app_id = app.app_id AND a.state = 'published';
+
+-- Chart artifacts: DerivePromotability(CHART, chart.deploy_unit) is always
+-- 'promotable', because chart.deploy_unit is always the hardcoded 'chart'
+-- constant (see "Why chart_manifest has no generated columns" above) -- no
+-- join needed, unlike the image case, since there is no other value it can
+-- take today.
+UPDATE artifact
+SET promotability = 'promotable'
+WHERE kind = 'chart' AND state = 'published';
+
+-- Ties promotability's presence to state, the same way migration 007's
+-- artifact_state_shape ties digest/build_id to state: a published row
+-- always has one (RecordArtifact/insertArtifact's published path always
+-- sets it -- see postgres/artifact.go), anything else never does.
+ALTER TABLE artifact ADD CONSTRAINT artifact_promotability_shape CHECK (
+    (state = 'published' AND promotability IS NOT NULL) OR
+    (state != 'published' AND promotability IS NULL)
+);
+
+-- ============================================================================
+-- 4. app / chart become pure identity
+-- ============================================================================
+
+ALTER TABLE app
+    DROP COLUMN description,
+    DROP COLUMN language,
+    DROP COLUMN app_type,
+    DROP COLUMN deploy_unit,
+    DROP COLUMN bazel_label,
+    DROP COLUMN image_repository;
+
+ALTER TABLE chart
+    DROP COLUMN description,
+    DROP COLUMN chart_repository,
+    DROP COLUMN deploy_unit;
+
+-- ============================================================================
+-- 5. v_current_app / v_current_chart: identity ⋈ latest `main`-sweep snapshot
+-- ============================================================================
+
+-- Follows v_current_promotion's pattern (migration 003) exactly: pre-join
+-- so no consumer re-derives it. Column order/names match appColumns in
+-- postgres/app.go BEFORE this migration exactly, so scanApp is UNCHANGED --
+-- only the FROM clause of every read query moves from `app` to this view.
+--
+-- Deliberately reads ONLY provenance = 'sweep' snapshots, never 'release'
+-- ones: "what does this app look like today" is a main-tree question (see
+-- ARCHITECTURE.md "AssertApps (additive) vs. ReconcileApps (absence
+-- sweep)") -- a release-time AssertApps snapshot from a divergent/unmerged
+-- ref must never leak into what every other reader sees as "the app".
+-- LEFT JOIN LATERAL (not a plain join to a MAX(...) subquery) because
+-- "newest snapshot" needs every column from the SAME row, not just the
+-- newest timestamp.
+CREATE VIEW v_current_app AS
+SELECT
+    a.app_id,
+    a.domain,
+    a.name,
+    COALESCE(m.manifest_json ->> 'description', '')   AS description,
+    COALESCE(m.manifest_json ->> 'language', '')       AS language,
+    COALESCE(m.manifest_json ->> 'app_type', '')       AS app_type,
+    COALESCE(m.deploy_unit, 'chart')                   AS deploy_unit,
+    COALESCE(m.manifest_json ->> 'binary_target', '')  AS bazel_label,
+    COALESCE(m.image_repository, '')                   AS image_repository,
+    a.status,
+    a.first_seen_at,
+    a.last_seen_at
+FROM app a
+LEFT JOIN LATERAL (
+    SELECT deploy_unit, image_repository, manifest_json
+    FROM app_manifest
+    WHERE owner_id = a.app_id AND provenance = 'sweep'
+    ORDER BY source_committed_at DESC, recorded_at DESC
+    LIMIT 1
+) m ON true;
+
+-- chart's deploy_unit/description/chart_repository are constants, not
+-- projections off manifest_json -- see "Why chart_manifest has no generated
+-- columns" above: none of those three were ever sourced from the manifest
+-- to begin with (deploy_unit was hardcoded, description/chart_repository
+-- were always ''), so hardcoding them here is not a behavior change, it is
+-- the SAME behavior expressed as a view instead of dead INSERT columns.
+CREATE VIEW v_current_chart AS
+SELECT
+    c.chart_id,
+    c.domain,
+    c.name,
+    ''::text     AS description,
+    ''::text     AS chart_repository,
+    'chart'::text AS deploy_unit,
+    c.status,
+    c.first_seen_at,
+    c.last_seen_at
+FROM chart c;

--- a/tools/app_registry/protos/api.proto
+++ b/tools/app_registry/protos/api.proto
@@ -24,6 +24,15 @@ service AppRegistry {
   // Apps absent from the request are marked MISSING, never deleted.
   rpc ReconcileApps(ReconcileAppsRequest) returns (ReconcileAppsResponse);
 
+  // AR-7c (issue #558): additive identity + manifest-snapshot write, safe to
+  // call from ANY ref -- the released ref, not just main. Never marks
+  // anything MISSING; rejects (per item) assertion against an ARCHIVED
+  // app/chart. Called as the first step of a release run, closing the
+  // release-vs-reconcile gap (issue #547) without depending on main's
+  // ReconcileApps having gone first. See ARCHITECTURE.md "AssertApps
+  // (additive) vs. ReconcileApps (absence sweep)".
+  rpc AssertApps(AssertAppsRequest) returns (AssertAppsResponse);
+
   rpc ListApps(ListAppsRequest) returns (ListAppsResponse);
   rpc GetApp(GetAppRequest) returns (GetAppResponse);
   rpc ListCharts(ListChartsRequest) returns (ListChartsResponse);

--- a/tools/app_registry/protos/api_messages_app.proto
+++ b/tools/app_registry/protos/api_messages_app.proto
@@ -95,6 +95,57 @@ message UnresolvedChart {
 }
 
 // ============================================================================
+// AssertApps (AR-7c, issue #558)
+// ============================================================================
+
+// AssertAppsRequest carries the SAME AppManifestSet shape ReconcileApps
+// does, but is safe from any ref: AssertApps only ever creates or recovers
+// identity + records a manifest snapshot, and never treats an app/chart
+// absent from this set as gone (contrast ReconcileAppsRequest's doc
+// comment). manifests.git_sha/source_committed_at are stored on the
+// snapshot rows this call writes, but -- unlike ReconcileApps -- are never
+// compared against the reconcile watermark.
+message AssertAppsRequest {
+  whalenet.appmeta.v1.AppManifestSet manifests = 1;
+
+  // Required. Repeated calls with the same key are a no-op returning the
+  // original result. Use "<workflow_run_id>-<attempt>-<domain>-<app>" (one
+  // release-job matrix leg's worth), matching the convention
+  // RecordBuild/RecordArtifact already use for CI.
+  string idempotency_key = 2;
+}
+
+message AssertAppsResponse {
+  repeated App created_apps = 1;
+  // Already ACTIVE; only the manifest snapshot changed (or this call was a
+  // no-op replay of an already-recorded (owner, git_sha) pair).
+  repeated App updated_apps = 2;
+  // Previously MISSING, automatically returned to ACTIVE -- same automatic
+  // recovery ReconcileApps's absence sweep triggers.
+  repeated App recovered_apps = 3;
+
+  repeated Chart created_charts = 4;
+  repeated Chart updated_charts = 5;
+  repeated Chart recovered_charts = 6;
+
+  // Apps/charts this call declined to touch because they are ARCHIVED --
+  // see AppRegistry.AssertApps's doc comment. Each entry is SKIPPED, not
+  // fatal: every other app/chart in this call still applied.
+  repeated RejectedOwner rejected_apps = 7;
+  repeated RejectedOwner rejected_charts = 8;
+}
+
+// RejectedOwner names one app or chart AssertApps declined to assert
+// because it is ARCHIVED -- see AssertAppsResponse.rejected_apps/
+// rejected_charts.
+message RejectedOwner {
+  string domain = 1;
+  string name = 2;
+  // Human-readable explanation. Not machine-parsed.
+  string reason = 3;
+}
+
+// ============================================================================
 // Reads
 // ============================================================================
 

--- a/tools/app_registry/server/handlers/app.go
+++ b/tools/app_registry/server/handlers/app.go
@@ -145,6 +145,78 @@ func unresolvedChartsToPB(cs []repository.UnresolvedChart) []*pb.UnresolvedChart
 	return out
 }
 
+// AssertApps implements the additive-only counterpart to ReconcileApps
+// (AR-7c, issue #558) -- see repository.AppRepository.AssertApps's doc
+// comment for the full contract. Called from release.yml as the first step
+// of a release run, from whatever ref is being released; unlike
+// ReconcileApps this never checks/advances the reconcile watermark and
+// never requires dry_run handling (AssertApps has no absence sweep to
+// preview).
+func (s *AppServer) AssertApps(ctx context.Context, req *pb.AssertAppsRequest) (*pb.AssertAppsResponse, error) {
+	if err := auth.Require(ctx, auth.RoleBuilder); err != nil {
+		return nil, err
+	}
+	if req.Manifests == nil {
+		return nil, status.Error(codes.InvalidArgument, "manifests is required")
+	}
+	if req.IdempotencyKey == "" {
+		return nil, status.Error(codes.InvalidArgument, "idempotency_key is required")
+	}
+
+	source := repository.ManifestSource{
+		GitSHA:            req.Manifests.GitSha,
+		SourceCommittedAt: req.Manifests.SourceCommittedAt,
+		DiscoveredAt:      req.Manifests.DiscoveredAt,
+	}
+
+	resp, _, err := runIdempotent(ctx, s.repo, req.IdempotencyKey, "AssertApps",
+		func() proto.Message { return &pb.AssertAppsResponse{} },
+		func(ctx context.Context, r repository.Registry) (proto.Message, error) {
+			result, err := r.Apps().AssertApps(ctx, req.Manifests.Apps, req.Manifests.Charts, source)
+			if err != nil {
+				return nil, err
+			}
+			for _, ra := range result.RejectedApps {
+				appLog.Warn("assert: app rejected, ARCHIVED",
+					slog.String("app_domain", ra.Domain), slog.String("app_name", ra.Name), slog.String("reason", ra.Reason))
+			}
+			for _, rc := range result.RejectedCharts {
+				appLog.Warn("assert: chart rejected, ARCHIVED",
+					slog.String("chart_domain", rc.Domain), slog.String("chart_name", rc.Name), slog.String("reason", rc.Reason))
+			}
+			return assertResultToPB(result), nil
+		},
+	)
+	if err != nil {
+		return nil, mapRepoErr(err)
+	}
+	return resp.(*pb.AssertAppsResponse), nil
+}
+
+func assertResultToPB(r *repository.AssertResult) *pb.AssertAppsResponse {
+	return &pb.AssertAppsResponse{
+		CreatedApps:     appsToPB(r.CreatedApps),
+		UpdatedApps:     appsToPB(r.UpdatedApps),
+		RecoveredApps:   appsToPB(r.RecoveredApps),
+		CreatedCharts:   chartsToPB(r.CreatedCharts),
+		UpdatedCharts:   chartsToPB(r.UpdatedCharts),
+		RecoveredCharts: chartsToPB(r.RecoveredCharts),
+		RejectedApps:    rejectedOwnersToPB(r.RejectedApps),
+		RejectedCharts:  rejectedOwnersToPB(r.RejectedCharts),
+	}
+}
+
+func rejectedOwnersToPB(rs []repository.RejectedOwner) []*pb.RejectedOwner {
+	if len(rs) == 0 {
+		return nil
+	}
+	out := make([]*pb.RejectedOwner, len(rs))
+	for i, r := range rs {
+		out[i] = &pb.RejectedOwner{Domain: r.Domain, Name: r.Name, Reason: r.Reason}
+	}
+	return out
+}
+
 func (s *AppServer) ListApps(ctx context.Context, req *pb.ListAppsRequest) (*pb.ListAppsResponse, error) {
 	if err := auth.RequireAuthenticated(ctx); err != nil {
 		return nil, err

--- a/tools/app_registry/server/handlers/app_test.go
+++ b/tools/app_registry/server/handlers/app_test.go
@@ -624,3 +624,253 @@ func TestSetAppStatus_RequiresReason(t *testing.T) {
 		t.Fatalf("expected InvalidArgument when reason is missing, got %v", err)
 	}
 }
+
+// ============================================================================
+// AssertApps (AR-7c, issue #558)
+// ============================================================================
+
+// TestAssertApps_CreatesIdentity covers the additive create path: a brand
+// new app/chart, asserted from what release.yml treats as "the released
+// ref" -- exercised here with no prior ReconcileApps call at all, proving
+// AssertApps needs no main-sweep to have run first.
+func TestAssertApps_CreatesIdentity(t *testing.T) {
+	ctx := authedCtx()
+	srv := NewAppServer(fake.New())
+
+	resp, err := srv.AssertApps(ctx, &pb.AssertAppsRequest{
+		Manifests: manifestSet(
+			[]*appmetapb.AppManifest{oneApp("demo", "svc")},
+			[]*appmetapb.ChartManifest{{Domain: "demo", Name: "chart"}},
+		),
+		IdempotencyKey: "assert-1",
+	})
+	if err != nil {
+		t.Fatalf("assert: %v", err)
+	}
+	if len(resp.CreatedApps) != 1 || resp.CreatedApps[0].Status != pb.AppStatus_APP_STATUS_ACTIVE {
+		t.Fatalf("expected 1 created ACTIVE app, got %+v", resp.CreatedApps)
+	}
+	if len(resp.CreatedCharts) != 1 || resp.CreatedCharts[0].Status != pb.AppStatus_APP_STATUS_ACTIVE {
+		t.Fatalf("expected 1 created ACTIVE chart, got %+v", resp.CreatedCharts)
+	}
+}
+
+// TestAssertApps_NeverMarksMissing proves the defining difference from
+// ReconcileApps: calling AssertApps with an EMPTY manifest set (as a
+// divergent/unmerged ref legitimately might, if the app doesn't exist on
+// that ref) must never mark a previously-asserted app MISSING -- only
+// ReconcileApps's absence sweep does that, and only from main.
+func TestAssertApps_NeverMarksMissing(t *testing.T) {
+	ctx := authedCtx()
+	srv := NewAppServer(fake.New())
+
+	if _, err := srv.AssertApps(ctx, &pb.AssertAppsRequest{
+		Manifests:      manifestSet([]*appmetapb.AppManifest{oneApp("demo", "svc")}, nil),
+		IdempotencyKey: "assert-2-1",
+	}); err != nil {
+		t.Fatalf("first assert: %v", err)
+	}
+
+	resp, err := srv.AssertApps(ctx, &pb.AssertAppsRequest{
+		Manifests:      manifestSet(nil, nil),
+		IdempotencyKey: "assert-2-2",
+	})
+	if err != nil {
+		t.Fatalf("empty-set assert: %v", err)
+	}
+	if len(resp.CreatedApps) != 0 || len(resp.UpdatedApps) != 0 || len(resp.RecoveredApps) != 0 {
+		t.Fatalf("expected an empty-set AssertApps call to touch nothing, got %+v", resp)
+	}
+
+	got, err := srv.GetApp(ctx, &pb.GetAppRequest{FullName: "demo-svc"})
+	if err != nil {
+		t.Fatalf("get app: %v", err)
+	}
+	if got.App.Status != pb.AppStatus_APP_STATUS_ACTIVE {
+		t.Fatalf("expected demo-svc to remain ACTIVE (AssertApps must never mark it MISSING), got %v", got.App.Status)
+	}
+}
+
+// TestAssertApps_RecoversMissingApp: AssertApps shares Reconcile's
+// automatic MISSING -> ACTIVE recovery -- it's an ADDITIVE write path, not
+// a read-only one, so a release for an app main's sweep had flagged
+// MISSING still un-flags it.
+func TestAssertApps_RecoversMissingApp(t *testing.T) {
+	ctx := authedCtx()
+	srv := NewAppServer(fake.New())
+
+	created, err := srv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
+		Manifests:      manifestSet([]*appmetapb.AppManifest{oneApp("demo", "svc")}, nil),
+		IdempotencyKey: "assert-3-1",
+	})
+	if err != nil {
+		t.Fatalf("reconcile create: %v", err)
+	}
+	svcID := created.CreatedApps[0].AppId
+
+	if _, err := srv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
+		Manifests:      manifestSet(nil, nil),
+		IdempotencyKey: "assert-3-2",
+	}); err != nil {
+		t.Fatalf("reconcile drop: %v", err)
+	}
+	if got, _ := srv.GetApp(ctx, &pb.GetAppRequest{AppId: svcID}); got.App.Status != pb.AppStatus_APP_STATUS_MISSING {
+		t.Fatalf("expected svc MISSING after being dropped from the sweep, got %v", got.App.Status)
+	}
+
+	resp, err := srv.AssertApps(ctx, &pb.AssertAppsRequest{
+		Manifests:      manifestSet([]*appmetapb.AppManifest{oneApp("demo", "svc")}, nil),
+		IdempotencyKey: "assert-3-3",
+	})
+	if err != nil {
+		t.Fatalf("assert: %v", err)
+	}
+	if len(resp.RecoveredApps) != 1 || resp.RecoveredApps[0].Status != pb.AppStatus_APP_STATUS_ACTIVE {
+		t.Fatalf("expected svc recovered to ACTIVE, got %+v", resp)
+	}
+}
+
+// TestAssertApps_RejectsArchivedAppPerItem is the exit criterion named in
+// PLAN.md's AR-7c scope: AssertApps against an ARCHIVED app is rejected --
+// but per item, not for the whole call, matching UnresolvedChart's
+// established skip-and-report shape.
+func TestAssertApps_RejectsArchivedAppPerItem(t *testing.T) {
+	ctx := authedCtx()
+	srv := NewAppServer(fake.New())
+
+	created, err := srv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
+		Manifests: manifestSet(
+			[]*appmetapb.AppManifest{oneApp("demo", "gone"), oneApp("demo", "other")}, nil),
+		IdempotencyKey: "assert-4-1",
+	})
+	if err != nil {
+		t.Fatalf("reconcile create: %v", err)
+	}
+	goneID := created.CreatedApps[0].AppId
+	if created.CreatedApps[0].Name != "gone" {
+		goneID = created.CreatedApps[1].AppId
+	}
+
+	if _, err := srv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
+		Manifests:      manifestSet([]*appmetapb.AppManifest{oneApp("demo", "other")}, nil),
+		IdempotencyKey: "assert-4-2",
+	}); err != nil {
+		t.Fatalf("reconcile drop gone: %v", err)
+	}
+	if _, err := srv.SetAppStatus(ctx, &pb.SetAppStatusRequest{
+		AppId: goneID, Status: pb.AppStatus_APP_STATUS_ARCHIVED, Reason: "gone for good",
+	}); err != nil {
+		t.Fatalf("archive gone: %v", err)
+	}
+
+	resp, err := srv.AssertApps(ctx, &pb.AssertAppsRequest{
+		Manifests: manifestSet(
+			[]*appmetapb.AppManifest{oneApp("demo", "gone"), oneApp("demo", "other")}, nil),
+		IdempotencyKey: "assert-4-3",
+	})
+	if err != nil {
+		t.Fatalf("assert should succeed for the call as a whole: %v", err)
+	}
+	if len(resp.RejectedApps) != 1 || resp.RejectedApps[0].Name != "gone" {
+		t.Fatalf("expected 'gone' rejected as ARCHIVED, got rejected=%+v", resp.RejectedApps)
+	}
+	// The OTHER app in the same call must still apply -- a per-item skip,
+	// not a whole-call failure.
+	if len(resp.UpdatedApps) != 1 || resp.UpdatedApps[0].Name != "other" {
+		t.Fatalf("expected 'other' to still apply in the same call, got updated=%+v", resp.UpdatedApps)
+	}
+
+	got, err := srv.GetApp(ctx, &pb.GetAppRequest{AppId: goneID})
+	if err != nil {
+		t.Fatalf("get archived app: %v", err)
+	}
+	if got.App.Status != pb.AppStatus_APP_STATUS_ARCHIVED {
+		t.Fatalf("AssertApps must not resurrect an ARCHIVED app: expected still ARCHIVED, got %v", got.App.Status)
+	}
+}
+
+// TestAssertApps_ThenRecordArtifact_NoReconcileNeeded is the AR-7c exit
+// criterion closing issue #547's gap: a release from a ref calls AssertApps
+// first, then RecordArtifact for a BRAND NEW app succeeds immediately --
+// with NO ReconcileApps call anywhere in this test. Before AR-7c this
+// sequence would hit ErrOwnerNotReconciled / exit code 3 (see
+// ARCHITECTURE.md "Release-vs-reconcile gap").
+func TestAssertApps_ThenRecordArtifact_NoReconcileNeeded(t *testing.T) {
+	ctx := authedCtx()
+	repo := fake.New()
+	appSrv := NewAppServer(repo)
+	artSrv := NewArtifactServer(repo)
+
+	if _, err := appSrv.AssertApps(ctx, &pb.AssertAppsRequest{
+		Manifests:      manifestSet([]*appmetapb.AppManifest{oneApp("demo", "new-app")}, nil),
+		IdempotencyKey: "assert-5-1",
+	}); err != nil {
+		t.Fatalf("assert: %v", err)
+	}
+
+	build, err := artSrv.RecordBuild(ctx, &pb.RecordBuildRequest{
+		GitSha: "sha1", WorkflowRunId: "run-1", IdempotencyKey: "build-1",
+	})
+	if err != nil {
+		t.Fatalf("record build: %v", err)
+	}
+
+	_, err = artSrv.RecordArtifact(ctx, &pb.RecordArtifactRequest{
+		BuildId: build.Build.BuildId, Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE,
+		OwnerFullName: "demo-new-app", Version: "v1.0.0", Digest: "sha256:new1",
+		IdempotencyKey: "artifact-1",
+	})
+	if err != nil {
+		t.Fatalf("RecordArtifact should succeed immediately after AssertApps, with no ReconcileApps ever having run: %v", err)
+	}
+}
+
+// TestRecordArtifact_RejectsArchivedOwner is the second AR-7c exit
+// criterion named in PLAN.md: "RecordArtifact against an ARCHIVED owner is
+// rejected too" -- before AR-7c this succeeded silently.
+func TestRecordArtifact_RejectsArchivedOwner(t *testing.T) {
+	ctx := authedCtx()
+	repo := fake.New()
+	appSrv := NewAppServer(repo)
+	artSrv := NewArtifactServer(repo)
+
+	created, err := appSrv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
+		Manifests:      manifestSet([]*appmetapb.AppManifest{oneApp("demo", "svc")}, nil),
+		IdempotencyKey: "archived-owner-1",
+	})
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	svcID := created.CreatedApps[0].AppId
+
+	if _, err := appSrv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
+		Manifests:      manifestSet(nil, nil),
+		IdempotencyKey: "archived-owner-2",
+	}); err != nil {
+		t.Fatalf("reconcile drop: %v", err)
+	}
+	if _, err := appSrv.SetAppStatus(ctx, &pb.SetAppStatusRequest{
+		AppId: svcID, Status: pb.AppStatus_APP_STATUS_ARCHIVED, Reason: "gone",
+	}); err != nil {
+		t.Fatalf("archive: %v", err)
+	}
+
+	build, err := artSrv.RecordBuild(ctx, &pb.RecordBuildRequest{
+		GitSha: "sha1", WorkflowRunId: "run-1", IdempotencyKey: "build-2",
+	})
+	if err != nil {
+		t.Fatalf("record build: %v", err)
+	}
+
+	_, err = artSrv.RecordArtifact(ctx, &pb.RecordArtifactRequest{
+		BuildId: build.Build.BuildId, Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE,
+		OwnerFullName: "demo-svc", Version: "v1.0.0", Digest: "sha256:archived1",
+		IdempotencyKey: "artifact-2",
+	})
+	if err == nil {
+		t.Fatal("expected RecordArtifact against an ARCHIVED owner to be rejected")
+	}
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("expected FailedPrecondition, got %v (%v)", status.Code(err), err)
+	}
+}

--- a/tools/app_registry/server/handlers/artifact.go
+++ b/tools/app_registry/server/handlers/artifact.go
@@ -166,11 +166,21 @@ func (s *ArtifactServer) resolveOwner(ctx context.Context, r repository.Registry
 		if aerr != nil {
 			return "", "", fmt.Errorf("%w: app %q not found -- has it been reconciled? (ReconcileApps runs on push to main via ci.yml)", repository.ErrOwnerNotReconciled, ownerFullName)
 		}
+		// AR-7c (issue #558): recording against an ARCHIVED owner is
+		// rejected, same rule AssertApps enforces for identity assertion --
+		// see repository.ErrOwnerArchived's doc comment. Before AR-7c this
+		// succeeded silently, which was not intended.
+		if app.Status == repository.StatusArchived {
+			return "", "", fmt.Errorf("%w: app %q", repository.ErrOwnerArchived, ownerFullName)
+		}
 		return app.AppID, app.Domain, nil
 	}
 	chart, cerr := r.Apps().GetChartByFullName(ctx, ownerFullName)
 	if cerr != nil {
 		return "", "", fmt.Errorf("%w: chart %q not found -- has it been reconciled? (ReconcileApps runs on push to main via ci.yml)", repository.ErrOwnerNotReconciled, ownerFullName)
+	}
+	if chart.Status == repository.StatusArchived {
+		return "", "", fmt.Errorf("%w: chart %q", repository.ErrOwnerArchived, ownerFullName)
 	}
 	return chart.ChartID, chart.Domain, nil
 }
@@ -366,11 +376,21 @@ func (s *ArtifactServer) resolveOwnerAndDomain(ctx context.Context, kind reposit
 		if aerr != nil {
 			return "", "", "", status.Errorf(codes.InvalidArgument, "app %q not found -- has it been reconciled? (ReconcileApps runs on push to main via ci.yml)", ownerFullName)
 		}
+		// AR-7c (issue #558): same ARCHIVED rejection resolveOwner enforces
+		// for RecordArtifact -- see repository.ErrOwnerArchived's doc
+		// comment. Applied here too so BeginPublish/AllocateVersion can't
+		// start a publish against an owner a human has archived.
+		if app.Status == repository.StatusArchived {
+			return "", "", "", mapRepoErr(fmt.Errorf("%w: app %q", repository.ErrOwnerArchived, ownerFullName))
+		}
 		return app.Domain, app.AppID, app.ImageRepository, nil
 	}
 	chart, cerr := s.repo.Apps().GetChartByFullName(ctx, ownerFullName)
 	if cerr != nil {
 		return "", "", "", status.Errorf(codes.InvalidArgument, "chart %q not found -- has it been reconciled? (ReconcileApps runs on push to main via ci.yml)", ownerFullName)
+	}
+	if chart.Status == repository.StatusArchived {
+		return "", "", "", mapRepoErr(fmt.Errorf("%w: chart %q", repository.ErrOwnerArchived, ownerFullName))
 	}
 	return chart.Domain, chart.ChartID, chart.ChartRepository, nil
 }

--- a/tools/app_registry/server/handlers/artifact_test.go
+++ b/tools/app_registry/server/handlers/artifact_test.go
@@ -94,6 +94,74 @@ func TestRecordArtifact_PromotabilityDerivation(t *testing.T) {
 	_ = apps
 }
 
+// TestRecordArtifact_PromotabilityIsNotRetroactive is AR-7c's (issue #558)
+// headline correctness fix, and PLAN.md's AR-7c exit criterion, proven
+// here: editing an app's deploy_unit AFTER an artifact has been published
+// must NOT change that artifact's promotability. Before AR-7c,
+// scanArtifact/derivePromotability re-joined the owner's CURRENT deploy_unit
+// on every read, so this test would have failed -- the published artifact's
+// promotability would have silently flipped from PROMOTABLE to VIA_CHART.
+func TestRecordArtifact_PromotabilityIsNotRetroactive(t *testing.T) {
+	appSrv, artifactSrv, _ := setup(t)
+	ctx := authedCtx()
+	build := recordBuild(t, artifactSrv, "run-retro")
+
+	// image-app is DEPLOY_UNIT_IMAGE at publish time -> PROMOTABLE.
+	published, err := artifactSrv.RecordArtifact(ctx, &pb.RecordArtifactRequest{
+		BuildId: build.BuildId, Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE,
+		OwnerFullName: "demo-image-app", Digest: "sha256:retro1", Version: "v1.0.0",
+		IdempotencyKey: "record-retro",
+	})
+	if err != nil {
+		t.Fatalf("RecordArtifact: %v", err)
+	}
+	if published.Artifact.Promotability != pb.Promotability_PROMOTABILITY_PROMOTABLE {
+		t.Fatalf("expected PROMOTABLE at publish time, got %v", published.Artifact.Promotability)
+	}
+
+	// Now edit image-app's deploy_unit to CHART -- a later release_app
+	// change, reconciled through main exactly as it would be in production.
+	if _, err := appSrv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
+		Manifests: manifestSet([]*appmetapb.AppManifest{
+			{Domain: "demo", Name: "chart-app", DeployUnit: appmetapb.DeployUnit_DEPLOY_UNIT_CHART},
+			{Domain: "demo", Name: "image-app", DeployUnit: appmetapb.DeployUnit_DEPLOY_UNIT_CHART}, // <- changed
+			{Domain: "demo", Name: "none-app", DeployUnit: appmetapb.DeployUnit_DEPLOY_UNIT_NONE},
+		}, []*appmetapb.ChartManifest{
+			{Domain: "demo", Name: "achart", Apps: []string{"chart-app"}},
+		}),
+		IdempotencyKey: "retro-edit-deploy-unit",
+	}); err != nil {
+		t.Fatalf("reconcile with edited deploy_unit: %v", err)
+	}
+
+	// GetArtifact (a fresh read, not the RecordArtifact response we already
+	// have) must still report PROMOTABLE -- the value stored at publish
+	// time, unaffected by the edit above.
+	reread, err := artifactSrv.GetArtifact(ctx, &pb.GetArtifactRequest{ArtifactId: published.Artifact.ArtifactId})
+	if err != nil {
+		t.Fatalf("GetArtifact: %v", err)
+	}
+	if reread.Artifact.Promotability != pb.Promotability_PROMOTABILITY_PROMOTABLE {
+		t.Fatalf("retroactivity bug: expected the already-published artifact to STAY PROMOTABLE after image-app's deploy_unit changed, got %v", reread.Artifact.Promotability)
+	}
+
+	// A NEW artifact for the SAME (now-edited) app, published after the
+	// edit, correctly reflects the new deploy_unit -- proving the fix is
+	// "frozen at publish time," not "never updates at all."
+	build2 := recordBuild(t, artifactSrv, "run-retro-2")
+	newPub, err := artifactSrv.RecordArtifact(ctx, &pb.RecordArtifactRequest{
+		BuildId: build2.BuildId, Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE,
+		OwnerFullName: "demo-image-app", Digest: "sha256:retro2", Version: "v1.0.1",
+		IdempotencyKey: "record-retro-2",
+	})
+	if err != nil {
+		t.Fatalf("RecordArtifact after edit: %v", err)
+	}
+	if newPub.Artifact.Promotability != pb.Promotability_PROMOTABILITY_VIA_CHART {
+		t.Fatalf("expected a NEW publish after the edit to derive VIA_CHART from the new deploy_unit, got %v", newPub.Artifact.Promotability)
+	}
+}
+
 func TestRecordArtifact_ChartIsAlwaysPromotable(t *testing.T) {
 	_, artifactSrv, _ := setup(t)
 	ctx := authedCtx()

--- a/tools/app_registry/server/repository/fake/fake.go
+++ b/tools/app_registry/server/repository/fake/fake.go
@@ -177,6 +177,14 @@ func (r *Registry) Reconcile(ctx context.Context, apps []*appmetapb.AppManifest,
 	return reconcile(r.state, apps, charts, source, dryRun)
 }
 
+// AssertApps mirrors postgres's appRepo.AssertApps -- see
+// repository.AppRepository.AssertApps's doc comment. source is accepted for
+// interface-shape parity with Reconcile but unused: AssertApps never
+// consults or advances the reconcile watermark.
+func (r *Registry) AssertApps(ctx context.Context, apps []*appmetapb.AppManifest, charts []*appmetapb.ChartManifest, source repository.ManifestSource) (*repository.AssertResult, error) {
+	return assertApps(r.state, apps, charts), nil
+}
+
 func (r *Registry) ListApps(ctx context.Context, filter repository.AppListFilter) ([]repository.App, error) {
 	statuses := defaultAppStatuses(filter.Statuses)
 	var out []repository.App
@@ -319,8 +327,13 @@ func (r *Registry) RecordArtifact(ctx context.Context, a repository.Artifact, co
 		// relying on a.Digest never being "" too, which happens to be true
 		// today but shouldn't be load-bearing.
 		if existing.Digest != "" && existing.Digest == a.Digest {
+			// Promotability is STORED as of AR-7c (migration 008, mirrored
+			// here without a real snapshot table) -- see insertArtifact/
+			// completePublish below, which set it ONCE at publish time.
+			// Never re-derived here, which is the whole point: the value on
+			// existing is what a caller gets, unaffected by any deploy_unit
+			// edit made since.
 			out := existing
-			out.Promotability = r.derivePromotability(existing)
 			return &out, true, nil
 		}
 	}
@@ -379,15 +392,24 @@ func ownerID(a repository.Artifact) string {
 // brand-new artifact row directly in state, with versionSource and
 // Provenance "observed" -- shared by RecordArtifact's direct-create path,
 // BeginPublish's ∅ -> publishing branch, and AllocateVersion's ∅ ->
-// allocated write.
+// allocated write. As of AR-7c (migration 008), Promotability is resolved
+// and STORED here -- once, only when state is reaching
+// ArtifactStatePublished -- never re-derived on a later read. See
+// repository.Artifact.Promotability's doc comment for why this is the
+// retroactivity fix, not just a refactor.
 func (r *Registry) insertArtifact(a repository.Artifact, contains []repository.ContainedImageInput, state repository.ArtifactState, versionSource repository.VersionSource) (*repository.Artifact, error) {
 	a.ArtifactID = uuid.NewString()
 	a.State = state
 	a.Provenance = repository.ArtifactProvenanceObserved
 	a.VersionSource = versionSource
 	a.StateChangedAt = timeNow()
-	if state == repository.ArtifactStatePublished && a.PublishedAt.IsZero() {
-		a.PublishedAt = timeNow()
+	if state == repository.ArtifactStatePublished {
+		if a.PublishedAt.IsZero() {
+			a.PublishedAt = timeNow()
+		}
+		a.Promotability = r.derivePromotability(a)
+	} else {
+		a.Promotability = ""
 	}
 
 	if a.Kind == repository.ArtifactKindChart && state == repository.ArtifactStatePublished {
@@ -400,12 +422,13 @@ func (r *Registry) insertArtifact(a repository.Artifact, contains []repository.C
 
 	r.state.Artifacts[a.ArtifactID] = a
 	out := a
-	out.Promotability = r.derivePromotability(a)
 	return &out, nil
 }
 
 // completePublish mirrors postgres's artifactRepo.completePublish: the
-// publishing -> published transition against an EXISTING row.
+// publishing -> published transition against an EXISTING row. Promotability
+// is resolved and stored HERE, at the instant state actually reaches
+// "published" -- see insertArtifact's doc comment above.
 func (r *Registry) completePublish(existing, a repository.Artifact, contains []repository.ContainedImageInput) (*repository.Artifact, error) {
 	updated := existing
 	updated.Digest = a.Digest
@@ -418,6 +441,7 @@ func (r *Registry) completePublish(existing, a repository.Artifact, contains []r
 	}
 	updated.State = repository.ArtifactStatePublished
 	updated.StateChangedAt = timeNow()
+	updated.Promotability = r.derivePromotability(updated)
 
 	if updated.Kind == repository.ArtifactKindChart {
 		links, err := r.linkContains(contains)
@@ -429,7 +453,6 @@ func (r *Registry) completePublish(existing, a repository.Artifact, contains []r
 
 	r.state.Artifacts[updated.ArtifactID] = updated
 	out := updated
-	out.Promotability = r.derivePromotability(updated)
 	return &out, nil
 }
 
@@ -553,7 +576,6 @@ func (r *Registry) BeginPublish(ctx context.Context, kind repository.ArtifactKin
 	existing.FailReason = ""
 	r.state.Artifacts[existing.ArtifactID] = existing
 	out := existing
-	out.Promotability = r.derivePromotability(existing)
 	return &out, nil
 }
 
@@ -573,7 +595,6 @@ func (r *Registry) FailPublish(ctx context.Context, kind repository.ArtifactKind
 	existing.FailReason = reason
 	r.state.Artifacts[existing.ArtifactID] = existing
 	out := existing
-	out.Promotability = r.derivePromotability(existing)
 	return &out, nil
 }
 
@@ -616,7 +637,9 @@ func (r *Registry) ListArtifacts(ctx context.Context, filter repository.Artifact
 				continue
 			}
 		}
-		a.Promotability = r.derivePromotability(a)
+		// Promotability is read directly off the stored row -- see
+		// insertArtifact/completePublish, which set it once at publish time
+		// (AR-7c). Not re-derived here.
 		if filter.PromotableOnly && a.Promotability != repository.PromotabilityPromotable {
 			continue
 		}
@@ -632,7 +655,6 @@ func (r *Registry) GetArtifact(ctx context.Context, lookup repository.ArtifactLo
 		return nil, err
 	}
 	cp := *a
-	cp.Promotability = r.derivePromotability(cp)
 	return &cp, nil
 }
 
@@ -673,7 +695,6 @@ func (r *Registry) ResolveArtifact(ctx context.Context, lookup repository.Artifa
 		return nil, nil, nil, fmt.Errorf("%w: artifact %s is not a chart", repository.ErrInvalidArgument, a.ArtifactID)
 	}
 	cp := *a
-	cp.Promotability = r.derivePromotability(cp)
 
 	var images []repository.Artifact
 	var builds []repository.Build
@@ -682,7 +703,6 @@ func (r *Registry) ResolveArtifact(ctx context.Context, lookup repository.Artifa
 		if !ok {
 			continue
 		}
-		img.Promotability = r.derivePromotability(img)
 		images = append(images, img)
 		if b, ok := r.state.Builds[img.BuildID]; ok {
 			builds = append(builds, b)

--- a/tools/app_registry/server/repository/fake/reconcile.go
+++ b/tools/app_registry/server/repository/fake/reconcile.go
@@ -172,6 +172,111 @@ func reconcile(s *state, apps []*appmetapb.AppManifest, charts []*appmetapb.Char
 	return result, nil
 }
 
+// assertApps mirrors postgres/app.go's assertApps -- the additive-only
+// counterpart to reconcile above. See repository.AppRepository.AssertApps's
+// doc comment for the full contract: create-or-recover only, never marks
+// MISSING, never touches chart_app membership, and rejects (per item) any
+// app/chart that is currently ARCHIVED rather than silently resurrecting it.
+// Unlike reconcile, this never consults or advances s.Watermark.
+func assertApps(s *state, apps []*appmetapb.AppManifest, charts []*appmetapb.ChartManifest) *repository.AssertResult {
+	now := time.Now().UTC()
+	result := &repository.AssertResult{}
+
+	for _, am := range apps {
+		id, existing, found := findAppByDomainName(s, am.Domain, am.Name)
+		if !found {
+			id = uuid.NewString()
+			newApp := repository.App{
+				AppID:           id,
+				Domain:          am.Domain,
+				Name:            am.Name,
+				Description:     am.Description,
+				Language:        am.Language,
+				AppType:         am.AppType,
+				DeployUnit:      normalizeDeployUnit(am.DeployUnit),
+				BazelLabel:      am.BinaryTarget,
+				ImageRepository: imageRepository(am),
+				Status:          repository.StatusActive,
+				FirstSeenAt:     now,
+				LastSeenAt:      now,
+			}
+			s.Apps[id] = newApp
+			result.CreatedApps = append(result.CreatedApps, newApp)
+			continue
+		}
+
+		if existing.Status == repository.StatusArchived {
+			result.RejectedApps = append(result.RejectedApps, repository.RejectedOwner{
+				Domain: am.Domain, Name: am.Name,
+				Reason: fmt.Sprintf("app %s/%s is ARCHIVED -- a human archived it deliberately; AssertApps does not resurrect it", am.Domain, am.Name),
+			})
+			continue
+		}
+
+		wasMissing := existing.Status == repository.StatusMissing
+		updated := existing
+		updated.Description = am.Description
+		updated.Language = am.Language
+		updated.AppType = am.AppType
+		updated.DeployUnit = normalizeDeployUnit(am.DeployUnit)
+		updated.BazelLabel = am.BinaryTarget
+		updated.ImageRepository = imageRepository(am)
+		updated.Status = repository.StatusActive
+		updated.LastSeenAt = now
+		s.Apps[id] = updated
+
+		if wasMissing {
+			result.RecoveredApps = append(result.RecoveredApps, updated)
+		} else {
+			result.UpdatedApps = append(result.UpdatedApps, updated)
+		}
+	}
+
+	for _, cm := range charts {
+		id, existing, found := findChartByDomainName(s, cm.Domain, cm.Name)
+		if !found {
+			id = uuid.NewString()
+			newChart := repository.Chart{
+				ChartID:     id,
+				Domain:      cm.Domain,
+				Name:        cm.Name,
+				DeployUnit:  appmetapb.DeployUnit_DEPLOY_UNIT_CHART,
+				Status:      repository.StatusActive,
+				FirstSeenAt: now,
+				LastSeenAt:  now,
+			}
+			s.Charts[id] = newChart
+			result.CreatedCharts = append(result.CreatedCharts, newChart)
+			continue
+		}
+
+		if existing.Status == repository.StatusArchived {
+			result.RejectedCharts = append(result.RejectedCharts, repository.RejectedOwner{
+				Domain: cm.Domain, Name: cm.Name,
+				Reason: fmt.Sprintf("chart %s/%s is ARCHIVED -- a human archived it deliberately; AssertApps does not resurrect it", cm.Domain, cm.Name),
+			})
+			continue
+		}
+
+		wasMissing := existing.Status == repository.StatusMissing
+		updated := existing
+		updated.Status = repository.StatusActive
+		updated.LastSeenAt = now
+		// Deliberately NOT touching updated.AppIDs / chart_app membership --
+		// see AssertApps's doc comment: composition resolution stays
+		// Reconcile-only.
+		s.Charts[id] = updated
+
+		if wasMissing {
+			result.RecoveredCharts = append(result.RecoveredCharts, updated)
+		} else {
+			result.UpdatedCharts = append(result.UpdatedCharts, updated)
+		}
+	}
+
+	return result
+}
+
 func findAppByDomainName(s *state, domain, name string) (string, repository.App, bool) {
 	for id, a := range s.Apps {
 		if a.Domain == domain && a.Name == name {

--- a/tools/app_registry/server/repository/models.go
+++ b/tools/app_registry/server/repository/models.go
@@ -35,7 +35,67 @@ const (
 	PromotabilityNotPromotable Promotability = "not_promotable"
 )
 
+// ManifestProvenance mirrors app_manifest.provenance / chart_manifest.provenance
+// (migration 008, AR-7c, issue #558): which call wrote a manifest snapshot.
+// "sweep" is ReconcileApps, running only from main push -- the only
+// provenance v_current_app/v_current_chart read (see ARCHITECTURE.md
+// "AssertApps (additive) vs. ReconcileApps"). "release" is AssertApps,
+// called from release.yml against whatever ref is being released -- kept
+// for audit ("was this artifact's promotability derived from a sweep
+// snapshot or a release-time one?"), never read by the current-state views.
+type ManifestProvenance string
+
+const (
+	ManifestProvenanceSweep   ManifestProvenance = "sweep"
+	ManifestProvenanceRelease ManifestProvenance = "release"
+)
+
+// ManifestSource is the ordering/provenance metadata one Reconcile or
+// AssertApps call carries -- the same three AppManifestSet fields
+// ReconcileSource already wraps (git_sha / source_committed_at /
+// discovered_at), reused here rather than duplicated because AssertApps
+// needs exactly the same triple, just without ever consulting the reconcile
+// watermark. See AppRepository.AssertApps's doc comment.
+type ManifestSource = ReconcileSource
+
+// RejectedOwner is one app or chart AssertApps declined to touch because it
+// is ARCHIVED -- a human said this app/chart is gone for good, and a
+// release silently resurrecting it is worse than a red step (AR-7c, issue
+// #558). Modeled on UnresolvedChart's per-item skip-and-report shape: every
+// other app/chart in the same AssertApps call still applies.
+type RejectedOwner struct {
+	Domain string
+	Name   string
+	Reason string
+}
+
+// AssertResult buckets every App/Chart row touched by one AssertApps call --
+// the additive-only counterpart to ReconcileResult. See
+// AppRepository.AssertApps's doc comment for exactly what each bucket means;
+// unlike ReconcileResult there is no NewlyMissing bucket (AssertApps never
+// marks anything MISSING) and no UnresolvedCharts (AssertApps never resolves
+// chart_app membership -- that stays ReconcileApps-only).
+type AssertResult struct {
+	CreatedApps   []App
+	UpdatedApps   []App // already ACTIVE; only the manifest snapshot changed
+	RecoveredApps []App // MISSING -> ACTIVE
+	RejectedApps  []RejectedOwner
+
+	CreatedCharts   []Chart
+	UpdatedCharts   []Chart
+	RecoveredCharts []Chart
+	RejectedCharts  []RejectedOwner
+}
+
 // App mirrors one release_app manifest. Never hard-deleted.
+//
+// As of migration 008 (AR-7c, issue #558) `app` itself is pure identity
+// (domain, name, status, first/last-seen) -- every field below EXCEPT those
+// is populated by a join to the latest `main`-sweep app_manifest snapshot
+// (v_current_app, in postgres/app.go), not stored directly. This struct's
+// SHAPE is unchanged from before AR-7c on purpose: the wire (App in
+// protos/messages.proto) and every handler/CLI consumer read these fields
+// exactly as before -- only where postgres/app.go sources them from moved.
 type App struct {
 	AppID           string
 	Domain          string
@@ -53,7 +113,12 @@ type App struct {
 
 func (a App) FullName() string { return a.Domain + "-" + a.Name }
 
-// Chart is a Helm chart composing one or more apps.
+// Chart is a Helm chart composing one or more apps. As of migration 008
+// (AR-7c) `chart` itself is pure identity -- see App's doc comment for the
+// same split; v_current_chart supplies Description/ChartRepository/
+// DeployUnit, though for a chart those are (and always were) constants, not
+// values sourced from a manifest -- see migration 008's "Why chart_manifest
+// has no generated columns".
 type Chart struct {
 	ChartID         string
 	Domain          string
@@ -224,8 +289,28 @@ type Artifact struct {
 	// State == ArtifactStateFailed.
 	FailReason string
 
-	// Promotability is DERIVED — computed at read time from the owner's
-	// DeployUnit, never persisted. Populated by repository read methods.
+	// ManifestID is the app_manifest/chart_manifest snapshot (migration 008,
+	// AR-7c) this row's Promotability was derived from -- set once, at the
+	// instant State reaches ArtifactStatePublished, never touched again.
+	// Empty for allocated/publishing/failed rows, and for any row published
+	// before migration 008 (no snapshot exists that honestly corresponds to
+	// what was live when those were originally published -- see migration
+	// 008's backfill comments). No FK: it is a polymorphic reference (an
+	// image artifact's ManifestID names an app_manifest row, a chart
+	// artifact's a chart_manifest row), same reasoning as Artifact not
+	// carrying its own FK-typed owner_id.
+	ManifestID string
+
+	// Promotability is now STORED (migration 008, AR-7c) -- computed ONCE by
+	// repository.DerivePromotability at the instant State reaches
+	// ArtifactStatePublished, from ManifestID's snapshot (or, absent one,
+	// the owner's current v_current_app/v_current_chart deploy_unit -- see
+	// postgres/artifact.go's resolveManifestForPublish). Never recomputed on
+	// read. This is the fix for the retroactivity bug ARCHITECTURE.md
+	// documents: editing an app's deploy_unit after a build was published no
+	// longer changes that build's promotability. Empty/unset for
+	// allocated/publishing/failed rows -- there is nothing to derive it from
+	// until publish.
 	Promotability Promotability
 
 	// Contains is populated only for Kind == ArtifactKindChart.

--- a/tools/app_registry/server/repository/postgres/BUILD.bazel
+++ b/tools/app_registry/server/repository/postgres/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "@com_github_jackc_pgx_v5//:pgx",
         "@com_github_jackc_pgx_v5//pgconn",
         "@com_github_jackc_pgx_v5//pgxpool",
+        "@org_golang_google_protobuf//encoding/protojson",
     ],
 )
 
@@ -74,6 +75,8 @@ go_test(
         "//tools/app_registry/server/handlers",
         "//tools/app_registry/server/repository",
         "//tools/appmeta/proto:appmetapb",
+        "@com_github_google_uuid//:uuid",
+        "@com_github_jackc_pgx_v5//:pgx",
         "@com_github_jackc_pgx_v5//pgconn",
         "@com_github_jackc_pgx_v5//pgxpool",
         "@com_github_jackc_pgx_v5//stdlib",

--- a/tools/app_registry/server/repository/postgres/app.go
+++ b/tools/app_registry/server/repository/postgres/app.go
@@ -11,10 +11,17 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/whale-net/everything/tools/app_registry/server/repository"
 	appmetapb "github.com/whale-net/everything/tools/appmeta/proto"
+	"google.golang.org/protobuf/encoding/protojson"
 )
 
 type appRepo struct{ ex dbtx }
 
+// appColumns/chartColumns are read against v_current_app/v_current_chart
+// (migration 008, AR-7c) -- identity ⋈ latest `main`-sweep manifest
+// snapshot, see that migration's comments. Column NAMES and ORDER are
+// unchanged from before AR-7c on purpose: scanApp/scanChart below, and
+// every wire type they feed (App/Chart in protos/messages.proto), are
+// untouched by this split.
 const appColumns = `app_id, domain, name, description, language, app_type, deploy_unit, bazel_label, image_repository, status, first_seen_at, last_seen_at`
 
 func scanApp(row pgx.Row) (repository.App, error) {
@@ -106,23 +113,25 @@ func (r *appRepo) Reconcile(ctx context.Context, apps []*appmetapb.AppManifest, 
 			appID := ""
 			if !dryRun {
 				appID = uuid.NewString()
+				// AR-7c (migration 008): `app` is pure identity now --
+				// description/language/app_type/deploy_unit/bazel_label/
+				// image_repository all live only in the manifest snapshot
+				// below, never on this row -- see appColumns's doc comment.
 				_, err := r.ex.Exec(ctx, `
-					INSERT INTO app (app_id, domain, name, description, language, app_type, deploy_unit, bazel_label, image_repository, status, first_seen_at, last_seen_at)
-					VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, 'active', $10, $10)`,
-					appID, am.Domain, am.Name, am.Description, am.Language, am.AppType, deployUnitToDB(am.DeployUnit), am.BinaryTarget, imageRepository(am), now)
+					INSERT INTO app (app_id, domain, name, status, first_seen_at, last_seen_at)
+					VALUES ($1, $2, $3, 'active', $4, $4)`,
+					appID, am.Domain, am.Name, now)
 				if err != nil {
 					if de, ok := translatePgError(err, fmt.Sprintf("app %s-%s already recorded", am.Domain, am.Name)); ok {
 						return nil, de
 					}
 					return nil, fmt.Errorf("reconcile: insert app %s/%s: %w", am.Domain, am.Name, err)
 				}
+				if err := r.upsertAppManifestSnapshot(ctx, appID, am, source, repository.ManifestProvenanceSweep); err != nil {
+					return nil, fmt.Errorf("reconcile: %w", err)
+				}
 			}
-			newApp := repository.App{
-				AppID: appID, Domain: am.Domain, Name: am.Name, Description: am.Description,
-				Language: am.Language, AppType: am.AppType, DeployUnit: normalizeDeployUnit(am.DeployUnit),
-				BazelLabel: am.BinaryTarget, ImageRepository: imageRepository(am),
-				Status: repository.StatusActive, FirstSeenAt: now, LastSeenAt: now,
-			}
+			newApp := appFromManifest(appID, am, repository.StatusActive, now, now)
 			result.CreatedApps = append(result.CreatedApps, newApp)
 			if appID != "" {
 				presentAppIDs[appID] = true
@@ -132,23 +141,14 @@ func (r *appRepo) Reconcile(ctx context.Context, apps []*appmetapb.AppManifest, 
 		}
 
 		wasMissing := existing.Status == repository.StatusMissing
-		updated := *existing
-		updated.Description = am.Description
-		updated.Language = am.Language
-		updated.AppType = am.AppType
-		updated.DeployUnit = normalizeDeployUnit(am.DeployUnit)
-		updated.BazelLabel = am.BinaryTarget
-		updated.ImageRepository = imageRepository(am)
-		updated.Status = repository.StatusActive
-		updated.LastSeenAt = now
+		updated := appFromManifest(existing.AppID, am, repository.StatusActive, existing.FirstSeenAt, now)
 
 		if !dryRun {
-			_, err := r.ex.Exec(ctx, `
-				UPDATE app SET description=$2, language=$3, app_type=$4, deploy_unit=$5, bazel_label=$6, image_repository=$7, status='active', last_seen_at=$8
-				WHERE app_id=$1`,
-				existing.AppID, updated.Description, updated.Language, updated.AppType, deployUnitToDB(updated.DeployUnit), updated.BazelLabel, updated.ImageRepository, now)
-			if err != nil {
+			if _, err := r.ex.Exec(ctx, `UPDATE app SET status='active', last_seen_at=$2 WHERE app_id=$1`, existing.AppID, now); err != nil {
 				return nil, fmt.Errorf("reconcile: update app %s/%s: %w", am.Domain, am.Name, err)
+			}
+			if err := r.upsertAppManifestSnapshot(ctx, existing.AppID, am, source, repository.ManifestProvenanceSweep); err != nil {
+				return nil, fmt.Errorf("reconcile: %w", err)
 			}
 		}
 		presentAppIDs[existing.AppID] = true
@@ -164,7 +164,7 @@ func (r *appRepo) Reconcile(ctx context.Context, apps []*appmetapb.AppManifest, 
 	// Anything active-and-absent becomes MISSING. last_seen_at is
 	// deliberately left untouched — SetAppStatus's "present in the latest
 	// reconcile" check compares it against the table-wide max.
-	rows, err := r.ex.Query(ctx, `SELECT `+appColumns+` FROM app WHERE status = 'active'`)
+	rows, err := r.ex.Query(ctx, `SELECT `+appColumns+` FROM v_current_app WHERE status = 'active'`)
 	if err != nil {
 		return nil, fmt.Errorf("reconcile: scan active apps: %w", err)
 	}
@@ -231,8 +231,8 @@ func (r *appRepo) Reconcile(ctx context.Context, apps []*appmetapb.AppManifest, 
 			if !dryRun {
 				chartID = uuid.NewString()
 				if _, err := r.ex.Exec(ctx, `
-					INSERT INTO chart (chart_id, domain, name, deploy_unit, status, first_seen_at, last_seen_at)
-					VALUES ($1, $2, $3, 'chart', 'active', $4, $4)`,
+					INSERT INTO chart (chart_id, domain, name, status, first_seen_at, last_seen_at)
+					VALUES ($1, $2, $3, 'active', $4, $4)`,
 					chartID, cm.Domain, cm.Name, now); err != nil {
 					if de, ok := translatePgError(err, fmt.Sprintf("chart %s-%s already recorded", cm.Domain, cm.Name)); ok {
 						return nil, de
@@ -242,11 +242,11 @@ func (r *appRepo) Reconcile(ctx context.Context, apps []*appmetapb.AppManifest, 
 				if err := r.setChartApps(ctx, chartID, appIDs); err != nil {
 					return nil, err
 				}
+				if err := r.upsertChartManifestSnapshot(ctx, chartID, cm, source, repository.ManifestProvenanceSweep); err != nil {
+					return nil, fmt.Errorf("reconcile: %w", err)
+				}
 			}
-			newChart := repository.Chart{
-				ChartID: chartID, Domain: cm.Domain, Name: cm.Name, DeployUnit: appmetapb.DeployUnit_DEPLOY_UNIT_CHART,
-				Status: repository.StatusActive, AppIDs: appIDs, FirstSeenAt: now, LastSeenAt: now,
-			}
+			newChart := chartFromManifest(chartID, cm, appIDs, repository.StatusActive, now, now)
 			result.CreatedCharts = append(result.CreatedCharts, newChart)
 			if chartID != "" {
 				presentChartIDs[chartID] = true
@@ -255,10 +255,7 @@ func (r *appRepo) Reconcile(ctx context.Context, apps []*appmetapb.AppManifest, 
 		}
 
 		wasMissing := existing.Status == repository.StatusMissing
-		updated := *existing
-		updated.AppIDs = appIDs
-		updated.Status = repository.StatusActive
-		updated.LastSeenAt = now
+		updated := chartFromManifest(existing.ChartID, cm, appIDs, repository.StatusActive, existing.FirstSeenAt, now)
 
 		if !dryRun {
 			if _, err := r.ex.Exec(ctx, `UPDATE chart SET status='active', last_seen_at=$2 WHERE chart_id=$1`, existing.ChartID, now); err != nil {
@@ -266,6 +263,9 @@ func (r *appRepo) Reconcile(ctx context.Context, apps []*appmetapb.AppManifest, 
 			}
 			if err := r.setChartApps(ctx, existing.ChartID, appIDs); err != nil {
 				return nil, err
+			}
+			if err := r.upsertChartManifestSnapshot(ctx, existing.ChartID, cm, source, repository.ManifestProvenanceSweep); err != nil {
+				return nil, fmt.Errorf("reconcile: %w", err)
 			}
 		}
 		presentChartIDs[existing.ChartID] = true
@@ -277,7 +277,7 @@ func (r *appRepo) Reconcile(ctx context.Context, apps []*appmetapb.AppManifest, 
 		}
 	}
 
-	crows, err := r.ex.Query(ctx, `SELECT `+chartColumns+` FROM chart WHERE status = 'active'`)
+	crows, err := r.ex.Query(ctx, `SELECT `+chartColumns+` FROM v_current_chart WHERE status = 'active'`)
 	if err != nil {
 		return nil, fmt.Errorf("reconcile: scan active charts: %w", err)
 	}
@@ -306,6 +306,126 @@ func (r *appRepo) Reconcile(ctx context.Context, apps []*appmetapb.AppManifest, 
 	if !dryRun {
 		if err := r.advanceReconcileWatermark(ctx, source, now); err != nil {
 			return nil, fmt.Errorf("reconcile: advance watermark: %w", err)
+		}
+	}
+
+	return result, nil
+}
+
+// ============================================================================
+// AssertApps (AR-7c, issue #558)
+// ============================================================================
+
+// AssertApps implements repository.AppRepository.AssertApps -- see that doc
+// comment for the full contract. Deliberately much smaller than Reconcile:
+// no watermark check, no absence sweep, no chart_app membership write --
+// just create-or-recover identity plus a manifest snapshot, per item,
+// rejecting (not aborting) an ARCHIVED target.
+func (r *appRepo) AssertApps(ctx context.Context, apps []*appmetapb.AppManifest, charts []*appmetapb.ChartManifest, source repository.ManifestSource) (*repository.AssertResult, error) {
+	now := time.Now().UTC()
+	result := &repository.AssertResult{}
+
+	for _, am := range apps {
+		existing, err := r.getAppByDomainName(ctx, am.Domain, am.Name)
+		if err != nil && !errors.Is(err, repository.ErrNotFound) {
+			return nil, fmt.Errorf("assert: look up app %s/%s: %w", am.Domain, am.Name, err)
+		}
+
+		if existing == nil {
+			appID := uuid.NewString()
+			if _, err := r.ex.Exec(ctx, `
+				INSERT INTO app (app_id, domain, name, status, first_seen_at, last_seen_at)
+				VALUES ($1, $2, $3, 'active', $4, $4)`,
+				appID, am.Domain, am.Name, now); err != nil {
+				if de, ok := translatePgError(err, fmt.Sprintf("app %s-%s already recorded", am.Domain, am.Name)); ok {
+					return nil, de
+				}
+				return nil, fmt.Errorf("assert: insert app %s/%s: %w", am.Domain, am.Name, err)
+			}
+			if err := r.upsertAppManifestSnapshot(ctx, appID, am, source, repository.ManifestProvenanceRelease); err != nil {
+				return nil, fmt.Errorf("assert: %w", err)
+			}
+			result.CreatedApps = append(result.CreatedApps, appFromManifest(appID, am, repository.StatusActive, now, now))
+			continue
+		}
+
+		// AR-7c: reject, per item, rather than resurrect an app a human
+		// archived on purpose -- see repository.AppRepository.AssertApps's
+		// doc comment.
+		if existing.Status == repository.StatusArchived {
+			result.RejectedApps = append(result.RejectedApps, repository.RejectedOwner{
+				Domain: am.Domain, Name: am.Name,
+				Reason: fmt.Sprintf("app %s/%s is ARCHIVED -- a human archived it deliberately; AssertApps does not resurrect it", am.Domain, am.Name),
+			})
+			continue
+		}
+
+		wasMissing := existing.Status == repository.StatusMissing
+		if _, err := r.ex.Exec(ctx, `UPDATE app SET status='active', last_seen_at=$2 WHERE app_id=$1`, existing.AppID, now); err != nil {
+			return nil, fmt.Errorf("assert: update app %s/%s: %w", am.Domain, am.Name, err)
+		}
+		if err := r.upsertAppManifestSnapshot(ctx, existing.AppID, am, source, repository.ManifestProvenanceRelease); err != nil {
+			return nil, fmt.Errorf("assert: %w", err)
+		}
+		updated := appFromManifest(existing.AppID, am, repository.StatusActive, existing.FirstSeenAt, now)
+		if wasMissing {
+			result.RecoveredApps = append(result.RecoveredApps, updated)
+		} else {
+			result.UpdatedApps = append(result.UpdatedApps, updated)
+		}
+	}
+
+	for _, cm := range charts {
+		existing, err := r.getChartByDomainName(ctx, cm.Domain, cm.Name)
+		if err != nil && !errors.Is(err, repository.ErrNotFound) {
+			return nil, fmt.Errorf("assert: look up chart %s/%s: %w", cm.Domain, cm.Name, err)
+		}
+
+		if existing == nil {
+			chartID := uuid.NewString()
+			// Deliberately NOT resolving app_refs / writing chart_app here --
+			// see AssertApps's doc comment: composition resolution stays
+			// Reconcile-only, because it needs the canonical complete tree
+			// to be safe, which a release ref is not guaranteed to be.
+			if _, err := r.ex.Exec(ctx, `
+				INSERT INTO chart (chart_id, domain, name, status, first_seen_at, last_seen_at)
+				VALUES ($1, $2, $3, 'active', $4, $4)`,
+				chartID, cm.Domain, cm.Name, now); err != nil {
+				if de, ok := translatePgError(err, fmt.Sprintf("chart %s-%s already recorded", cm.Domain, cm.Name)); ok {
+					return nil, de
+				}
+				return nil, fmt.Errorf("assert: insert chart %s/%s: %w", cm.Domain, cm.Name, err)
+			}
+			if err := r.upsertChartManifestSnapshot(ctx, chartID, cm, source, repository.ManifestProvenanceRelease); err != nil {
+				return nil, fmt.Errorf("assert: %w", err)
+			}
+			result.CreatedCharts = append(result.CreatedCharts, chartFromManifest(chartID, cm, nil, repository.StatusActive, now, now))
+			continue
+		}
+
+		if existing.Status == repository.StatusArchived {
+			result.RejectedCharts = append(result.RejectedCharts, repository.RejectedOwner{
+				Domain: cm.Domain, Name: cm.Name,
+				Reason: fmt.Sprintf("chart %s/%s is ARCHIVED -- a human archived it deliberately; AssertApps does not resurrect it", cm.Domain, cm.Name),
+			})
+			continue
+		}
+
+		wasMissing := existing.Status == repository.StatusMissing
+		if _, err := r.ex.Exec(ctx, `UPDATE chart SET status='active', last_seen_at=$2 WHERE chart_id=$1`, existing.ChartID, now); err != nil {
+			return nil, fmt.Errorf("assert: update chart %s/%s: %w", cm.Domain, cm.Name, err)
+		}
+		if err := r.upsertChartManifestSnapshot(ctx, existing.ChartID, cm, source, repository.ManifestProvenanceRelease); err != nil {
+			return nil, fmt.Errorf("assert: %w", err)
+		}
+		// existing.AppIDs (populated by getChartByDomainName via
+		// chartAppIDs) is left exactly as Reconcile last set it -- AssertApps
+		// never touches chart_app membership.
+		updated := chartFromManifest(existing.ChartID, cm, existing.AppIDs, repository.StatusActive, existing.FirstSeenAt, now)
+		if wasMissing {
+			result.RecoveredCharts = append(result.RecoveredCharts, updated)
+		} else {
+			result.UpdatedCharts = append(result.UpdatedCharts, updated)
 		}
 	}
 
@@ -492,9 +612,43 @@ func imageRepository(am *appmetapb.AppManifest) string {
 // Reads
 // ============================================================================
 
+// identityColumns / scanAppIdentity / getAppByDomainName: as of migration
+// 008 (AR-7c), `app` itself is pure identity, so a write-path lookup that
+// only needs app_id/status (Reconcile's/AssertApps's existing-row check,
+// resolveChartApps's app_ref resolution) queries the bare `app` table
+// directly rather than v_current_app -- there is no reason for a write to
+// pull in a manifest-snapshot join it doesn't need. Every OTHER field on
+// the returned App is left zero-valued; callers of this function must never
+// pass its result to a wire response (appToPB) -- construct that from the
+// AppManifest/ChartManifest already in hand instead (see Reconcile/
+// AssertApps below).
+const identityColumns = `app_id, domain, name, status, first_seen_at, last_seen_at`
+
+func scanAppIdentity(row pgx.Row) (repository.App, error) {
+	var a repository.App
+	var status string
+	if err := row.Scan(&a.AppID, &a.Domain, &a.Name, &status, &a.FirstSeenAt, &a.LastSeenAt); err != nil {
+		return repository.App{}, err
+	}
+	a.Status = repository.Status(status)
+	return a, nil
+}
+
+const chartIdentityColumns = `chart_id, domain, name, status, first_seen_at, last_seen_at`
+
+func scanChartIdentity(row pgx.Row) (repository.Chart, error) {
+	var c repository.Chart
+	var status string
+	if err := row.Scan(&c.ChartID, &c.Domain, &c.Name, &status, &c.FirstSeenAt, &c.LastSeenAt); err != nil {
+		return repository.Chart{}, err
+	}
+	c.Status = repository.Status(status)
+	return c, nil
+}
+
 func (r *appRepo) getAppByDomainName(ctx context.Context, domain, name string) (*repository.App, error) {
-	row := r.ex.QueryRow(ctx, `SELECT `+appColumns+` FROM app WHERE domain = $1 AND name = $2`, domain, name)
-	a, err := scanApp(row)
+	row := r.ex.QueryRow(ctx, `SELECT `+identityColumns+` FROM app WHERE domain = $1 AND name = $2`, domain, name)
+	a, err := scanAppIdentity(row)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, repository.ErrNotFound
@@ -505,8 +659,8 @@ func (r *appRepo) getAppByDomainName(ctx context.Context, domain, name string) (
 }
 
 func (r *appRepo) getChartByDomainName(ctx context.Context, domain, name string) (*repository.Chart, error) {
-	row := r.ex.QueryRow(ctx, `SELECT `+chartColumns+` FROM chart WHERE domain = $1 AND name = $2`, domain, name)
-	c, err := scanChart(row)
+	row := r.ex.QueryRow(ctx, `SELECT `+chartIdentityColumns+` FROM chart WHERE domain = $1 AND name = $2`, domain, name)
+	c, err := scanChartIdentity(row)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, repository.ErrNotFound
@@ -517,6 +671,78 @@ func (r *appRepo) getChartByDomainName(ctx context.Context, domain, name string)
 		c.AppIDs = ids
 	}
 	return &c, nil
+}
+
+// ============================================================================
+// Manifest snapshots (migration 008, AR-7c)
+// ============================================================================
+
+// manifestJSONMarshal serializes AppManifest/ChartManifest VERBATIM as
+// protojson for storage in app_manifest.manifest_json / chart_manifest.
+// manifest_json. UseProtoNames keeps keys snake_case, matching the
+// Starlark-emitted JSON these values originated from (ARCHITECTURE.md
+// "Shared manifest schema"). EmitUnpopulated writes every field, including
+// zero-valued ones (e.g. an unset deploy_unit becomes the literal string
+// "DEPLOY_UNIT_UNSPECIFIED" rather than being omitted) -- required for
+// "verbatim" to mean what it says, and for migration 008's generated
+// columns' CASE expressions to see a key that is genuinely always present.
+var manifestJSONMarshal = protojson.MarshalOptions{UseProtoNames: true, EmitUnpopulated: true}
+
+// upsertAppManifestSnapshot writes one app_manifest row keyed
+// (appID, source.GitSHA) -- idempotent via ON CONFLICT DO NOTHING, because
+// the manifest for a given commit cannot change (migration 008's header
+// comment). provenance distinguishes a ReconcileApps sweep (the only kind
+// v_current_app reads) from an AssertApps release-time call.
+func (r *appRepo) upsertAppManifestSnapshot(ctx context.Context, appID string, am *appmetapb.AppManifest, source repository.ManifestSource, provenance repository.ManifestProvenance) error {
+	body, err := manifestJSONMarshal.Marshal(am)
+	if err != nil {
+		return fmt.Errorf("marshal app manifest for %s/%s: %w", am.Domain, am.Name, err)
+	}
+	if _, err := r.ex.Exec(ctx, `
+		INSERT INTO app_manifest (owner_id, source_git_sha, source_committed_at, provenance, manifest_json)
+		VALUES ($1, $2, $3, $4, $5)
+		ON CONFLICT (owner_id, source_git_sha) DO NOTHING`,
+		appID, source.GitSHA, source.SourceCommittedAt, string(provenance), string(body)); err != nil {
+		return fmt.Errorf("record app manifest snapshot for %s/%s: %w", am.Domain, am.Name, err)
+	}
+	return nil
+}
+
+func (r *appRepo) upsertChartManifestSnapshot(ctx context.Context, chartID string, cm *appmetapb.ChartManifest, source repository.ManifestSource, provenance repository.ManifestProvenance) error {
+	body, err := manifestJSONMarshal.Marshal(cm)
+	if err != nil {
+		return fmt.Errorf("marshal chart manifest for %s/%s: %w", cm.Domain, cm.Name, err)
+	}
+	if _, err := r.ex.Exec(ctx, `
+		INSERT INTO chart_manifest (owner_id, source_git_sha, source_committed_at, provenance, manifest_json)
+		VALUES ($1, $2, $3, $4, $5)
+		ON CONFLICT (owner_id, source_git_sha) DO NOTHING`,
+		chartID, source.GitSHA, source.SourceCommittedAt, string(provenance), string(body)); err != nil {
+		return fmt.Errorf("record chart manifest snapshot for %s/%s: %w", cm.Domain, cm.Name, err)
+	}
+	return nil
+}
+
+// appFromManifest/chartFromManifest build the wire-shaped App/Chart struct
+// straight from the AppManifest/ChartManifest just asserted/reconciled --
+// avoiding a redundant read-back through v_current_app/v_current_chart
+// immediately after writing the very row that view would join against.
+// Mirrors exactly what the pre-AR-7c code built inline for
+// CreatedApps/UpdatedApps -- see Reconcile below.
+func appFromManifest(appID string, am *appmetapb.AppManifest, status repository.Status, firstSeenAt, lastSeenAt time.Time) repository.App {
+	return repository.App{
+		AppID: appID, Domain: am.Domain, Name: am.Name, Description: am.Description,
+		Language: am.Language, AppType: am.AppType, DeployUnit: normalizeDeployUnit(am.DeployUnit),
+		BazelLabel: am.BinaryTarget, ImageRepository: imageRepository(am),
+		Status: status, FirstSeenAt: firstSeenAt, LastSeenAt: lastSeenAt,
+	}
+}
+
+func chartFromManifest(chartID string, cm *appmetapb.ChartManifest, appIDs []string, status repository.Status, firstSeenAt, lastSeenAt time.Time) repository.Chart {
+	return repository.Chart{
+		ChartID: chartID, Domain: cm.Domain, Name: cm.Name, DeployUnit: appmetapb.DeployUnit_DEPLOY_UNIT_CHART,
+		Status: status, AppIDs: appIDs, FirstSeenAt: firstSeenAt, LastSeenAt: lastSeenAt,
+	}
 }
 
 func (r *appRepo) chartAppIDs(ctx context.Context, chartID string) ([]string, error) {
@@ -546,7 +772,7 @@ func (r *appRepo) ListApps(ctx context.Context, filter repository.AppListFilter)
 		statusStrs[i] = string(s)
 	}
 
-	query := `SELECT ` + appColumns + ` FROM app WHERE status = ANY($1)`
+	query := `SELECT ` + appColumns + ` FROM v_current_app WHERE status = ANY($1)`
 	args := []any{statusStrs}
 	if filter.Domain != "" {
 		args = append(args, filter.Domain)
@@ -575,7 +801,7 @@ func (r *appRepo) ListApps(ctx context.Context, filter repository.AppListFilter)
 }
 
 func (r *appRepo) GetAppByID(ctx context.Context, appID string) (*repository.App, error) {
-	row := r.ex.QueryRow(ctx, `SELECT `+appColumns+` FROM app WHERE app_id = $1`, appID)
+	row := r.ex.QueryRow(ctx, `SELECT `+appColumns+` FROM v_current_app WHERE app_id = $1`, appID)
 	a, err := scanApp(row)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -587,7 +813,7 @@ func (r *appRepo) GetAppByID(ctx context.Context, appID string) (*repository.App
 }
 
 func (r *appRepo) GetAppByFullName(ctx context.Context, fullName string) (*repository.App, error) {
-	row := r.ex.QueryRow(ctx, `SELECT `+appColumns+` FROM app WHERE domain || '-' || name = $1`, fullName)
+	row := r.ex.QueryRow(ctx, `SELECT `+appColumns+` FROM v_current_app WHERE domain || '-' || name = $1`, fullName)
 	a, err := scanApp(row)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -600,7 +826,7 @@ func (r *appRepo) GetAppByFullName(ctx context.Context, fullName string) (*repos
 
 func (r *appRepo) ChartsForApp(ctx context.Context, appID string) ([]repository.Chart, error) {
 	rows, err := r.ex.Query(ctx, `
-		SELECT `+chartColumns+` FROM chart c
+		SELECT `+chartColumns+` FROM v_current_chart c
 		JOIN chart_app ca ON ca.chart_id = c.chart_id
 		WHERE ca.app_id = $1
 		ORDER BY c.domain, c.name`, appID)
@@ -632,7 +858,7 @@ func (r *appRepo) ListCharts(ctx context.Context, filter repository.ChartListFil
 		statusStrs[i] = string(s)
 	}
 
-	query := `SELECT ` + chartColumns + ` FROM chart WHERE status = ANY($1)`
+	query := `SELECT ` + chartColumns + ` FROM v_current_chart WHERE status = ANY($1)`
 	args := []any{statusStrs}
 	if filter.Domain != "" {
 		args = append(args, filter.Domain)
@@ -660,7 +886,7 @@ func (r *appRepo) ListCharts(ctx context.Context, filter repository.ChartListFil
 }
 
 func (r *appRepo) GetChartByID(ctx context.Context, chartID string) (*repository.Chart, error) {
-	row := r.ex.QueryRow(ctx, `SELECT `+chartColumns+` FROM chart WHERE chart_id = $1`, chartID)
+	row := r.ex.QueryRow(ctx, `SELECT `+chartColumns+` FROM v_current_chart WHERE chart_id = $1`, chartID)
 	c, err := scanChart(row)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -675,7 +901,7 @@ func (r *appRepo) GetChartByID(ctx context.Context, chartID string) (*repository
 }
 
 func (r *appRepo) GetChartByFullName(ctx context.Context, fullName string) (*repository.Chart, error) {
-	row := r.ex.QueryRow(ctx, `SELECT `+chartColumns+` FROM chart WHERE domain || '-' || name = $1`, fullName)
+	row := r.ex.QueryRow(ctx, `SELECT `+chartColumns+` FROM v_current_chart WHERE domain || '-' || name = $1`, fullName)
 	c, err := scanChart(row)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -694,7 +920,7 @@ func (r *appRepo) GetChartByFullName(ctx context.Context, fullName string) (*rep
 // ============================================================================
 
 func (r *appRepo) SetAppStatus(ctx context.Context, appID string, target repository.Status, reason string) (*repository.App, error) {
-	row := r.ex.QueryRow(ctx, `SELECT `+appColumns+` FROM app WHERE app_id = $1`, appID)
+	row := r.ex.QueryRow(ctx, `SELECT `+appColumns+` FROM v_current_app WHERE app_id = $1`, appID)
 
 	var a repository.App
 	var deployUnit, dbStatus string

--- a/tools/app_registry/server/repository/postgres/artifact.go
+++ b/tools/app_registry/server/repository/postgres/artifact.go
@@ -89,16 +89,27 @@ func (r *buildRepo) GetBuild(ctx context.Context, buildID string) (*repository.B
 
 type artifactRepo struct{ ex dbtx }
 
-// artifactRow is what every artifact SELECT returns: the artifact plus the
-// owning app's/chart's deploy_unit, which is all repository.DerivePromotability
-// needs. Promotability is never persisted — see ARCHITECTURE.md "Promotability".
-// digest/build_id/published_at are nullable as of migration 007 (AR-7b) —
-// an "allocated" row has neither, a "publishing" row has a build but no
-// digest — so they scan into pointers and get zero-valued below.
+// artifactRow is what every artifact SELECT returns. As of migration 008
+// (AR-7c), promotability/manifest_id are STORED columns on `artifact`
+// itself -- read directly here, never re-derived from a live join to
+// app.deploy_unit/chart.deploy_unit the way this query did before AR-7c
+// (that live join is exactly the retroactivity bug ARCHITECTURE.md
+// documents: editing an app's deploy_unit after publish used to silently
+// change every past artifact's promotability). digest/build_id/
+// published_at/manifest_id/promotability are all nullable -- an "allocated"
+// row has none of them yet; see migration 007's artifact_state_shape and
+// migration 008's artifact_promotability_shape CHECK constraints for
+// exactly which states may have which.
+// The LEFT JOINs to app/chart exist ONLY so lookups by owner full name
+// (findArtifact's OwnerFullName branch, ListArtifacts' OwnerFullName
+// filter, below) can match "domain-name" against the right owner -- NOT to
+// source promotability, which is why scanArtifact selects no columns off
+// them: as of migration 008 (AR-7c), a.manifest_id/a.promotability are
+// stored on `artifact` itself.
 const artifactSelectBase = `
 	SELECT a.artifact_id, a.kind, a.app_id, a.chart_id, a.repository, a.version, a.digest, a.build_id, a.published_at,
 	       a.state, a.provenance, a.version_source, a.state_changed_at, a.fail_reason,
-	       COALESCE(app.deploy_unit, chart.deploy_unit) AS owner_deploy_unit
+	       a.manifest_id, a.promotability
 	FROM artifact a
 	LEFT JOIN app ON a.app_id = app.app_id
 	LEFT JOIN chart ON a.chart_id = chart.chart_id`
@@ -106,13 +117,12 @@ const artifactSelectBase = `
 func scanArtifact(row pgx.Row) (repository.Artifact, error) {
 	var a repository.Artifact
 	var kind, state, provenance, versionSource string
-	var appID, chartID, digest, buildID *string
+	var appID, chartID, digest, buildID, manifestID, promotability *string
 	var publishedAt *time.Time
-	var ownerDeployUnit *string
 	if err := row.Scan(
 		&a.ArtifactID, &kind, &appID, &chartID, &a.Repository, &a.Version, &digest, &buildID, &publishedAt,
 		&state, &provenance, &versionSource, &a.StateChangedAt, &a.FailReason,
-		&ownerDeployUnit,
+		&manifestID, &promotability,
 	); err != nil {
 		return repository.Artifact{}, err
 	}
@@ -135,11 +145,12 @@ func scanArtifact(row pgx.Row) (repository.Artifact, error) {
 	if publishedAt != nil {
 		a.PublishedAt = *publishedAt
 	}
-	var du appmetapb.DeployUnit
-	if ownerDeployUnit != nil {
-		du = deployUnitFromDB(*ownerDeployUnit)
+	if manifestID != nil {
+		a.ManifestID = *manifestID
 	}
-	a.Promotability = repository.DerivePromotability(a.Kind, du)
+	if promotability != nil {
+		a.Promotability = repository.Promotability(*promotability)
+	}
 	return a, nil
 }
 
@@ -222,6 +233,112 @@ func ownerIDOf(a repository.Artifact) string {
 	return a.ChartID
 }
 
+// ============================================================================
+// Manifest resolution at publish time (migration 008, AR-7c)
+// ============================================================================
+
+// resolveManifestForPublish resolves the app_manifest/chart_manifest
+// snapshot to attribute a NEWLY published artifact to, and derives its
+// Promotability from that snapshot -- see ARCHITECTURE.md "App identity vs.
+// per-build manifest snapshot". Called from insertArtifact/completePublish
+// at the exact instant a row reaches "published", and ONLY then -- the
+// result is stored and never recomputed, which is what fixes the
+// retroactivity bug (repository.Artifact.Promotability's doc comment).
+//
+// Prefers the snapshot recorded at the EXACT commit buildID's build was
+// built from -- typically the one release.yml's AssertApps step just wrote,
+// at this same run's git_sha. Falls back to the newest snapshot for this
+// owner, regardless of commit, when no exact match exists (a domain that
+// hasn't wired AssertApps into its release path yet, or a build whose
+// commit predates AR-7c). This is a deliberate simplification: "derived at
+// publish time" means "from the best snapshot known at publish time," not
+// "guaranteed to be the exact build commit" -- requiring an exact match
+// would make every domain's FIRST post-AR-7c publish fail until it adopts
+// AssertApps, which is the opposite of "additive, safe from any ref."
+//
+// Errors (ErrFailedPrecondition) only if NO snapshot exists at all for this
+// owner, which should be unreachable in practice: every write path that can
+// create an app/chart identity row (Reconcile, AssertApps, and migration
+// 008's backfill) always writes at least one manifest snapshot in the same
+// call/migration -- resolveOwner (handlers/artifact.go) already guarantees
+// the owner's IDENTITY exists before RecordArtifact/BeginPublish ever calls
+// this, so a missing snapshot here would mean that invariant broke, not a
+// normal operational condition.
+func (r *artifactRepo) resolveManifestForPublish(ctx context.Context, kind repository.ArtifactKind, ownerID, buildID string) (manifestID string, promotability repository.Promotability, err error) {
+	var buildGitSHA string
+	if buildID != "" {
+		row := r.ex.QueryRow(ctx, `SELECT git_sha FROM build WHERE build_id = $1`, buildID)
+		_ = row.Scan(&buildGitSHA) // best-effort -- falls through to "newest" below regardless
+	}
+
+	if kind == repository.ArtifactKindChart {
+		id, ferr := r.latestChartManifestID(ctx, ownerID, buildGitSHA)
+		if ferr != nil {
+			return "", "", ferr
+		}
+		// A chart artifact's Promotability never depends on its own
+		// snapshot: chart.deploy_unit is always the hardcoded 'chart'
+		// constant (migration 008's "Why chart_manifest has no generated
+		// columns"), so DerivePromotability(CHART, CHART) is always
+		// PROMOTABLE -- no data-dependent branch needed.
+		return id, repository.DerivePromotability(kind, appmetapb.DeployUnit_DEPLOY_UNIT_CHART), nil
+	}
+
+	id, deployUnit, ferr := r.latestAppManifest(ctx, ownerID, buildGitSHA)
+	if ferr != nil {
+		return "", "", ferr
+	}
+	return id, repository.DerivePromotability(kind, deployUnit), nil
+}
+
+func (r *artifactRepo) latestAppManifest(ctx context.Context, ownerID, preferGitSHA string) (manifestID string, deployUnit appmetapb.DeployUnit, err error) {
+	if preferGitSHA != "" {
+		row := r.ex.QueryRow(ctx, `SELECT app_manifest_id, deploy_unit FROM app_manifest WHERE owner_id = $1 AND source_git_sha = $2`, ownerID, preferGitSHA)
+		var id, du string
+		if serr := row.Scan(&id, &du); serr == nil {
+			return id, deployUnitFromDB(du), nil
+		} else if !errors.Is(serr, pgx.ErrNoRows) {
+			return "", 0, fmt.Errorf("resolve manifest for publish: %w", serr)
+		}
+	}
+	row := r.ex.QueryRow(ctx, `
+		SELECT app_manifest_id, deploy_unit FROM app_manifest
+		WHERE owner_id = $1
+		ORDER BY source_committed_at DESC, recorded_at DESC LIMIT 1`, ownerID)
+	var id, du string
+	if serr := row.Scan(&id, &du); serr != nil {
+		if errors.Is(serr, pgx.ErrNoRows) {
+			return "", 0, fmt.Errorf("%w: no manifest snapshot recorded for app owner %s -- AssertApps/ReconcileApps must run before publishing", repository.ErrFailedPrecondition, ownerID)
+		}
+		return "", 0, fmt.Errorf("resolve manifest for publish: %w", serr)
+	}
+	return id, deployUnitFromDB(du), nil
+}
+
+func (r *artifactRepo) latestChartManifestID(ctx context.Context, ownerID, preferGitSHA string) (string, error) {
+	if preferGitSHA != "" {
+		row := r.ex.QueryRow(ctx, `SELECT chart_manifest_id FROM chart_manifest WHERE owner_id = $1 AND source_git_sha = $2`, ownerID, preferGitSHA)
+		var id string
+		if serr := row.Scan(&id); serr == nil {
+			return id, nil
+		} else if !errors.Is(serr, pgx.ErrNoRows) {
+			return "", fmt.Errorf("resolve manifest for publish: %w", serr)
+		}
+	}
+	row := r.ex.QueryRow(ctx, `
+		SELECT chart_manifest_id FROM chart_manifest
+		WHERE owner_id = $1
+		ORDER BY source_committed_at DESC, recorded_at DESC LIMIT 1`, ownerID)
+	var id string
+	if serr := row.Scan(&id); serr != nil {
+		if errors.Is(serr, pgx.ErrNoRows) {
+			return "", fmt.Errorf("%w: no manifest snapshot recorded for chart owner %s -- AssertApps/ReconcileApps must run before publishing", repository.ErrFailedPrecondition, ownerID)
+		}
+		return "", fmt.Errorf("resolve manifest for publish: %w", serr)
+	}
+	return id, nil
+}
+
 // insertArtifact writes a brand-new artifact row directly in state, with
 // versionSource and Provenance "observed" (the only provenance this phase
 // ever writes -- see ArtifactProvenance's doc comment). digest/build_id/
@@ -265,12 +382,29 @@ func (r *artifactRepo) insertArtifact(ctx context.Context, a repository.Artifact
 	ownerName := r.ownerFullName(ctx, a)
 	versionMajor, versionMinor, versionPatch := parseVersionTriple(a.Version)
 
+	// AR-7c (migration 008): manifest_id/promotability are resolved and
+	// STORED here, ONCE, only at the instant this row reaches "published" --
+	// never for allocated/publishing (nothing to derive them from yet, and
+	// migration 008's artifact_promotability_shape CHECK enforces that).
+	// This is the retroactivity fix -- see
+	// repository.Artifact.Promotability's doc comment.
+	var manifestID, promotability any
+	if state == repository.ArtifactStatePublished {
+		mid, promo, err := r.resolveManifestForPublish(ctx, a.Kind, ownerIDOf(a), a.BuildID)
+		if err != nil {
+			return nil, false, err
+		}
+		manifestID, promotability = mid, string(promo)
+	}
+
 	if _, err := r.ex.Exec(ctx, `
 		INSERT INTO artifact (artifact_id, kind, app_id, chart_id, repository, version, digest, build_id, published_at,
-		                       version_major, version_minor, version_patch, state, provenance, version_source, state_changed_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)`,
+		                       version_major, version_minor, version_patch, state, provenance, version_source, state_changed_at,
+		                       manifest_id, promotability)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)`,
 		a.ArtifactID, string(a.Kind), appID, chartID, a.Repository, a.Version, digest, buildID, publishedAt,
-		versionMajor, versionMinor, versionPatch, string(a.State), string(a.Provenance), string(a.VersionSource), a.StateChangedAt); err != nil {
+		versionMajor, versionMinor, versionPatch, string(a.State), string(a.Provenance), string(a.VersionSource), a.StateChangedAt,
+		manifestID, promotability); err != nil {
 		msg := fmt.Sprintf("artifact %s %s already recorded", ownerName, a.Version)
 		if de, ok := translatePgError(err, msg); ok {
 			return nil, false, de
@@ -284,8 +418,6 @@ func (r *artifactRepo) insertArtifact(ctx context.Context, a repository.Artifact
 		}
 	}
 
-	// Re-derive promotability against the freshly-read owner deploy_unit,
-	// rather than trusting whatever the caller set on the input struct.
 	out, err := r.GetArtifact(ctx, repository.ArtifactLookup{ArtifactID: a.ArtifactID})
 	if err != nil {
 		return nil, false, err
@@ -308,10 +440,21 @@ func (r *artifactRepo) completePublish(ctx context.Context, existing, a reposito
 		buildID = a.BuildID
 	}
 	now := time.Now().UTC()
+
+	// AR-7c (migration 008): resolved and stored ONCE, right here, at the
+	// instant this row actually transitions to "published" -- see
+	// insertArtifact's matching comment and repository.Artifact.
+	// Promotability's doc comment for why this fixes the retroactivity bug.
+	manifestID, promotability, err := r.resolveManifestForPublish(ctx, existing.Kind, ownerIDOf(existing), buildID)
+	if err != nil {
+		return nil, err
+	}
+
 	if _, err := r.ex.Exec(ctx, `
-		UPDATE artifact SET digest = $1, build_id = $2, published_at = $3, state = 'published', state_changed_at = $4
-		WHERE artifact_id = $5`,
-		a.Digest, buildID, publishedAt, now, existing.ArtifactID); err != nil {
+		UPDATE artifact SET digest = $1, build_id = $2, published_at = $3, state = 'published', state_changed_at = $4,
+		                     manifest_id = $5, promotability = $6
+		WHERE artifact_id = $7`,
+		a.Digest, buildID, publishedAt, now, manifestID, string(promotability), existing.ArtifactID); err != nil {
 		msg := fmt.Sprintf("artifact %s already recorded", a.Digest)
 		if de, ok := translatePgError(err, msg); ok {
 			return nil, de

--- a/tools/app_registry/server/repository/postgres/postgres_integration_test.go
+++ b/tools/app_registry/server/repository/postgres/postgres_integration_test.go
@@ -24,6 +24,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 	_ "github.com/jackc/pgx/v5/stdlib" // database/sql driver for the migration runner
@@ -79,26 +81,83 @@ func newTestRegistry(t *testing.T) (*Registry, *pgxpool.Pool) {
 
 // --- fixtures ---------------------------------------------------------
 
+// seedApp inserts pure identity (migration 008, AR-7c) plus ONE
+// 'sweep'-provenance app_manifest snapshot carrying deployUnit -- so
+// v_current_app (which every read path now goes through) resolves the same
+// deploy_unit callers of this helper have always passed. git_sha is a
+// per-call-unique "seed-<uuid>" value: uniqueness only matters relative to
+// this app's OWN app_id (the unique index is (owner_id, source_git_sha)),
+// and every call here creates a fresh app_id anyway, so a constant literal
+// would already be safe -- the uuid form is used only so a test that seeds
+// the SAME app twice (deliberately, to test update/recovery flows) doesn't
+// have to think about it either.
 func seedApp(t *testing.T, pool *pgxpool.Pool, domain, name, deployUnit string) string {
 	t.Helper()
+	ctx := context.Background()
 	var appID string
-	err := pool.QueryRow(context.Background(), `
-		INSERT INTO app (domain, name, deploy_unit) VALUES ($1, $2, $3)
-		RETURNING app_id`, domain, name, deployUnit).Scan(&appID)
+	err := pool.QueryRow(ctx, `
+		INSERT INTO app (domain, name) VALUES ($1, $2)
+		RETURNING app_id`, domain, name).Scan(&appID)
 	if err != nil {
 		t.Fatalf("seed app %s/%s: %v", domain, name, err)
 	}
+	seedAppManifest(t, pool, appID, domain, name, deployUnit, "seed-"+uuid.NewString())
 	return appID
 }
 
+// seedAppManifest writes one app_manifest snapshot row directly, bypassing
+// protojson -- a raw SQL fixture matching EXACTLY the key shape
+// postgres/app.go's manifestJSONMarshal produces (UseProtoNames,
+// EmitUnpopulated): snake_case keys, deploy_unit as the protojson enum NAME
+// ("DEPLOY_UNIT_IMAGE" etc, matching migration 008's generated-column CASE
+// expression), so tests can seed a specific (owner, git_sha) snapshot
+// directly -- e.g. to test resolveManifestForPublish's exact-commit
+// preference, or app_manifest's (owner_id, source_git_sha) idempotency.
+func seedAppManifest(t *testing.T, pool *pgxpool.Pool, appID, domain, name, deployUnit, gitSHA string) {
+	t.Helper()
+	protoDeployUnit := map[string]string{
+		"image": "DEPLOY_UNIT_IMAGE",
+		"none":  "DEPLOY_UNIT_NONE",
+		"chart": "DEPLOY_UNIT_CHART",
+		"":      "DEPLOY_UNIT_UNSPECIFIED",
+	}[deployUnit]
+	if protoDeployUnit == "" {
+		protoDeployUnit = "DEPLOY_UNIT_UNSPECIFIED"
+	}
+	manifestJSON := fmt.Sprintf(`{"domain":%q,"name":%q,"deploy_unit":%q,"registry":"","organization":"","repo_name":""}`,
+		domain, name, protoDeployUnit)
+	_, err := pool.Exec(context.Background(), `
+		INSERT INTO app_manifest (owner_id, source_git_sha, provenance, manifest_json)
+		VALUES ($1, $2, 'sweep', $3::jsonb)
+		ON CONFLICT (owner_id, source_git_sha) DO NOTHING`,
+		appID, gitSHA, manifestJSON)
+	if err != nil {
+		t.Fatalf("seed app_manifest for %s/%s: %v", domain, name, err)
+	}
+}
+
+// seedChart mirrors seedApp: pure identity plus one 'sweep'-provenance
+// chart_manifest snapshot, so any test that goes on to publish a chart
+// artifact finds a snapshot for resolveManifestForPublish to attribute it
+// to -- without one, RecordArtifact/BeginPublish for a chart kind would
+// fail with ErrFailedPrecondition ("no manifest snapshot recorded").
 func seedChart(t *testing.T, pool *pgxpool.Pool, domain, name string) string {
 	t.Helper()
+	ctx := context.Background()
 	var chartID string
-	err := pool.QueryRow(context.Background(), `
+	err := pool.QueryRow(ctx, `
 		INSERT INTO chart (domain, name) VALUES ($1, $2)
 		RETURNING chart_id`, domain, name).Scan(&chartID)
 	if err != nil {
 		t.Fatalf("seed chart %s/%s: %v", domain, name, err)
+	}
+	manifestJSON := fmt.Sprintf(`{"domain":%q,"name":%q}`, domain, name)
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO chart_manifest (owner_id, source_git_sha, provenance, manifest_json)
+		VALUES ($1, $2, 'sweep', $3::jsonb)
+		ON CONFLICT (owner_id, source_git_sha) DO NOTHING`,
+		chartID, "seed-"+uuid.NewString(), manifestJSON); err != nil {
+		t.Fatalf("seed chart_manifest for %s/%s: %v", domain, name, err)
 	}
 	return chartID
 }
@@ -515,12 +574,19 @@ func TestPromotion_CurrentIdxRejectsConcurrentCurrentRows(t *testing.T) {
 // version_source are NOT NULL as of migration 007 (AR-7b) -- state and
 // version_source have no safe default (see that migration's comments), so
 // every raw INSERT in this file must set them explicitly.
+// seedArtifact seeds a 'published' image artifact directly. As of migration
+// 008 (AR-7c), artifact_promotability_shape requires promotability
+// NOT NULL whenever state = 'published' -- 'promotable' here matches
+// seedApp's default "image" deploy_unit (DerivePromotability(IMAGE, IMAGE)
+// = PROMOTABLE). manifest_id is left NULL: these promotion/writeback tests
+// don't exercise manifest attribution, only that an artifact row exists to
+// promote.
 func seedArtifact(t *testing.T, pool *pgxpool.Pool, appID, buildID, digest, version string) string {
 	t.Helper()
 	var artifactID string
 	err := pool.QueryRow(context.Background(), `
-		INSERT INTO artifact (kind, app_id, repository, version, digest, build_id, state, provenance, version_source)
-		VALUES ('image', $1, 'ghcr.io/acme/widget', $2, $3, $4, 'published', 'observed', 'tag')
+		INSERT INTO artifact (kind, app_id, repository, version, digest, build_id, state, provenance, version_source, promotability)
+		VALUES ('image', $1, 'ghcr.io/acme/widget', $2, $3, $4, 'published', 'observed', 'tag', 'promotable')
 		RETURNING artifact_id`, appID, version, digest, buildID).Scan(&artifactID)
 	if err != nil {
 		t.Fatalf("seed artifact %s: %v", digest, err)
@@ -1236,7 +1302,17 @@ func TestMigration004BackfillsVersionColumns(t *testing.T) {
 		t.Fatalf("apply migrations 001-003: %v", err)
 	}
 
-	appID := seedApp(t, db.Pool, "acme", "widget", "image")
+	// Seeded via raw SQL against the pre-migration-008 `app` shape --
+	// app_manifest doesn't exist at migration 3, so seedApp/seedAppManifest
+	// (which target the post-008 schema) can't be used here. Same pattern
+	// as TestMigration007FoldsVersionAllocationIntoArtifact and
+	// TestMigration008BackfillsSnapshotsFromExistingRows below.
+	var appID string
+	if err := db.Pool.QueryRow(ctx, `
+		INSERT INTO app (domain, name, deploy_unit) VALUES ($1, $2, $3)
+		RETURNING app_id`, "acme", "widget", "image").Scan(&appID); err != nil {
+		t.Fatalf("seed pre-migration-008 app row: %v", err)
+	}
 	buildID := seedBuild(t, db.Pool, "run-backfill")
 
 	type seed struct{ digest, version string }
@@ -2429,9 +2505,16 @@ func TestMigration007FoldsVersionAllocationIntoArtifact(t *testing.T) {
 		t.Fatalf("apply migrations 001-006: %v", err)
 	}
 
-	appID := seedApp(t, db.Pool, "acme", "folded", "image")
-	if _, err := db.Pool.Exec(ctx, `UPDATE app SET image_repository = $1 WHERE app_id = $2`, "ghcr.io/acme/folded", appID); err != nil {
-		t.Fatalf("set image_repository: %v", err)
+	// Seeded via raw SQL against the pre-migration-008 `app` shape (still
+	// carrying deploy_unit/image_repository directly -- migration 008 is
+	// what removes them, and app_manifest doesn't exist until it runs) --
+	// deliberately NOT the seedApp/seedAppManifest helpers, which target the
+	// POST-008 schema this test's seed point (migration 6) predates.
+	var appID string
+	if err := db.Pool.QueryRow(ctx, `
+		INSERT INTO app (domain, name, deploy_unit, image_repository) VALUES ($1, $2, 'image', $3)
+		RETURNING app_id`, "acme", "folded", "ghcr.io/acme/folded").Scan(&appID); err != nil {
+		t.Fatalf("seed pre-migration-008 app row: %v", err)
 	}
 
 	var allocationID string
@@ -2476,5 +2559,468 @@ func TestMigration007FoldsVersionAllocationIntoArtifact(t *testing.T) {
 	}
 	if tableExists {
 		t.Fatalf("expected version_allocation to be dropped by migration 007")
+	}
+}
+
+// ============================================================================
+// 10. App identity / manifest snapshot split (AR-7c, migration 008, issue #558)
+// ============================================================================
+
+// appManifestRow reads back one app_manifest row's generated columns plus
+// the raw manifest_json, for asserting the generated-column derivation
+// directly against real Postgres (not just through v_current_app).
+func appManifestRow(t *testing.T, pool *pgxpool.Pool, appID, gitSHA string) (deployUnit, imageRepository string, found bool) {
+	t.Helper()
+	err := pool.QueryRow(context.Background(), `
+		SELECT deploy_unit, image_repository FROM app_manifest WHERE owner_id = $1 AND source_git_sha = $2`,
+		appID, gitSHA).Scan(&deployUnit, &imageRepository)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return "", "", false
+	}
+	if err != nil {
+		t.Fatalf("read app_manifest for %s/%s: %v", appID, gitSHA, err)
+	}
+	return deployUnit, imageRepository, true
+}
+
+func appManifestSnapshotCount(t *testing.T, pool *pgxpool.Pool, appID string) int {
+	t.Helper()
+	var n int
+	if err := pool.QueryRow(context.Background(), `SELECT count(*) FROM app_manifest WHERE owner_id = $1`, appID).Scan(&n); err != nil {
+		t.Fatalf("count app_manifest rows for %s: %v", appID, err)
+	}
+	return n
+}
+
+// TestAssertApps_CreatesIdentityAndSnapshot_Postgres proves AR-7c's AssertApps
+// against real Postgres: identity row created, exactly one app_manifest
+// snapshot written, and the generated deploy_unit/image_repository columns
+// resolve correctly straight off manifest_json.
+func TestAssertApps_CreatesIdentityAndSnapshot_Postgres(t *testing.T) {
+	reg, pool := newTestRegistry(t)
+	ctx := authedCtx()
+	srv := handlers.NewAppServer(reg)
+
+	am := &appmetapb.AppManifest{
+		Domain: "acme", Name: "assert-svc", DeployUnit: appmetapb.DeployUnit_DEPLOY_UNIT_IMAGE,
+		Registry: "ghcr.io", Organization: "acme", RepoName: "acme-assert-svc",
+	}
+	resp, err := srv.AssertApps(ctx, &pb.AssertAppsRequest{
+		Manifests:      reconcileManifests("sha-assert-1", 100, 100, []*appmetapb.AppManifest{am}, nil),
+		IdempotencyKey: "assert-pg-1",
+	})
+	if err != nil {
+		t.Fatalf("assert: %v", err)
+	}
+	if len(resp.CreatedApps) != 1 || resp.CreatedApps[0].Status != pb.AppStatus_APP_STATUS_ACTIVE {
+		t.Fatalf("expected 1 created ACTIVE app, got %+v", resp.CreatedApps)
+	}
+	appID := resp.CreatedApps[0].AppId
+
+	if n := appManifestSnapshotCount(t, pool, appID); n != 1 {
+		t.Fatalf("expected exactly 1 app_manifest snapshot, got %d", n)
+	}
+	du, repoCol, found := appManifestRow(t, pool, appID, "sha-assert-1")
+	if !found {
+		t.Fatalf("expected an app_manifest row keyed (owner_id=%s, source_git_sha=sha-assert-1)", appID)
+	}
+	if du != "image" {
+		t.Fatalf("expected the generated deploy_unit column to resolve 'image', got %q", du)
+	}
+	if repoCol != "ghcr.io/acme/acme-assert-svc" {
+		t.Fatalf("expected the generated image_repository column to resolve 'ghcr.io/acme/acme-assert-svc', got %q", repoCol)
+	}
+
+	// The provenance recorded is 'release', not 'sweep' -- AssertApps, not
+	// ReconcileApps.
+	var provenance string
+	if err := pool.QueryRow(ctx, `SELECT provenance FROM app_manifest WHERE owner_id = $1`, appID).Scan(&provenance); err != nil {
+		t.Fatalf("read provenance: %v", err)
+	}
+	if provenance != "release" {
+		t.Fatalf("expected provenance 'release' for an AssertApps snapshot, got %q", provenance)
+	}
+}
+
+// TestAppManifestSnapshot_IdempotentOnOwnerGitSha proves migration 008's
+// UNIQUE (owner_id, source_git_sha) is what makes repeated AssertApps calls
+// for the SAME commit naturally idempotent -- a real release re-run (same
+// git_sha, different idempotency_key) writes no new snapshot row.
+func TestAppManifestSnapshot_IdempotentOnOwnerGitSha(t *testing.T) {
+	reg, pool := newTestRegistry(t)
+	ctx := authedCtx()
+	srv := handlers.NewAppServer(reg)
+
+	am := oneAppManifest("acme", "idem-svc")
+	first, err := srv.AssertApps(ctx, &pb.AssertAppsRequest{
+		Manifests:      reconcileManifests("sha-idem", 100, 100, []*appmetapb.AppManifest{am}, nil),
+		IdempotencyKey: "assert-idem-1",
+	})
+	if err != nil {
+		t.Fatalf("first assert: %v", err)
+	}
+	appID := first.CreatedApps[0].AppId
+
+	// Re-run with a DIFFERENT idempotency_key (a real second CI attempt, not
+	// a replay) but the SAME git_sha -- this must still write no NEW
+	// snapshot row, because ON CONFLICT (owner_id, source_git_sha) DO
+	// NOTHING is what carries the idempotency here, not the idempotency_key
+	// table.
+	if _, err := srv.AssertApps(ctx, &pb.AssertAppsRequest{
+		Manifests:      reconcileManifests("sha-idem", 100, 100, []*appmetapb.AppManifest{am}, nil),
+		IdempotencyKey: "assert-idem-2",
+	}); err != nil {
+		t.Fatalf("second assert (same git_sha): %v", err)
+	}
+	if n := appManifestSnapshotCount(t, pool, appID); n != 1 {
+		t.Fatalf("expected exactly 1 snapshot after two calls for the SAME git_sha, got %d", n)
+	}
+
+	// A DIFFERENT git_sha for the same owner DOES write a new snapshot.
+	if _, err := srv.AssertApps(ctx, &pb.AssertAppsRequest{
+		Manifests:      reconcileManifests("sha-idem-2", 200, 200, []*appmetapb.AppManifest{am}, nil),
+		IdempotencyKey: "assert-idem-3",
+	}); err != nil {
+		t.Fatalf("third assert (new git_sha): %v", err)
+	}
+	if n := appManifestSnapshotCount(t, pool, appID); n != 2 {
+		t.Fatalf("expected 2 snapshots after a genuinely new commit, got %d", n)
+	}
+}
+
+// TestAssertApps_RejectsArchivedApp_Postgres is PLAN.md's AR-7c exit
+// criterion against real Postgres: AssertApps against an ARCHIVED app is
+// rejected per item, every other app/chart in the same call still applies,
+// and the archived app's status is untouched.
+func TestAssertApps_RejectsArchivedApp_Postgres(t *testing.T) {
+	reg, pool := newTestRegistry(t)
+	ctx := authedCtx()
+	appSrv := handlers.NewAppServer(reg)
+
+	created, err := appSrv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
+		Manifests: reconcileManifests("sha-arch-1", 100, 100,
+			[]*appmetapb.AppManifest{oneAppManifest("acme", "gone"), oneAppManifest("acme", "stays")}, nil),
+		IdempotencyKey: "arch-pg-1",
+	})
+	if err != nil {
+		t.Fatalf("reconcile create: %v", err)
+	}
+	var goneID string
+	for _, a := range created.CreatedApps {
+		if a.Name == "gone" {
+			goneID = a.AppId
+		}
+	}
+	if goneID == "" {
+		t.Fatalf("expected to find created app 'gone': %+v", created.CreatedApps)
+	}
+
+	if _, err := appSrv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
+		Manifests:      reconcileManifests("sha-arch-2", 200, 200, []*appmetapb.AppManifest{oneAppManifest("acme", "stays")}, nil),
+		IdempotencyKey: "arch-pg-2",
+	}); err != nil {
+		t.Fatalf("reconcile drop gone: %v", err)
+	}
+	if _, err := appSrv.SetAppStatus(ctx, &pb.SetAppStatusRequest{
+		AppId: goneID, Status: pb.AppStatus_APP_STATUS_ARCHIVED, Reason: "gone for good",
+	}); err != nil {
+		t.Fatalf("archive: %v", err)
+	}
+
+	resp, err := appSrv.AssertApps(ctx, &pb.AssertAppsRequest{
+		Manifests: reconcileManifests("sha-arch-3", 300, 300,
+			[]*appmetapb.AppManifest{oneAppManifest("acme", "gone"), oneAppManifest("acme", "stays")}, nil),
+		IdempotencyKey: "arch-pg-3",
+	})
+	if err != nil {
+		t.Fatalf("assert (call itself must succeed): %v", err)
+	}
+	if len(resp.RejectedApps) != 1 || resp.RejectedApps[0].Name != "gone" {
+		t.Fatalf("expected 'gone' rejected, got %+v", resp.RejectedApps)
+	}
+	if len(resp.UpdatedApps) != 1 || resp.UpdatedApps[0].Name != "stays" {
+		t.Fatalf("expected 'stays' to still apply in the same call, got %+v", resp.UpdatedApps)
+	}
+	if got := appStatus(t, pool, goneID); got != "archived" {
+		t.Fatalf("expected 'gone' to remain archived (not resurrected), got %q", got)
+	}
+}
+
+// TestRecordArtifact_RejectsArchivedOwner_Postgres is the OTHER AR-7c exit
+// criterion: "RecordArtifact against an ARCHIVED owner is rejected too" --
+// before AR-7c this succeeded silently.
+func TestRecordArtifact_RejectsArchivedOwner_Postgres(t *testing.T) {
+	reg, pool := newTestRegistry(t)
+	ctx := authedCtx()
+	appSrv := handlers.NewAppServer(reg)
+	artSrv := handlers.NewArtifactServer(reg)
+
+	created, err := appSrv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
+		Manifests:      reconcileManifests("sha-arch-owner-1", 100, 100, []*appmetapb.AppManifest{oneAppManifest("acme", "archowner")}, nil),
+		IdempotencyKey: "arch-owner-pg-1",
+	})
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	appID := created.CreatedApps[0].AppId
+
+	if _, err := appSrv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
+		Manifests:      reconcileManifests("sha-arch-owner-2", 200, 200, nil, nil),
+		IdempotencyKey: "arch-owner-pg-2",
+	}); err != nil {
+		t.Fatalf("reconcile drop: %v", err)
+	}
+	if _, err := appSrv.SetAppStatus(ctx, &pb.SetAppStatusRequest{
+		AppId: appID, Status: pb.AppStatus_APP_STATUS_ARCHIVED, Reason: "gone",
+	}); err != nil {
+		t.Fatalf("archive: %v", err)
+	}
+
+	buildID := seedBuild(t, pool, "run-arch-owner")
+	_, err = artSrv.RecordArtifact(ctx, &pb.RecordArtifactRequest{
+		BuildId: buildID, Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE,
+		OwnerFullName: "acme-archowner", Version: "v1.0.0", Digest: "sha256:archowner1",
+		IdempotencyKey: "arch-owner-artifact-1",
+	})
+	if err == nil {
+		t.Fatal("expected RecordArtifact against an ARCHIVED owner to be rejected")
+	}
+	st, _ := status.FromError(err)
+	if st.Code() != codes.FailedPrecondition {
+		t.Fatalf("expected FailedPrecondition, got %v (%v)", st.Code(), err)
+	}
+}
+
+// TestAssertApps_ThenRecordArtifact_NoReconcileNeeded_Postgres is AR-7c's
+// central exit criterion against real Postgres: a release from a ref that
+// NEVER merges (simulated here simply as "no ReconcileApps call ever ran")
+// calls AssertApps first, then records its build and artifact successfully
+// -- exit 3 / ReasonOwnerNotReconciled (issue #547) is unreachable. Also
+// proves the "writes no mutable state anything else can observe" half of
+// the exit criterion: app is pure identity, so there is nothing for
+// AssertApps to have mutated beyond the identity row and its own
+// manifest snapshot.
+func TestAssertApps_ThenRecordArtifact_NoReconcileNeeded_Postgres(t *testing.T) {
+	reg, pool := newTestRegistry(t)
+	ctx := authedCtx()
+	appSrv := handlers.NewAppServer(reg)
+	artSrv := handlers.NewArtifactServer(reg)
+
+	am := &appmetapb.AppManifest{
+		Domain: "acme", Name: "unmerged-branch-app", DeployUnit: appmetapb.DeployUnit_DEPLOY_UNIT_IMAGE,
+		Registry: "ghcr.io", Organization: "acme", RepoName: "acme-unmerged-branch-app",
+	}
+	if _, err := appSrv.AssertApps(ctx, &pb.AssertAppsRequest{
+		Manifests:      reconcileManifests("sha-unmerged-1", 100, 100, []*appmetapb.AppManifest{am}, nil),
+		IdempotencyKey: "unmerged-assert-1",
+	}); err != nil {
+		t.Fatalf("assert: %v", err)
+	}
+
+	build, err := artSrv.RecordBuild(ctx, &pb.RecordBuildRequest{
+		GitSha: "sha-unmerged-1", WorkflowRunId: "run-unmerged", IdempotencyKey: "unmerged-build-1",
+	})
+	if err != nil {
+		t.Fatalf("record build: %v", err)
+	}
+
+	artResp, err := artSrv.RecordArtifact(ctx, &pb.RecordArtifactRequest{
+		BuildId: build.Build.BuildId, Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE,
+		OwnerFullName: "acme-unmerged-branch-app", Version: "v1.0.0", Digest: "sha256:unmerged1",
+		IdempotencyKey: "unmerged-artifact-1",
+	})
+	if err != nil {
+		t.Fatalf("RecordArtifact should succeed with no ReconcileApps ever having run: %v", err)
+	}
+	if artResp.Artifact.Promotability != pb.Promotability_PROMOTABILITY_PROMOTABLE {
+		t.Fatalf("expected PROMOTABLE (deploy_unit=image), got %v", artResp.Artifact.Promotability)
+	}
+
+	// "no mutable state anything else can observe": ReconcileApps's own
+	// absence sweep has never run, so nothing about `app` beyond identity
+	// (domain/name/status/timestamps) was ever written for this owner --
+	// confirmed by the fact this app never shows up in chart_app (there is
+	// no chart here) and its ONLY manifest snapshot is the AssertApps one
+	// at sha-unmerged-1, never superseded by a 'sweep' snapshot.
+	appID, err := reg.Apps().GetAppByFullName(ctx, "acme-unmerged-branch-app")
+	if err != nil {
+		t.Fatalf("get app: %v", err)
+	}
+	if n := appManifestSnapshotCount(t, pool, appID.AppID); n != 1 {
+		t.Fatalf("expected exactly 1 manifest snapshot (the AssertApps one), got %d", n)
+	}
+}
+
+// TestRecordArtifact_PromotabilityIsNotRetroactive_Postgres is PLAN.md's
+// central AR-7c exit criterion against real Postgres: editing an app's
+// deploy_unit after an artifact was published must not change that
+// artifact's promotability. Mirrors
+// handlers.TestRecordArtifact_PromotabilityIsNotRetroactive but exercised
+// through the real scanArtifact/artifact.promotability column, not the fake.
+func TestRecordArtifact_PromotabilityIsNotRetroactive_Postgres(t *testing.T) {
+	reg, pool := newTestRegistry(t)
+	ctx := authedCtx()
+	appSrv := handlers.NewAppServer(reg)
+	artSrv := handlers.NewArtifactServer(reg)
+
+	created, err := appSrv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
+		Manifests: reconcileManifests("sha-retro-1", 100, 100,
+			[]*appmetapb.AppManifest{{Domain: "acme", Name: "retro-app", DeployUnit: appmetapb.DeployUnit_DEPLOY_UNIT_IMAGE}}, nil),
+		IdempotencyKey: "retro-pg-1",
+	})
+	if err != nil {
+		t.Fatalf("reconcile create: %v", err)
+	}
+	_ = created
+
+	buildID := seedBuild(t, pool, "run-retro-pg")
+	published, err := artSrv.RecordArtifact(ctx, &pb.RecordArtifactRequest{
+		BuildId: buildID, Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE,
+		OwnerFullName: "acme-retro-app", Version: "v1.0.0", Digest: "sha256:retropg1",
+		IdempotencyKey: "retro-pg-artifact-1",
+	})
+	if err != nil {
+		t.Fatalf("RecordArtifact: %v", err)
+	}
+	if published.Artifact.Promotability != pb.Promotability_PROMOTABILITY_PROMOTABLE {
+		t.Fatalf("expected PROMOTABLE at publish time, got %v", published.Artifact.Promotability)
+	}
+
+	// Edit deploy_unit to CHART via a later reconcile -- a real
+	// release_app.bzl change reaching main.
+	if _, err := appSrv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
+		Manifests: reconcileManifests("sha-retro-2", 200, 200,
+			[]*appmetapb.AppManifest{{Domain: "acme", Name: "retro-app", DeployUnit: appmetapb.DeployUnit_DEPLOY_UNIT_CHART}}, nil),
+		IdempotencyKey: "retro-pg-2",
+	}); err != nil {
+		t.Fatalf("reconcile with edited deploy_unit: %v", err)
+	}
+
+	// The stored artifact.promotability column, read directly, must be
+	// unaffected.
+	var storedPromotability string
+	if err := pool.QueryRow(ctx, `SELECT promotability FROM artifact WHERE artifact_id = $1`, published.Artifact.ArtifactId).Scan(&storedPromotability); err != nil {
+		t.Fatalf("read stored promotability: %v", err)
+	}
+	if storedPromotability != "promotable" {
+		t.Fatalf("retroactivity bug: expected the stored artifact.promotability column to STAY 'promotable' after image-app's deploy_unit changed, got %q", storedPromotability)
+	}
+
+	// GetArtifact (the read path) must agree.
+	reread, err := artSrv.GetArtifact(ctx, &pb.GetArtifactRequest{ArtifactId: published.Artifact.ArtifactId})
+	if err != nil {
+		t.Fatalf("GetArtifact: %v", err)
+	}
+	if reread.Artifact.Promotability != pb.Promotability_PROMOTABILITY_PROMOTABLE {
+		t.Fatalf("retroactivity bug via GetArtifact: expected PROMOTABLE, got %v", reread.Artifact.Promotability)
+	}
+}
+
+// TestMigration008BackfillsSnapshotsFromExistingRows applies migrations
+// 001-007 against a fresh database, seeds `app`/`chart` rows in the
+// PRE-008 shape (mutable columns directly on the table, as every
+// pre-AR-7c row in a real deployed environment would be), then applies
+// migration 008 and proves: exactly one app_manifest/chart_manifest
+// snapshot per existing row, attributed to reconcile_watermark's current
+// git_sha, and v_current_app/v_current_chart reproduce the SAME
+// deploy_unit/image_repository/status the pre-migration flat columns held
+// "nothing loses metadata," PLAN.md's AR-7c backfill requirement.
+func TestMigration008BackfillsSnapshotsFromExistingRows(t *testing.T) {
+	ctx := context.Background()
+	db := dbtest.NewPostgres(ctx, t, dbtest.Options{})
+
+	sqlDB, err := sql.Open("pgx", db.ConnString)
+	if err != nil {
+		t.Fatalf("open database/sql handle: %v", err)
+	}
+	defer sqlDB.Close()
+
+	runner := migrate.NewRunner(sqlDB, schema.Migrations, schema.Dir)
+	if err := runner.Steps(7); err != nil {
+		t.Fatalf("apply migrations 001-007: %v", err)
+	}
+
+	// Seed a pre-AR-7c app/chart pair directly, matching the schema shape
+	// migrations 001-007 produce (deploy_unit/image_repository/
+	// chart_repository still live on the base tables).
+	var appID string
+	if err := db.Pool.QueryRow(ctx, `
+		INSERT INTO app (domain, name, description, language, app_type, deploy_unit, bazel_label, image_repository, status)
+		VALUES ('acme', 'backfill-app', 'a description', 'go', 'worker', 'image', '//acme:bin', 'ghcr.io/acme/backfill-app', 'active')
+		RETURNING app_id`).Scan(&appID); err != nil {
+		t.Fatalf("seed pre-008 app: %v", err)
+	}
+	var chartID string
+	if err := db.Pool.QueryRow(ctx, `
+		INSERT INTO chart (domain, name, status) VALUES ('acme', 'backfill-chart', 'active')
+		RETURNING chart_id`).Scan(&chartID); err != nil {
+		t.Fatalf("seed pre-008 chart: %v", err)
+	}
+	if _, err := db.Pool.Exec(ctx, `INSERT INTO chart_app (chart_id, app_id) VALUES ($1, $2)`, chartID, appID); err != nil {
+		t.Fatalf("seed pre-008 chart_app: %v", err)
+	}
+
+	// Advance the reconcile watermark, exactly as a real prior ReconcileApps
+	// call would have -- migration 008's backfill attributes every
+	// synthesized snapshot to THIS git_sha.
+	if _, err := db.Pool.Exec(ctx, `
+		UPDATE reconcile_watermark SET git_sha = 'sha-pre-008', source_committed_at = 500, discovered_at = 500 WHERE id = 1`); err != nil {
+		t.Fatalf("advance watermark: %v", err)
+	}
+
+	if err := runner.Up(); err != nil {
+		t.Fatalf("apply migration 008: %v", err)
+	}
+
+	// Exactly one snapshot each, attributed to the watermark's git_sha.
+	if n := appManifestSnapshotCount(t, db.Pool, appID); n != 1 {
+		t.Fatalf("expected exactly 1 backfilled app_manifest row, got %d", n)
+	}
+	var appSnapGitSHA string
+	if err := db.Pool.QueryRow(ctx, `SELECT source_git_sha FROM app_manifest WHERE owner_id = $1`, appID).Scan(&appSnapGitSHA); err != nil {
+		t.Fatalf("read backfilled app_manifest git_sha: %v", err)
+	}
+	if appSnapGitSHA != "sha-pre-008" {
+		t.Fatalf("expected the backfilled snapshot attributed to the watermark's git_sha 'sha-pre-008', got %q", appSnapGitSHA)
+	}
+
+	var chartSnapCount int
+	if err := db.Pool.QueryRow(ctx, `SELECT count(*) FROM chart_manifest WHERE owner_id = $1`, chartID).Scan(&chartSnapCount); err != nil {
+		t.Fatalf("count backfilled chart_manifest rows: %v", err)
+	}
+	if chartSnapCount != 1 {
+		t.Fatalf("expected exactly 1 backfilled chart_manifest row, got %d", chartSnapCount)
+	}
+
+	// v_current_app reproduces the SAME deploy_unit/image_repository/status
+	// the pre-migration flat columns held -- nothing lost.
+	var deployUnit, imageRepository, status, description string
+	if err := db.Pool.QueryRow(ctx, `
+		SELECT deploy_unit, image_repository, status, description FROM v_current_app WHERE app_id = $1`, appID).
+		Scan(&deployUnit, &imageRepository, &status, &description); err != nil {
+		t.Fatalf("read v_current_app: %v", err)
+	}
+	if deployUnit != "image" {
+		t.Fatalf("expected v_current_app.deploy_unit = 'image' (backfilled), got %q", deployUnit)
+	}
+	if imageRepository != "ghcr.io/acme/backfill-app" {
+		t.Fatalf("expected v_current_app.image_repository backfilled, got %q", imageRepository)
+	}
+	if status != "active" {
+		t.Fatalf("expected v_current_app.status = 'active', got %q", status)
+	}
+	if description != "a description" {
+		t.Fatalf("expected v_current_app.description backfilled, got %q", description)
+	}
+
+	// app/chart no longer carry the dropped columns at all.
+	var appHasDeployUnit bool
+	if err := db.Pool.QueryRow(ctx, `
+		SELECT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'app' AND column_name = 'deploy_unit')`).
+		Scan(&appHasDeployUnit); err != nil {
+		t.Fatalf("check app.deploy_unit column existence: %v", err)
+	}
+	if appHasDeployUnit {
+		t.Fatalf("expected migration 008 to have dropped app.deploy_unit")
 	}
 }

--- a/tools/app_registry/server/repository/repository.go
+++ b/tools/app_registry/server/repository/repository.go
@@ -44,6 +44,19 @@ var (
 	// message text. See issue #547 and ARCHITECTURE.md "Reconcile
 	// watermark" for why this case is common and expected, not a bug.
 	ErrOwnerNotReconciled = fmt.Errorf("%w: owner not reconciled", ErrInvalidArgument)
+
+	// ErrOwnerArchived: a write RPC (RecordArtifact, BeginPublish,
+	// AllocateVersion) targeted an app/chart whose Status is ARCHIVED.
+	// A human archived it deliberately via SetAppStatus (see ARCHITECTURE.md
+	// "Triage: the MISSING/ARCHIVED lifecycle") -- silently resurrecting it
+	// by recording a new build against it would undo that decision without
+	// telling anyone. Wraps ErrFailedPrecondition (well-formed request,
+	// illegal given current state), matching the AssertApps per-item reject
+	// this same rule enforces for identity assertion -- see
+	// AppRepository.AssertApps's doc comment. Distinct from
+	// ErrOwnerNotReconciled (which wraps ErrInvalidArgument -- an unknown
+	// owner is a caller mistake, not a state conflict).
+	ErrOwnerArchived = fmt.Errorf("%w: owner is archived", ErrFailedPrecondition)
 )
 
 // AppRepository covers App and Chart identity — the two tables ReconcileApps
@@ -83,6 +96,41 @@ type AppRepository interface {
 	// SAME transaction as the app/chart writes, so two concurrent Reconcile
 	// calls serialize rather than both reading a stale watermark.
 	Reconcile(ctx context.Context, apps []*appmetapb.AppManifest, charts []*appmetapb.ChartManifest, source ReconcileSource, dryRun bool) (*ReconcileResult, error)
+
+	// AssertApps is the additive-only counterpart to Reconcile (AR-7c, issue
+	// #558): identity assert + manifest snapshot write, safe to call from
+	// ANY ref -- a divergent branch, an old tag, an unmerged PR -- because it
+	// NEVER marks anything MISSING and NEVER touches chart_app membership
+	// (that stays Reconcile/main-sweep-only: resolving composition correctly
+	// needs the canonical complete tree, which a release ref is not
+	// guaranteed to be). This is what closes ordering 1 (issue #547) without
+	// the provisional-upsert trade #547's own "Rejected alternatives"
+	// rejected: there is no more mutable metadata for a divergent ref to
+	// clobber, because App/Chart's mutable fields all live in the per-commit
+	// manifest snapshot now (see ARCHITECTURE.md "App identity vs. per-build
+	// manifest snapshot").
+	//
+	// Every app/chart in apps/charts is either created (∅ -> ACTIVE),
+	// recovered (MISSING -> ACTIVE, same automatic recovery Reconcile's
+	// absence sweep triggers), or -- if already ACTIVE -- left with its
+	// identity untouched and just gets a fresh manifest snapshot recorded
+	// (idempotent on (owner_id, source_git_sha); a repeat call for the same
+	// commit writes nothing new). An app/chart that is ARCHIVED is REJECTED
+	// per item, not for the whole call -- see AssertResult.RejectedApps/
+	// RejectedCharts, modeled on ReconcileResult.UnresolvedCharts's
+	// per-item-skip shape: a human archived it on purpose (SetAppStatus,
+	// see ARCHITECTURE.md "Triage"), and a release silently resurrecting it
+	// is worse than a red step. Every other app/chart in the same call still
+	// applies.
+	//
+	// source carries the same ordering/provenance metadata Reconcile's
+	// source does, but AssertApps NEVER consults or advances the reconcile
+	// watermark -- that guard exists to keep an OLDER main sweep from
+	// reverting a NEWER one's absence-sweep result, a concern that does not
+	// apply here (AssertApps never marks anything MISSING, so there is
+	// nothing for a stale call to wrongly revert). Must be called inside
+	// Registry.WithTx.
+	AssertApps(ctx context.Context, apps []*appmetapb.AppManifest, charts []*appmetapb.ChartManifest, source ManifestSource) (*AssertResult, error)
 
 	ListApps(ctx context.Context, filter AppListFilter) ([]App, error)
 	GetAppByID(ctx context.Context, appID string) (*App, error)


### PR DESCRIPTION
Implements **AR-7c — App identity / manifest snapshot split** from `tools/app_registry/PLAN.md`. This is the central design change of AR-7 (issue #558); design merged in #559. Bottom of a 2-PR stack — #567 (AR-7d) sits on top. Follows #561/#562, now merged.

Today `app` carries *mutable metadata* — `deploy_unit`, `image_repository`, `bazel_label`, `app_type` — and some ref has to author it. Every answer to "which ref?" is bad: let any ref write it and it drifts; let only `main` write it and releases depend on `main`'s CI having gone first (ordering 1). This PR removes the question rather than answering it.

## What changed

**Migration `008`.** Append-only `app_manifest` / `chart_manifest`, unique on `(owner_id, source_git_sha)` — same commit, same manifest, so writes are naturally idempotent. The manifest is stored **verbatim as protojson `JSONB`**, which stays the single source of truth: a new appmeta field needs no migration and cannot drift from the manifest. Stored generated columns exist for `deploy_unit` and `image_repository` only, because those are what the hot read paths need indexable — fully typed columns were rejected in review as reintroducing the hand-maintained duplicate of the manifest schema that AR-M spent a phase deleting.

`app`/`chart` drop their mutable columns and become pure identity. `artifact` gains `manifest_id` and a **stored** `promotability` derived at publish time. `v_current_app`/`v_current_chart` pre-join identity with the latest `main`-sweep snapshot, the same pattern `v_current_promotion` uses. Snapshots backfill from current `app`/`chart` rows against the latest reconciled `git_sha`, so nothing loses metadata.

**`AssertApps`** — additive identity + snapshot write, safe from any ref, never marks anything `MISSING`, and **rejects** assertion against an `ARCHIVED` app per item: a human said that app is gone for good, and a release silently resurrecting it is worse than a red step. `RecordArtifact` against an `ARCHIVED` owner is now rejected too — today it succeeds, which was never intended. `release.yml` calls `AssertApps` as the first step of the release job, from the released ref, which is what closes #547.

`ReconcileApps` keeps the absence sweep, `chart_app` membership, the watermark, and AR-7a's partial-apply behavior, and now also writes `main`-sweep snapshots. Reads move to the views; **wire responses are unchanged**.

## The correctness fix

`RecordArtifact` used to re-derive promotability from the owner's *current* `deploy_unit`, so editing a `release_app` rule silently changed the promotability of artifacts published years ago. Promotability is now derived from the build's own manifest snapshot and stored. This is a behavior fix, not a refactor, and it's pinned by a test: reintroducing the live `v_current_app` join makes `TestRecordArtifact_PromotabilityIsNotRetroactive_Postgres` fail with `PROMOTABILITY_VIA_CHART` instead of `PROMOTABLE`.

## Tests

Postgres integration tests cover the backfill, the views, snapshot idempotency on `(owner_id, source_git_sha)`, `AssertApps` against `ARCHIVED`, and the generated-column derivation read straight off `app_manifest`. Handler and fake tests kept in lockstep with the postgres repository.

Four behaviors were verified by deliberately breaking them and confirming the guarding test failed, then reverting: the retroactivity fix (both postgres and fake), the `ARCHIVED` rejection, and snapshot idempotency.

## Verification

`bazel build //tools/...` and `bazel test //tools/...` green (14/14). `postgres_integration_test` passes against real Docker Postgres — **104.5s on the combined stack tip with #567's tests included**, covering this PR's suite and every pre-existing AR-7a/AR-7b test.

Ref: #558, #559, #547
