### PR TITLE
feat(app-registry): AR-7e admin-only artifact adoption + DR runbook (#558)

### DIFF
--- a/tools/app_registry/ARCHITECTURE.md
+++ b/tools/app_registry/ARCHITECTURE.md
@@ -397,23 +397,25 @@ tradeoff above, not a separate gap to close.
 
 ## Release lifecycle (issue #558)
 
-**Status: AR-7a and AR-7b built and merged to `main` (#561, #562); AR-7c and
-AR-7d built, not yet merged; AR-7e and AR-7f designed, not built.** Delivery
-is PLAN.md's AR-7. Four slices of this section describe real code: AR-7a's —
+**Status: AR-7a and AR-7b built and merged to `main` (#561, #562); AR-7c,
+AR-7d, and AR-7e built, not yet merged; AR-7f designed, not built.** Delivery
+is PLAN.md's AR-7. Five slices of this section describe real code: AR-7a's —
 ordering 4, partial-apply reconcile, domain-qualified chart app references,
 and the `continue-on-error` drop on `ci.yml`'s sweep job — AR-7b's — the
 artifact lifecycle (`allocated → publishing → published → failed`),
 migration `007`, `BeginPublish`/`FailPublish`, `RecordArtifact`'s
 `publishing → published` transition, and the stale-row reaper — AR-7c's —
 migration `008`, the app identity / manifest-snapshot split, `AssertApps`,
-and `artifact`'s stored `manifest_id`/`promotability` — and AR-7d's —
+and `artifact`'s stored `manifest_id`/`promotability` — AR-7d's —
 `GetReleaseRun`, the up-front intent write, `builds status --incomplete`,
-and re-run-as-resume. `AdoptArtifact` and compose-time chart hermeticity
-remain proposed: every table, column and RPC named in those subsections is
-unbuilt. This section supersedes "Release-vs-reconcile gap (issue #547)"
-above — AR-7c closes that gap for real, see the callout there — and changes
-what "Availability and bootstrap" below promises; both are cross-referenced
-where that happens.
+and re-run-as-resume — and AR-7e's — `AdoptArtifact`, its admin-only
+authorization, the `∅|failed → published(adopted)` state-collision rules,
+and `ListArtifacts`' provenance filter. Compose-time chart hermeticity
+(AR-7f) remains proposed: every table, column and RPC named in that
+subsection is unbuilt. This section supersedes "Release-vs-reconcile gap
+(issue #547)" above — AR-7c closes that gap for real, see the callout there
+— and changes what "Availability and bootstrap" below promises; both are
+cross-referenced where that happens.
 
 ### The problem: four cross-run orderings, three of them unenforced
 
@@ -892,6 +894,47 @@ state is re-adoptable. OPERATIONS.md carries the runbook (AR-7e). The design
 goal is that this is *rare and deliberate*, not a recurring chore — every
 other part of AR-7 exists to keep it that way.
 
+**As built (AR-7e).** Everything above is real: `ArtifactRegistry.
+AdoptArtifact` (`server/handlers/artifact.go`), gated on
+`auth.RoleAdmin` — never `auth.RoleBuilder`, the one deliberate exception to
+every other `ArtifactRegistry` write RPC requiring the builder role, because
+this is the single RPC that asserts an artifact into existence rather than
+recording an observed publish. Two decisions this section left implicit and
+the implementation had to make explicit:
+
+- **State-collision semantics**, since `AdoptArtifact` is a new entry point
+  into the same `artifact` state machine `postgres/artifact.go` already
+  enforces, not a separate table. An existing `published` row with the SAME
+  digest (observed or previously adopted) is an idempotent no-op —
+  Provenance/State are never rewritten, so adoption can never downgrade an
+  `observed` row to `adopted` after the fact. A DIFFERENT digest on an
+  already-`published` row is `ErrAlreadyExists`, mirroring
+  `RecordArtifact`'s identical conflict rule. An `allocated` or `publishing`
+  row is `ErrFailedPrecondition` — a live reservation or in-flight publish
+  is not what adoption is for. A `failed` row is the one NEW legal starting
+  state adoption alone can complete (`failed → published(adopted)`) — the
+  disaster-recovery case: a run already tried and gave up, but the artifact
+  demonstrably exists.
+- **`artifact.build_id` is a real foreign key, and migration 007's
+  `artifact_state_shape` CHECK requires it `NOT NULL` once `published` —
+  but by definition there is no CI run behind a pre-registry artifact.**
+  Rather than a schema change (ruled out by this phase's own scope),
+  `AdoptArtifact` writes a synthetic `build` row: `workflow_run_id`
+  `"adopted:<uuid>"` (non-numeric, cannot collide with a real GitHub
+  Actions run id), `git_ref = "adopted"` as the same marker, `actor` the
+  calling admin's own identity. The `failed → published` branch reuses the
+  existing row's `build_id` when it already has one (true whenever the
+  reaper reaped a `publishing` row; false when it reaped an `allocated`
+  row, which never had one) — the real CI run that actually attempted the
+  push is more honest provenance than a synthetic placeholder.
+
+`reason` is required (validated at the handler layer) and logged
+structurally on every call, but — like `SetAppStatusRequest.reason` — not
+stored in a new column: no schema change was needed, matching this section's
+"no backfill" framing. `ListArtifactsRequest.provenance` /
+`ArtifactListFilter.Provenance` make "which rows did we take on faith?" a
+query, satisfying the exit criterion's "distinguishable in one query" half.
+
 ### Relationship to AR-5 (allocation cutover)
 
 **AR-7 does not conflict with what remains of AR-5, and belongs strictly
@@ -1091,11 +1134,11 @@ in `server/auth`:
 
 | Role | Services | Credential |
 |---|---|---|
-| `app-registry-builder` | `AppRegistry` (writes), `ArtifactRegistry` (writes) | Keycloak service account, CI/all workflows |
+| `app-registry-builder` | `AppRegistry` (writes), `ArtifactRegistry` (writes except `AdoptArtifact`) | Keycloak service account, CI/all workflows |
 | `app-registry-promoter-dev` | `PromotionRegistry` (writes), `dev` only | Keycloak service account scoped to the `dev` GitHub Environment; humans |
 | `app-registry-promoter-stage` | `PromotionRegistry` (writes), `stage` only | Keycloak service account scoped to the `stage` GitHub Environment; humans |
 | `app-registry-promoter-prod` | `PromotionRegistry` (writes), `prod` only | Keycloak service account scoped to the `prod` GitHub Environment; a small human group |
-| `app-registry-admin` | `EnvironmentRegistry`, `SetAppStatus` | Human only |
+| `app-registry-admin` | `EnvironmentRegistry`, `SetAppStatus`, `AdoptArtifact` (AR-7e) | Human only |
 | reader | all reads | Any authenticated principal |
 
 Roles are flat and explicit — `app-registry-admin` does not imply

--- a/tools/app_registry/OPERATIONS.md
+++ b/tools/app_registry/OPERATIONS.md
@@ -296,6 +296,105 @@ original if GitHub Actions reused the same run) means every child reached
 at a real, recurring problem (a bad Dockerfile, a registry permissions
 issue) rather than something a second re-run will fix on its own.
 
+## Adoption and disaster recovery
+
+**AR-7e (issue #558).** This is a rare, deliberate operation, not routine
+maintenance — every other part of AR-7 (the artifact lifecycle, the run log,
+`AssertApps`) exists precisely to keep the registry a complete, trustworthy
+record so you never need this section. If you're here often, something
+upstream is wrong and worth fixing (opt-in disabled for a domain that
+actually releases, a registry outage nobody noticed, `AssertApps` not wired
+into a release path) — file it, don't keep reaching for `adopt`.
+
+`ArtifactRegistry.AdoptArtifact` records a pre-existing GHCR image or chart
+as `published` with `provenance = 'adopted'` and a required `reason`, for
+when there is genuinely no CI run to resume — see
+[ARCHITECTURE.md "Adoption and disaster recovery"](ARCHITECTURE.md#adoption-and-disaster-recovery)
+for the design and the exact state-collision rules. **Admin role only** —
+the builder credential every CI job holds cannot call this RPC; see
+["Where each secret goes"](DEPLOY.md#4-ci-credentials) in DEPLOY.md for why
+the admin client secret is human-operated and kept out of CI entirely.
+
+**It is lazy and per-artifact.** There is no bulk/sweep mode — adopt exactly
+the one image or chart that is actually blocking you, with a reason that
+will make sense to someone reading it in six months. It is also not a
+liveness check: `AdoptArtifact` does not go and verify the digest actually
+exists in GHCR or the chart repository. You are asserting it does; get that
+right before you run the command.
+
+### Case 1: a chart release fails on a pre-registry pin
+
+A chart pins images by resolving `${IMG_REPO}:${IMG_VERSION}` to a digest at
+compose time (`tools/helm`), then `RecordArtifact` rejects the chart if any
+pinned digest was never itself recorded — "chart pins unrecorded image
+digest". This happens permanently for an image published before the registry
+existed, or while `APP_REGISTRY_CICD_OPT_IN` was off for that domain: there
+is no run to re-run, and reconcile never writes artifact rows (only
+identity), so the reject never clears on its own.
+
+1. Identify the unrecorded digest from the chart release's failure message,
+   and the app/version it belongs to (`tools/helm`'s lockfile output, or the
+   chart manifest's `contains` entries).
+2. Confirm the image genuinely exists — pull it, or check GHCR directly.
+   `AdoptArtifact` will not do this for you.
+3. Adopt it:
+   ```bash
+   app-registry artifacts adopt \
+     --kind image --owner <domain>-<app> \
+     --repository ghcr.io/whale-net/<domain>-<app> \
+     --version <version> --digest sha256:<digest> \
+     --reason "published <date/context> before the registry existed; confirmed present in GHCR"
+   ```
+   `--idempotency-key` is optional here — a UUID is generated if omitted,
+   the same as `promote`/`rollback` (this is a human action, not CI).
+4. Re-run the chart release. The pin now resolves against a `published` row
+   (`provenance = ADOPTED`) exactly as if it had been observed at publish
+   time.
+
+Adopting a chart directly (kind `chart`) works the same way, with
+`--contains` pointing at a JSON file of its resolved image references — see
+`app-registry artifacts record`'s `--contains` for the file shape; every
+referenced image must already be a `published` artifact (adopted or
+observed), or the call fails the same way `RecordArtifact` would.
+
+### Case 2: the registry is restored behind, or lost entirely
+
+If the registry database is restored from a backup taken before some
+publishes happened, or lost outright and rebuilt from migrations, its
+`artifact` rows no longer match reality — but **GHCR and the chart
+repository are unaffected**: they are the source of truth for artifacts, the
+registry only for the pipeline (see ARCHITECTURE.md "The principle that
+resolves it"). Nothing needs bulk-repairing immediately; the registry is
+simply missing history until something needs it:
+
+- **App/chart identity** (`app`, `chart`, and their manifest snapshots)
+  self-heals on the next `ReconcileApps` (main push) or `AssertApps`
+  (release run) — no adoption needed for identity, only for artifacts.
+- **Artifact rows** only need adopting lazily, the moment something actually
+  needs one that's missing — almost always surfacing as Case 1 above. Do
+  not attempt to walk GHCR and re-adopt everything "to be safe" — that is
+  exactly the bulk backfill this design rejects (see ARCHITECTURE.md
+  "Resolved questions" #3): it manufactures adopted rows for artifacts
+  nothing will ever ask about, with no way to know later which ones were
+  real gaps versus precautionary noise.
+- **Promotion history** (`promotion`, `promotion_event`) has no adoption
+  path at all — it is this registry's own record of what it did, not a
+  mirror of an external source of truth. A restore-behind here is a real
+  gap; there is nothing to reconstruct it from.
+
+### Auditing what was adopted
+
+```bash
+app-registry artifacts list --provenance adopted            # every adopted row, any owner
+app-registry artifacts list <domain-app> --provenance adopted  # scoped to one owner
+```
+
+The `reason` given at adopt time is not stored on the row itself (no schema
+change was needed for this phase — see ARCHITECTURE.md's "As built (AR-7e)"
+note) but is logged structurally by `app-registry-api` at call time, keyed
+by the same digest/owner/version this query returns — cross-reference
+against server logs for the full "why" behind any adopted row.
+
 ## Checking for drift
 
 Drift, here, specifically means: an image was promoted directly

--- a/tools/app_registry/PLAN.md
+++ b/tools/app_registry/PLAN.md
@@ -16,7 +16,7 @@ Read [ARCHITECTURE.md](ARCHITECTURE.md) before executing any phase.
 
 ## Current status
 
-*Last updated finishing AR-7c (issue #558). **AR-M through AR-7b are all
+*Last updated finishing AR-7e (issue #558). **AR-M through AR-7b are all
 merged to `main`** — see the table below.*
 
 | Phase | PR | State |
@@ -37,6 +37,7 @@ merged to `main`** — see the table below.*
 | AR-7b | [#562](https://github.com/whale-net/everything/pull/562) | merged — artifact lifecycle, migration `007`, `BeginPublish`/`FailPublish`, stale-row reaper |
 | AR-7c | branch `ar-7c-manifest-snapshot`, not yet merged | **implemented** — app identity/manifest-snapshot split, migration `008`, `AssertApps` |
 | AR-7d | branch `ar-7d-run-log`, stacked on `ar-7c-manifest-snapshot`, not yet merged | **implemented** — `GetReleaseRun`, `BeginPublishBatch`, `app-registry builds status`, `release.yml` resume, no schema change |
+| AR-7e | branch `ar-7e-adopt-artifact`, stacked on `ar-7d-run-log`, not yet merged | **implemented** — `AdoptArtifact` (admin-only), `app-registry artifacts adopt`/`list --provenance`, OPERATIONS.md disaster-recovery runbook, no schema change |
 
 The registry is being deployed to `dev` by the repo owner. `app-registry-api`
 and `app-registry-migration` images publish from `apps=all`.
@@ -52,8 +53,8 @@ say "not merged" in places; the table above is authoritative.
 implemented and tested, wired to nothing. See "AR-5" below for what remains
 before any domain can be cut over.
 
-**AR-7 (issue #558): AR-7a and AR-7b are merged to `main`; AR-7c and AR-7d
-are implemented, not yet merged.** The full phase makes a release run
+**AR-7 (issue #558): AR-7a and AR-7b are merged to `main`; AR-7c, AR-7d, and
+AR-7e are implemented, not yet merged.** The full phase makes a release run
 hermetic — no dependency on `main`'s reconcile having gone first — via an
 artifact
 `allocated → publishing → published` lifecycle, an identity/manifest-snapshot
@@ -70,9 +71,12 @@ and the promotability-retroactivity fix (see its subsection). AR-7d adds
 `GetReleaseRun`, the bulk `BeginPublishBatch` RPC that closes the gap AR-7b's
 own "Deliberately NOT done" left open (see AR-7b's section below),
 `app-registry builds status`/`--incomplete`, and `release.yml`'s resume
-behavior. Both phases' exit criteria are met; neither has merged yet.
-AR-7e and AR-7f remain design-only. Design is in ARCHITECTURE.md's "Release
-lifecycle (issue #558)"; delivery is "AR-7" below.
+behavior. AR-7e adds `AdoptArtifact` — an admin-only, per-artifact path for
+recording an artifact the registry never observed being published, used when
+a chart release fails on a pre-registry pin, plus OPERATIONS.md's
+disaster-recovery runbook. All three phases' exit criteria are met; none has
+merged yet. AR-7f remains design-only. Design is in ARCHITECTURE.md's
+"Release lifecycle (issue #558)"; delivery is "AR-7" below.
 
 **Where deferred work is tracked.** Three places, deliberately:
 [Carry-over items](#carry-over-items) for small cross-cutting gaps that
@@ -1534,19 +1538,130 @@ reaper-hazard follow-up fix below.
 
 ### AR-7e — Adoption and disaster recovery
 
-**Scope**
-- `ArtifactRegistry.AdoptArtifact` — admin role only, never the builder
-  credential — recording a pre-existing GHCR image or chart as `published`
-  with `provenance = 'adopted'` and a required reason. CLI
-  `app-registry artifacts adopt`; `artifacts list --provenance adopted`.
-- OPERATIONS.md disaster-recovery runbook: registry restored behind / lost,
-  chart release failing on a pre-registry pin, and the explicit statement that
-  this is a rare deliberate operation, not routine maintenance.
+**As built.** Implemented on branch `ar-7e-adopt-artifact`, stacked on
+`ar-7d-run-log` (which sits on `ar-7c-manifest-snapshot`, on `main`). No
+migration — `artifact.provenance ∈ ('observed', 'adopted')` already exists
+(migration `007`, AR-7b); this phase is the first to ever write `'adopted'`.
 
-**Exit criteria**
+**What shipped**
+- `ArtifactRegistry.AdoptArtifact` (new RPC, `protos/api_messages_artifact.
+  proto`): records a pre-existing GHCR image or chart as `published` with
+  `provenance = ADOPTED` and a required `reason`. **Role: admin ONLY** —
+  `server/handlers/artifact.go`'s `AdoptArtifact` calls
+  `auth.Require(ctx, auth.RoleAdmin)`, deliberately not `auth.RoleBuilder`
+  like every other write RPC in `ArtifactRegistry`. This is the
+  security-critical line of the phase: the builder credential is what every
+  CI job holds, and CI must never be able to assert an artifact into
+  existence that it did not observe being published. Proven by
+  `TestAdoptArtifact_Authorization` (`authz_test.go`): a builder credential
+  is `PermissionDenied`, an admin credential passes through to business
+  logic.
+- **State-collision semantics**, implemented identically in
+  `postgres/artifact.go` and `fake/fake.go`, documented on
+  `repository.ArtifactRepository.AdoptArtifact`'s doc comment:
+  - **Idempotent replay by digest**: an existing `published` row (observed
+    OR previously adopted) with the exact same digest is returned
+    unchanged, `already_recorded = true`. Provenance/state are NEVER
+    rewritten here — adopting a digest that turns out to already be
+    `observed` must not downgrade it to `adopted`; that would corrupt the
+    exact audit trail this RPC exists to provide
+    (`TestAdoptArtifact_NeverDowngradesObservedProvenance`).
+  - **`∅ → published` (adopted)** — the primary case: no row exists for
+    (owner, kind, version) yet.
+  - **`failed → published` (adopted)** — the disaster-recovery case: a run
+    already tried (`BeginPublish` ran, then `FailPublish` or the reaper
+    marked it `failed`), but the artifact demonstrably exists. If the
+    failed row already carries a `build_id` (true when the reaper reaped a
+    `publishing` row; false when it reaped an `allocated` row, which never
+    had one), that REAL `build_id` is reused rather than minting a
+    synthetic one.
+  - **`published` with a different digest → `ErrAlreadyExists`** — a real
+    conflict; adoption never silently overwrites a different recorded
+    digest.
+  - **`allocated` or `publishing` → `ErrFailedPrecondition`** — a live
+    reservation or in-flight publish is not what adoption is for; let it
+    complete, fail, or be reaped first.
+- **A synthetic `build` row**, not a schema change, closes the gap between
+  "no schema change" and `artifact.build_id`'s real foreign key /
+  migration `007`'s `artifact_state_shape` CHECK (`build_id NOT NULL` once
+  `published`) — there is by definition no real CI run behind a
+  pre-registry artifact. `workflow_run_id` is stamped `"adopted:<uuid>"`
+  (non-numeric, can never collide with a real GitHub Actions run id) and
+  `git_ref` carries `"adopted"` as the same at-a-glance marker in `builds
+  status`/`GetReleaseRun` output. `actor` is the calling admin's own
+  identity (`grpcauth.Claims.Subject`), not a service account. Only created
+  when needed — the `failed → published` branch reuses a real `build_id`
+  when the failed row already has one.
+- `ListArtifactsRequest.provenance` (new field) / `ArtifactListFilter.
+  Provenance`: "which rows did we take on faith?" as a query, implemented in
+  both the postgres query and the fake. CLI: `artifacts list --provenance
+  adopted`.
+- CLI (`cli/cmd/artifacts.go`): `app-registry artifacts adopt` (`--kind`,
+  `--owner`, `--repository`, `--version`, `--digest`, `--reason` required,
+  `--contains` for chart adoption, `--idempotency-key` — a UUID is
+  generated if omitted, same as `promote`/`rollback`, since this is a human
+  action, not CI). `artifacts list`'s owner positional argument is now
+  OPTIONAL (`[domain-name]`, was required) so `--provenance adopted` can
+  answer "every adopted row, across every owner" in one call.
+- The audit trail is a required `reason` plus a structured log line
+  (`artifactLog.Info("artifact adopted", ...)` — kind, owner, version,
+  digest, reason, actor, already_recorded), not a new column — mirroring
+  `SetAppStatus`'s identically-shaped `reason` parameter (required,
+  validated, not persisted; see `AppRepository.SetAppStatus`'s doc
+  comment). No schema change stays true.
+- OPERATIONS.md: "Adoption and disaster recovery" runbook — registry
+  restored behind or lost, a chart release failing on a pre-registry pin,
+  and the explicit statement that this is a rare, deliberate operation, not
+  routine maintenance.
+
+**Deliberately NOT done** (per this phase's own scope and the rejected
+alternatives it does not revisit):
+- **No bulk backfill.** `AdoptArtifact` is lazy and per-artifact — one call,
+  one artifact. There is no `--all`/`--sweep` flag, no batch RPC. "Resolved
+  questions" #3 still rejects a bulk backfill of historical GHCR artifacts.
+- **No live GHCR existence verifier.** `AdoptArtifact` records what an
+  operator asserts, with a required reason and an audit trail — it never
+  calls out to GHCR or the chart repository to check that the digest
+  actually exists. `published` stays proof-of-existence at write time, not
+  a liveness check.
+- **No domain-adoption-stage gate.** Unlike `AllocateVersion` (gated to
+  domains at stage `allocate`), `AdoptArtifact` works at any adoption stage
+  — it is an operator recovery mechanism, not part of the per-domain
+  rollout.
+- Compose-time chart hermeticity — AR-7f, unchanged.
+
+**Verified, not merely built:**
+- `bazel build //tools/...` and `bazel test //tools/...` are green.
+- `postgres_integration_test` (`manual`-tagged, requires Docker) was run for
+  real against `postgres:16-alpine`: the synthetic `build` row's shape
+  (`git_ref = "adopted"`, `workflow_run_id` prefixed `"adopted:"`, `actor`
+  stamped), the full unblock-a-chart-pin exit criterion end to end through
+  the handler layer (`TestAdoptArtifact_UnblocksChartPin_Postgres`), the
+  never-downgrade-observed invariant, the different-digest conflict, both
+  live-state rejections (`allocated`, `publishing`), and both `failed`-row
+  sub-cases (reuses an existing `build_id`; mints a synthetic one when the
+  failed row has none) — all against the real schema and CHECK constraints,
+  not just the fake.
+- Handler-level tests (fake-backed) cover the same state-collision matrix,
+  the authorization boundary, chart adoption with `contains`, and the
+  `ListArtifacts` provenance filter.
+- CLI unit tests lock in `artifacts adopt`'s required-flag surface and
+  `artifacts list`'s optional owner argument plus `--provenance` flag.
+- Every new test was verified to fail when the behavior it guards was
+  deliberately broken (the admin-only role check, the never-downgrade
+  invariant, both live-state rejections, the `build_id`-reuse branch, and a
+  CLI flag rename), then reverted.
+
+**Exit criteria — both met**
 - A chart pinning an image published before the registry existed can be
-  unblocked by one documented, audited command, and the adopted row is
-  distinguishable from an observed one in one query.
+  unblocked by one documented, audited command
+  (`TestAdoptArtifact_UnblocksChartPin_Postgres`,
+  `TestAdoptArtifact_UnblocksChartPinningPreRegistryImage`): the chart
+  record fails first on the unrecorded pin, `AdoptArtifact` records the
+  image, and the identical chart record then succeeds.
+- The adopted row is distinguishable from an observed one in one query —
+  `ListArtifacts(provenance=ADOPTED)` / `artifacts list --provenance
+  adopted`.
 
 ### AR-7f — Compose-time chart hermeticity — gated per domain
 

--- a/tools/app_registry/cli/README.md
+++ b/tools/app_registry/cli/README.md
@@ -3,7 +3,8 @@
 Thin gRPC client for the App Registry. Skeleton in **AR-1**, commands added
 alongside the RPCs they call in **AR-2** / **AR-3**. All commands below are
 implemented as of **AR-3d**, plus `artifacts begin-publish`/`fail-publish`
-added in **AR-7b**.
+added in **AR-7b**, and `artifacts adopt` / `artifacts list --provenance`
+added in **AR-7e**.
 
 ## Thin means thin
 
@@ -23,12 +24,13 @@ app-registry apps get <domain-name>
 app-registry apps set-status <domain-name> --status archived --reason "..."
 app-registry apps reconcile --from-plan <file> --idempotency-key K [--dry-run]     # CI
 
-app-registry artifacts list <domain-name> [--kind image|chart] [--promotable]
+app-registry artifacts list [domain-name] [--kind image|chart] [--promotable] [--provenance observed|adopted]
 app-registry artifacts get <domain-name> --version vX.Y.Z
 app-registry artifacts resolve <digest|artifact-id>            # chart -> images
 app-registry artifacts record ... --idempotency-key K          # CI
 app-registry artifacts begin-publish --kind K --owner O --version V --build-id B --idempotency-key K   # CI, AR-7b
 app-registry artifacts fail-publish --kind K --owner O --version V --reason "..." --idempotency-key K  # CI, AR-7b
+app-registry artifacts adopt --kind K --owner O --version V --digest D --reason "..." [--repository R] [--contains file] [--idempotency-key K]  # admin, AR-7e
 
 app-registry builds record ... --idempotency-key K             # CI
 
@@ -45,7 +47,24 @@ app-registry env list | upsert | archive                       # admin
 
 `--promotable` on `artifacts list` is the answer to "what can I actually
 promote?" — it filters by the derived promotability described in
-[`../ARCHITECTURE.md`](../ARCHITECTURE.md#promotability).
+[`../ARCHITECTURE.md`](../ARCHITECTURE.md#promotability). `--provenance
+adopted` (AR-7e) answers "which rows did we take on faith?" — see
+`../OPERATIONS.md`'s "Adoption and disaster recovery". The `[domain-name]`
+positional argument is optional specifically so that query can span every
+owner in one call, not just one.
+
+### `adopt`
+
+Admin-only (never the builder credential CI holds) — see
+[`../ARCHITECTURE.md`](../ARCHITECTURE.md#authorization). Records a
+pre-existing GHCR image or chart as `published` with `provenance = adopted`,
+for when there is no CI run to resume: a chart pinning an image published
+before the registry existed, or a registry restored behind/lost. `--reason`
+is required — the audit trail for a deliberately rare, human-triggered
+operation. `--idempotency-key` is optional (a UUID is generated if omitted,
+same as `promote`/`rollback`). `--contains` (kind `chart` only) takes the
+same JSON-array file shape as `artifacts record --contains`. Full runbook:
+`../OPERATIONS.md`'s "Adoption and disaster recovery".
 
 ### `promote` / `rollback`
 

--- a/tools/app_registry/cli/cmd/BUILD.bazel
+++ b/tools/app_registry/cli/cmd/BUILD.bazel
@@ -32,6 +32,7 @@ go_library(
 go_test(
     name = "cmd_test",
     srcs = [
+        "artifacts_test.go",
         "builds_test.go",
         "promote_test.go",
         "root_test.go",

--- a/tools/app_registry/cli/cmd/artifacts.go
+++ b/tools/app_registry/cli/cmd/artifacts.go
@@ -23,6 +23,7 @@ func newArtifactsCmd() *cobra.Command {
 		newArtifactsBeginPublishCmd(),
 		newArtifactsBeginPublishBatchCmd(),
 		newArtifactsFailPublishCmd(),
+		newArtifactsAdoptCmd(),
 	)
 	return artifactsCmd
 }
@@ -282,16 +283,25 @@ func newArtifactsFailPublishCmd() *cobra.Command {
 }
 
 func newArtifactsListCmd() *cobra.Command {
-	var kind string
+	var kind, provenance string
 	var promotableOnly bool
 	c := &cobra.Command{
-		Use:   "list <domain-name>",
-		Short: "List artifacts for an app or chart",
-		Args:  cobra.ExactArgs(1),
+		Use:   "list [domain-name]",
+		Short: "List artifacts, optionally scoped to one app or chart",
+		// domain-name is now OPTIONAL (AR-7e, issue #558): `artifacts list
+		// --provenance adopted` answers "which rows did we take on faith?"
+		// across every owner in one query -- the exit criterion's
+		// "distinguishable in one query" half. ListArtifactsRequest.
+		// owner_full_name has always been an optional filter server-side
+		// (see server/handlers/artifact.go's ListArtifacts); this only
+		// relaxes the CLI's own arg count.
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			req := &pb.ListArtifactsRequest{
-				OwnerFullName:  args[0],
 				PromotableOnly: promotableOnly,
+			}
+			if len(args) == 1 {
+				req.OwnerFullName = args[0]
 			}
 			if kind != "" {
 				k, err := parseArtifactKind(kind)
@@ -299,6 +309,13 @@ func newArtifactsListCmd() *cobra.Command {
 					return err
 				}
 				req.Kind = k
+			}
+			if provenance != "" {
+				p, err := parseArtifactProvenance(provenance)
+				if err != nil {
+					return err
+				}
+				req.Provenance = p
 			}
 			return withClient(cmd, func(rc *registryClient) error {
 				resp, err := rc.Artifact.ListArtifacts(cmd.Context(), req)
@@ -311,6 +328,80 @@ func newArtifactsListCmd() *cobra.Command {
 	}
 	c.Flags().StringVar(&kind, "kind", "", "Filter by kind (image|chart)")
 	c.Flags().BoolVar(&promotableOnly, "promotable", false, "Only artifacts a caller could legally promote")
+	c.Flags().StringVar(&provenance, "provenance", "", "Filter by provenance (observed|adopted)")
+	return c
+}
+
+// newArtifactsAdoptCmd is AR-7e's (issue #558) admin-only adoption /
+// disaster-recovery path: records a pre-existing GHCR image or chart as
+// published, for when there is no CI run to resume -- a chart pinning an
+// image published before the registry existed, or a registry restored
+// behind/lost. See ARCHITECTURE.md "Adoption and disaster recovery" and
+// OPERATIONS.md's disaster-recovery runbook. Deliberately lazy and
+// per-artifact, not a bulk backfill -- there is no --all/--sweep flag here
+// on purpose.
+func newArtifactsAdoptCmd() *cobra.Command {
+	var kind, owner, repository, version, digest, reason, containsFile string
+	var publishedAt int64
+	c := &cobra.Command{
+		Use:   "adopt",
+		Short: "Record a pre-existing artifact as published (admin, disaster recovery)",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			k, err := parseArtifactKind(kind)
+			if err != nil {
+				return err
+			}
+			req := &pb.AdoptArtifactRequest{
+				Kind:           k,
+				OwnerFullName:  owner,
+				Repository:     repository,
+				Version:        version,
+				Digest:         digest,
+				Reason:         reason,
+				PublishedAt:    publishedAt,
+				IdempotencyKey: promoteIdempotencyKey(idempotencyKeyFlag),
+			}
+			if containsFile != "" {
+				data, err := os.ReadFile(containsFile)
+				if err != nil {
+					return fmt.Errorf("read --contains %s: %w", containsFile, err)
+				}
+				var images []containedImageJSON
+				if err := json.Unmarshal(data, &images); err != nil {
+					return fmt.Errorf("parse --contains %s: %w", containsFile, err)
+				}
+				for _, img := range images {
+					req.Contains = append(req.Contains, &pb.ContainedImage{
+						AppFullName: img.AppFullName,
+						Repository:  img.Repository,
+						Version:     img.Version,
+						Digest:      img.Digest,
+					})
+				}
+			}
+			return withClient(cmd, func(rc *registryClient) error {
+				resp, err := rc.Artifact.AdoptArtifact(cmd.Context(), req)
+				if err != nil {
+					return err
+				}
+				return printResponse(resp)
+			})
+		},
+	}
+	c.Flags().StringVar(&kind, "kind", "", "Artifact kind (image|chart)")
+	c.Flags().StringVar(&owner, "owner", "", "Owning app or chart, as <domain>-<name>")
+	c.Flags().StringVar(&repository, "repository", "", "Registry repository, e.g. ghcr.io/whale-net/app-registry-api")
+	c.Flags().StringVar(&version, "version", "", "Semver tag, e.g. v1.2.3")
+	c.Flags().StringVar(&digest, "digest", "", `Content digest, "sha256:..."`)
+	c.Flags().StringVar(&reason, "reason", "", "Required. Why this artifact is being adopted instead of observed")
+	c.Flags().Int64Var(&publishedAt, "published-at", 0, "Best-known actual publish time, Unix timestamp (default: now)")
+	c.Flags().StringVar(&containsFile, "contains", "", "kind=chart only: path to a JSON array of resolved image references")
+	c.Flags().StringVar(&idempotencyKeyFlag, "idempotency-key", "", "Client-generated; a UUID is generated if omitted (this is a human action, not CI)")
+	_ = c.MarkFlagRequired("kind")
+	_ = c.MarkFlagRequired("owner")
+	_ = c.MarkFlagRequired("version")
+	_ = c.MarkFlagRequired("digest")
+	_ = c.MarkFlagRequired("reason")
 	return c
 }
 
@@ -370,5 +461,18 @@ func parseArtifactKind(s string) (pb.ArtifactKind, error) {
 		return pb.ArtifactKind_ARTIFACT_KIND_CHART, nil
 	default:
 		return pb.ArtifactKind_ARTIFACT_KIND_UNSPECIFIED, fmt.Errorf("unknown kind %q (want image|chart)", s)
+	}
+}
+
+// parseArtifactProvenance backs `artifacts list --provenance` (AR-7e, issue
+// #558).
+func parseArtifactProvenance(s string) (pb.ArtifactProvenance, error) {
+	switch s {
+	case "observed":
+		return pb.ArtifactProvenance_ARTIFACT_PROVENANCE_OBSERVED, nil
+	case "adopted":
+		return pb.ArtifactProvenance_ARTIFACT_PROVENANCE_ADOPTED, nil
+	default:
+		return pb.ArtifactProvenance_ARTIFACT_PROVENANCE_UNSPECIFIED, fmt.Errorf("unknown provenance %q (want observed|adopted)", s)
 	}
 }

--- a/tools/app_registry/cli/cmd/artifacts_test.go
+++ b/tools/app_registry/cli/cmd/artifacts_test.go
@@ -1,0 +1,62 @@
+package cmd
+
+import "testing"
+
+// TestNewArtifactsAdoptCmd_RegistersRequiredFlags locks in the flag surface
+// `artifacts adopt` exposes (AR-7e, issue #558) -- a future accidental
+// rename would break OPERATIONS.md's documented disaster-recovery runbook
+// silently otherwise. --reason is the one flag that matters most here: it
+// is the audit trail for a deliberately rare, human-triggered operation.
+func TestNewArtifactsAdoptCmd_RegistersRequiredFlags(t *testing.T) {
+	c := newArtifactsAdoptCmd()
+
+	for _, name := range []string{"kind", "owner", "repository", "version", "digest", "reason", "contains", "idempotency-key"} {
+		if c.Flags().Lookup(name) == nil {
+			t.Fatalf("expected a --%s flag", name)
+		}
+	}
+
+	required := map[string]bool{}
+	for _, name := range []string{"kind", "owner", "version", "digest", "reason"} {
+		required[name] = true
+	}
+	for name := range required {
+		f := c.Flags().Lookup(name)
+		if f.Annotations["cobra_annotation_bash_completion_one_required_flag"] == nil {
+			t.Errorf("expected --%s to be marked required", name)
+		}
+	}
+	// --idempotency-key is deliberately NOT required here (unlike
+	// `artifacts record`/`begin-publish`/`fail-publish`, the CI write
+	// paths): this is a human action, so a UUID is generated if omitted --
+	// see promoteIdempotencyKey.
+	if idem := c.Flags().Lookup("idempotency-key"); idem.Annotations["cobra_annotation_bash_completion_one_required_flag"] != nil {
+		t.Error("expected --idempotency-key to NOT be required (a UUID is generated if omitted)")
+	}
+
+	if c.Use != "adopt" {
+		t.Errorf("Use = %q, want %q", c.Use, "adopt")
+	}
+}
+
+// TestNewArtifactsListCmd_RegistersProvenanceFlagAndOptionalOwner covers
+// AR-7e's `artifacts list --provenance adopted` -- the owner positional arg
+// must be OPTIONAL so "every adopted row across every owner" is answerable
+// in one call, matching the exit criterion's "distinguishable in one
+// query."
+func TestNewArtifactsListCmd_RegistersProvenanceFlagAndOptionalOwner(t *testing.T) {
+	c := newArtifactsListCmd()
+
+	if c.Flags().Lookup("provenance") == nil {
+		t.Fatal("expected a --provenance flag")
+	}
+	if err := c.Args(c, nil); err != nil {
+		t.Errorf("expected zero args to be valid (owner is optional), got %v", err)
+	}
+	if err := c.Args(c, []string{"demo-svc"}); err != nil {
+		t.Errorf("expected one arg to still be valid, got %v", err)
+	}
+	if err := c.Args(c, []string{"a", "b"}); err == nil {
+		t.Error("expected two args to be rejected")
+	}
+}

--- a/tools/app_registry/protos/api.proto
+++ b/tools/app_registry/protos/api.proto
@@ -76,6 +76,15 @@ service ArtifactRegistry {
 
   // Phase AR-5: transactional version allocation, replacing git-tag scanning.
   rpc AllocateVersion(AllocateVersionRequest) returns (AllocateVersionResponse);
+
+  // Phase AR-7e (issue #558): the admin-only adoption / disaster-recovery
+  // path -- records a pre-existing GHCR image or chart as published with
+  // provenance ADOPTED and a required reason, for when there is no CI run to
+  // resume (a chart pinning an image published before the registry existed,
+  // or a registry restored behind/lost). Role: admin ONLY -- never the
+  // builder credential a CI job holds; see ARCHITECTURE.md "Authorization"
+  // and "Adoption and disaster recovery".
+  rpc AdoptArtifact(AdoptArtifactRequest) returns (AdoptArtifactResponse);
 }
 
 // ============================================================================

--- a/tools/app_registry/protos/api_messages_artifact.proto
+++ b/tools/app_registry/protos/api_messages_artifact.proto
@@ -202,6 +202,56 @@ message GetReleaseRunResponse {
 }
 
 // ============================================================================
+// Adoption and disaster recovery (AR-7e, issue #558)
+// ============================================================================
+
+// AdoptArtifactRequest is the ∅|failed -> published(provenance=ADOPTED)
+// admin path: records a pre-existing GHCR image or chart -- one that predates
+// the registry, or was pushed while the opt-in was off -- as published,
+// without ever having observed a BeginPublish/RecordArtifact for it. See
+// ARCHITECTURE.md "Adoption and disaster recovery". Lazy and per-artifact,
+// used when a chart release fails on an unknown pin -- NOT a bulk backfill
+// ("Resolved questions" #3 still rejects that), and NOT a live GHCR
+// existence check: this records what an operator asserts, with a required
+// reason, exactly as RecordArtifact records what CI observed.
+message AdoptArtifactRequest {
+  ArtifactKind kind = 1;
+
+  // For kind == IMAGE: the app's "<domain>-<name>".
+  // For kind == CHART: the chart's "<domain>-<name>".
+  string owner_full_name = 2;
+
+  string repository = 3;
+  string version = 4;  // semver tag, validated as v<major>.<minor>.<patch>
+  string digest = 5;    // "sha256:..." — required
+
+  // Only valid for kind == CHART, same shape and validation as
+  // RecordArtifactRequest.contains: every referenced image must already be
+  // a PUBLISHED artifact (adopted or observed), or the call fails.
+  repeated ContainedImage contains = 6;
+
+  // Best-known actual publish time, if known; defaults to now if unset.
+  int64 published_at = 7;
+
+  // Required. Why this artifact is being recorded after the fact instead of
+  // observed at publish time -- the audit trail for a deliberately rare,
+  // human-triggered operation. Never supplied by CI.
+  string reason = 8;
+
+  // Required. Client-generated (e.g. a UUID) -- this is a human action, not
+  // a CI run, so there is no natural <workflow_run_id>-based key.
+  string idempotency_key = 9;
+}
+
+message AdoptArtifactResponse {
+  Artifact artifact = 1;
+
+  // True when an artifact with this exact digest was already published
+  // (observed or previously adopted) and this call was a no-op replay.
+  bool already_recorded = 2;
+}
+
+// ============================================================================
 // Reads
 // ============================================================================
 
@@ -215,6 +265,11 @@ message ListArtifactsRequest {
   bool promotable_only = 3;
 
   PageRequest page = 4;
+
+  // When set, return only artifacts with this provenance -- AR-7e (issue
+  // #558): "which rows did we take on faith?" as a query. Unset (the
+  // default, ARTIFACT_PROVENANCE_UNSPECIFIED) returns every provenance.
+  ArtifactProvenance provenance = 5;
 }
 
 message ListArtifactsResponse {

--- a/tools/app_registry/server/handlers/BUILD.bazel
+++ b/tools/app_registry/server/handlers/BUILD.bazel
@@ -33,6 +33,7 @@ go_test(
     size = "small",
     srcs = [
         "app_test.go",
+        "artifact_adopt_test.go",
         "artifact_test.go",
         "authz_test.go",
         "environment_test.go",

--- a/tools/app_registry/server/handlers/artifact.go
+++ b/tools/app_registry/server/handlers/artifact.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"regexp"
 	"strings"
 	"time"
 
+	"github.com/whale-net/everything/libs/go/grpcauth"
+	"github.com/whale-net/everything/libs/go/logging"
 	"github.com/whale-net/everything/libs/go/semver"
 	pb "github.com/whale-net/everything/tools/app_registry/protos"
 	"github.com/whale-net/everything/tools/app_registry/server/auth"
@@ -18,6 +21,15 @@ import (
 )
 
 var semverRe = regexp.MustCompile(`^v\d+\.\d+\.\d+$`)
+
+// artifactLog is this file's logger name, matching app.go's appLog pattern
+// -- AdoptArtifact (AR-7e, issue #558) is the one write RPC in this file
+// whose audit trail is a log line rather than a stored column (its `reason`
+// is validated as required but not persisted -- see
+// repository.ArtifactRepository.AdoptArtifact's doc comment and
+// AppServer.SetAppStatus's identically-shaped `reason` parameter), so this
+// line is load-bearing, not incidental.
+var artifactLog = logging.Get("app-registry-handlers")
 
 // ArtifactServer implements pb.ArtifactRegistryServer, backed by
 // repository.Registry.
@@ -193,6 +205,7 @@ func (s *ArtifactServer) ListArtifacts(ctx context.Context, req *pb.ListArtifact
 		OwnerFullName:  req.OwnerFullName,
 		Kind:           artifactKindFromPB(req.Kind),
 		PromotableOnly: req.PromotableOnly,
+		Provenance:     artifactProvenanceFromPB(req.Provenance),
 	})
 	if err != nil {
 		return nil, mapRepoErr(err)
@@ -631,4 +644,108 @@ func (s *ArtifactServer) GetReleaseRun(ctx context.Context, req *pb.GetReleaseRu
 		Build:     buildToPB(*build),
 		Artifacts: artifactsToPB(artifacts),
 	}, nil
+}
+
+// AdoptArtifact implements AR-7e's (issue #558) admin-only adoption /
+// disaster-recovery path: records a pre-existing GHCR image or chart as
+// published with provenance ADOPTED and a required reason, for when there is
+// no CI run to resume. See ARCHITECTURE.md "Adoption and disaster recovery"
+// and repository.ArtifactRepository.AdoptArtifact's doc comment for the full
+// state-collision contract.
+//
+// Role: admin ONLY -- deliberately NOT auth.RoleBuilder, unlike every other
+// write RPC in this file. This is the security-critical line of the whole
+// phase: the builder credential is what every CI job holds, and CI must
+// never be able to assert an artifact into existence that it did not
+// observe being published -- see ARCHITECTURE.md "Authorization" and
+// server/handlers/authz_test.go's TestAdoptArtifact_Authorization.
+func (s *ArtifactServer) AdoptArtifact(ctx context.Context, req *pb.AdoptArtifactRequest) (*pb.AdoptArtifactResponse, error) {
+	if err := auth.Require(ctx, auth.RoleAdmin); err != nil {
+		return nil, err
+	}
+	kind := artifactKindFromPB(req.Kind)
+	if kind == "" {
+		return nil, status.Error(codes.InvalidArgument, "kind is required")
+	}
+	if req.OwnerFullName == "" {
+		return nil, status.Error(codes.InvalidArgument, "owner_full_name is required")
+	}
+	if req.Version == "" || !semverRe.MatchString(req.Version) {
+		return nil, status.Errorf(codes.InvalidArgument, "version %q must match v<major>.<minor>.<patch>", req.Version)
+	}
+	if req.Digest == "" || !strings.HasPrefix(req.Digest, "sha256:") {
+		return nil, status.Error(codes.InvalidArgument, `digest is required and must be "sha256:..."`)
+	}
+	if kind == repository.ArtifactKindImage && len(req.Contains) > 0 {
+		return nil, status.Error(codes.InvalidArgument, "contains is only valid for kind == CHART")
+	}
+	// Required -- the audit trail for a deliberately rare, human-triggered
+	// operation. Not persisted to a column (no schema change this phase --
+	// see repository.ArtifactRepository.AdoptArtifact's doc comment); logged
+	// below instead, same shape as AppServer.SetAppStatus's reason.
+	if req.Reason == "" {
+		return nil, status.Error(codes.InvalidArgument, "reason is required")
+	}
+	if req.IdempotencyKey == "" {
+		return nil, status.Error(codes.InvalidArgument, "idempotency_key is required")
+	}
+
+	_, ownerID, _, err := s.resolveOwnerAndDomain(ctx, kind, req.OwnerFullName)
+	if err != nil {
+		return nil, err
+	}
+
+	// actor authors the synthetic `build` row AdoptArtifact may need to
+	// create (see repository.ArtifactRepository.AdoptArtifact's doc
+	// comment) -- the calling admin's own identity, not a service account,
+	// since this credential is human-operated per DEPLOY.md §4's "Where
+	// each secret goes" table.
+	actor := "admin"
+	if claims, ok := grpcauth.ClaimsFromContext(ctx); ok && claims.Subject != "" {
+		actor = claims.Subject
+	}
+
+	resp, _, err := runIdempotent(ctx, s.repo, req.IdempotencyKey, "AdoptArtifact",
+		func() proto.Message { return &pb.AdoptArtifactResponse{} },
+		func(ctx context.Context, r repository.Registry) (proto.Message, error) {
+			a := repository.Artifact{
+				Kind:        kind,
+				Repository:  req.Repository,
+				Version:     req.Version,
+				Digest:      req.Digest,
+				PublishedAt: unixToTime(req.PublishedAt),
+			}
+			if kind == repository.ArtifactKindImage {
+				a.AppID = ownerID
+			} else {
+				a.ChartID = ownerID
+			}
+			artifact, alreadyRecorded, aerr := r.Artifacts().AdoptArtifact(ctx, a, containedImagesFromPB(req.Contains), req.Reason, actor)
+			if aerr != nil {
+				return nil, aerr
+			}
+			return &pb.AdoptArtifactResponse{Artifact: artifactToPB(*artifact), AlreadyRecorded: alreadyRecorded}, nil
+		},
+	)
+	if err != nil {
+		return nil, mapRepoErr(err)
+	}
+	out := resp.(*pb.AdoptArtifactResponse)
+
+	// The audit trail: a required reason, an identified actor, and exactly
+	// what was asserted -- structured so "why did we adopt this?" is a log
+	// query, not archaeology. Info, not Debug: every call here is a
+	// deliberate, rare, human-triggered operation (ARCHITECTURE.md "Adoption
+	// and disaster recovery"), worth a durable record even on the happy
+	// path -- unlike ReconcileApps's Warn-on-anomaly-only logging above.
+	artifactLog.Info("artifact adopted",
+		slog.String("kind", string(kind)),
+		slog.String("owner_full_name", req.OwnerFullName),
+		slog.String("version", req.Version),
+		slog.String("digest", req.Digest),
+		slog.String("reason", req.Reason),
+		slog.String("actor", actor),
+		slog.Bool("already_recorded", out.AlreadyRecorded),
+	)
+	return out, nil
 }

--- a/tools/app_registry/server/handlers/artifact_adopt_test.go
+++ b/tools/app_registry/server/handlers/artifact_adopt_test.go
@@ -1,0 +1,382 @@
+package handlers
+
+import (
+	"testing"
+
+	pb "github.com/whale-net/everything/tools/app_registry/protos"
+	"github.com/whale-net/everything/tools/app_registry/server/repository"
+	"github.com/whale-net/everything/tools/app_registry/server/repository/fake"
+	appmetapb "github.com/whale-net/everything/tools/appmeta/proto"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// This file covers AR-7e's (issue #558) AdoptArtifact business logic --
+// authorization itself is TestAdoptArtifact_Authorization in authz_test.go.
+// setup/recordBuild are defined in artifact_test.go: "demo-image-app" is
+// DEPLOY_UNIT_IMAGE, "demo-chart-app" is DEPLOY_UNIT_CHART (composed into
+// chart "demo-achart"), "demo-none-app" is DEPLOY_UNIT_NONE.
+
+// TestAdoptArtifact_NewRow_CreatesPublishedWithAdoptedProvenance is the
+// primary case: no row exists at all for (owner, kind, version) yet.
+func TestAdoptArtifact_NewRow_CreatesPublishedWithAdoptedProvenance(t *testing.T) {
+	_, artifactSrv, _ := setup(t)
+	ctx := authedCtx()
+
+	resp, err := artifactSrv.AdoptArtifact(ctx, &pb.AdoptArtifactRequest{
+		Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE, OwnerFullName: "demo-image-app",
+		Repository: "ghcr.io/demo/image-app", Version: "v0.9.0", Digest: "sha256:adopt-new",
+		Reason: "pre-dates the registry", IdempotencyKey: "adopt-new-1",
+	})
+	if err != nil {
+		t.Fatalf("AdoptArtifact: %v", err)
+	}
+	if resp.AlreadyRecorded {
+		t.Fatal("expected AlreadyRecorded=false for a brand-new adoption")
+	}
+	if resp.Artifact.State != pb.ArtifactState_ARTIFACT_STATE_PUBLISHED {
+		t.Fatalf("expected PUBLISHED, got %v", resp.Artifact.State)
+	}
+	if resp.Artifact.Provenance != pb.ArtifactProvenance_ARTIFACT_PROVENANCE_ADOPTED {
+		t.Fatalf("expected ADOPTED provenance, got %v", resp.Artifact.Provenance)
+	}
+	if resp.Artifact.BuildId == "" {
+		t.Fatal("expected a (synthetic) build_id to be stamped")
+	}
+}
+
+// TestAdoptArtifact_UnblocksChartPinningPreRegistryImage is PLAN.md's AR-7e
+// exit criterion, exercised end to end: a chart record fails on an
+// unrecorded pin, adopting the pinned image unblocks the SAME chart record.
+func TestAdoptArtifact_UnblocksChartPinningPreRegistryImage(t *testing.T) {
+	_, artifactSrv, _ := setup(t)
+	ctx := authedCtx()
+	build := recordBuild(t, artifactSrv, "run-adopt-unblock")
+
+	// Fails first: "demo-chart-app"'s v0.9.0 was never recorded -- as if it
+	// were published before the registry existed.
+	_, err := artifactSrv.RecordArtifact(ctx, &pb.RecordArtifactRequest{
+		BuildId: build.BuildId, Kind: pb.ArtifactKind_ARTIFACT_KIND_CHART,
+		OwnerFullName: "demo-achart", Digest: "sha256:chart-preadopt", Version: "v1.0.0",
+		Contains: []*pb.ContainedImage{
+			{AppFullName: "demo-chart-app", Repository: "ghcr.io/demo/chart-app", Version: "v0.9.0", Digest: "sha256:pre-registry-image"},
+		},
+		IdempotencyKey: "chart-preadopt-1",
+	})
+	if err == nil || status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("expected the chart record to reject the unrecorded pin first, got %v", err)
+	}
+
+	adoptResp, err := artifactSrv.AdoptArtifact(ctx, &pb.AdoptArtifactRequest{
+		Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE, OwnerFullName: "demo-chart-app",
+		Repository: "ghcr.io/demo/chart-app", Version: "v0.9.0", Digest: "sha256:pre-registry-image",
+		Reason: "pre-dates the registry", IdempotencyKey: "adopt-image-1",
+	})
+	if err != nil {
+		t.Fatalf("AdoptArtifact: %v", err)
+	}
+	if adoptResp.Artifact.Provenance != pb.ArtifactProvenance_ARTIFACT_PROVENANCE_ADOPTED {
+		t.Fatalf("expected ADOPTED provenance, got %v", adoptResp.Artifact.Provenance)
+	}
+
+	// The SAME chart record now succeeds -- one documented, audited command
+	// unblocked it.
+	chartResp, err := artifactSrv.RecordArtifact(ctx, &pb.RecordArtifactRequest{
+		BuildId: build.BuildId, Kind: pb.ArtifactKind_ARTIFACT_KIND_CHART,
+		OwnerFullName: "demo-achart", Digest: "sha256:chart-preadopt", Version: "v1.0.0",
+		Contains: []*pb.ContainedImage{
+			{AppFullName: "demo-chart-app", Repository: "ghcr.io/demo/chart-app", Version: "v0.9.0", Digest: "sha256:pre-registry-image"},
+		},
+		IdempotencyKey: "chart-preadopt-2",
+	})
+	if err != nil {
+		t.Fatalf("RecordArtifact after adoption should succeed: %v", err)
+	}
+	if len(chartResp.Artifact.Contains) != 1 || chartResp.Artifact.Contains[0].Digest != "sha256:pre-registry-image" {
+		t.Fatalf("expected the chart to pin the adopted image, got %+v", chartResp.Artifact.Contains)
+	}
+}
+
+// TestAdoptArtifact_NeverDowngradesObservedProvenance is the critical
+// invariant: adopting a digest that turns out to already be an "observed"
+// row must be an idempotent no-op, never a rewrite -- see
+// repository.ArtifactRepository.AdoptArtifact's doc comment.
+func TestAdoptArtifact_NeverDowngradesObservedProvenance(t *testing.T) {
+	_, artifactSrv, _ := setup(t)
+	ctx := authedCtx()
+	build := recordBuild(t, artifactSrv, "run-adopt-no-downgrade")
+
+	recorded, err := artifactSrv.RecordArtifact(ctx, &pb.RecordArtifactRequest{
+		BuildId: build.BuildId, Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE,
+		OwnerFullName: "demo-image-app", Digest: "sha256:observed-not-downgraded", Version: "v1.0.0",
+		IdempotencyKey: "record-observed-1",
+	})
+	if err != nil {
+		t.Fatalf("RecordArtifact: %v", err)
+	}
+	if recorded.Artifact.Provenance != pb.ArtifactProvenance_ARTIFACT_PROVENANCE_OBSERVED {
+		t.Fatalf("expected OBSERVED provenance from RecordArtifact, got %v", recorded.Artifact.Provenance)
+	}
+
+	adopted, err := artifactSrv.AdoptArtifact(ctx, &pb.AdoptArtifactRequest{
+		Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE, OwnerFullName: "demo-image-app",
+		Version: "v1.0.0", Digest: "sha256:observed-not-downgraded",
+		Reason: "operator mistake -- already observed", IdempotencyKey: "adopt-observed-1",
+	})
+	if err != nil {
+		t.Fatalf("AdoptArtifact against an already-observed digest should be an idempotent no-op, got %v", err)
+	}
+	if !adopted.AlreadyRecorded {
+		t.Fatal("expected AlreadyRecorded=true")
+	}
+	if adopted.Artifact.Provenance != pb.ArtifactProvenance_ARTIFACT_PROVENANCE_OBSERVED {
+		t.Fatalf("expected provenance to STAY OBSERVED (never downgraded to ADOPTED), got %v", adopted.Artifact.Provenance)
+	}
+}
+
+// TestAdoptArtifact_DifferentDigestConflict proves adoption cannot silently
+// overwrite an already-published version with a different digest.
+func TestAdoptArtifact_DifferentDigestConflict(t *testing.T) {
+	_, artifactSrv, _ := setup(t)
+	ctx := authedCtx()
+	build := recordBuild(t, artifactSrv, "run-adopt-conflict")
+
+	if _, err := artifactSrv.RecordArtifact(ctx, &pb.RecordArtifactRequest{
+		BuildId: build.BuildId, Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE,
+		OwnerFullName: "demo-image-app", Digest: "sha256:conflict-original", Version: "v1.0.0",
+		IdempotencyKey: "record-conflict-1",
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	_, err := artifactSrv.AdoptArtifact(ctx, &pb.AdoptArtifactRequest{
+		Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE, OwnerFullName: "demo-image-app",
+		Version: "v1.0.0", Digest: "sha256:conflict-different",
+		Reason: "trying to overwrite", IdempotencyKey: "adopt-conflict-1",
+	})
+	if err == nil {
+		t.Fatal("expected a conflict adopting a different digest onto an already-published version")
+	}
+	if status.Code(err) != codes.AlreadyExists {
+		t.Fatalf("expected AlreadyExists, got %v (%v)", status.Code(err), err)
+	}
+}
+
+// TestAdoptArtifact_RejectsAllocatedRow proves adoption does not silently
+// discard a live version reservation.
+func TestAdoptArtifact_RejectsAllocatedRow(t *testing.T) {
+	repo := fake.New()
+	appSrv := NewAppServer(repo)
+	artifactSrv := NewArtifactServer(repo)
+	ctx := authedCtx()
+
+	if _, err := appSrv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
+		Manifests:      manifestSet([]*appmetapb.AppManifest{{Domain: "demo", Name: "allocsvc", DeployUnit: appmetapb.DeployUnit_DEPLOY_UNIT_IMAGE}}, nil),
+		IdempotencyKey: "adopt-alloc-reconcile",
+	}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	repo.SetDomainAdoptionStage("demo", repository.DomainAdoptionStageAllocate)
+
+	alloc, err := artifactSrv.AllocateVersion(ctx, &pb.AllocateVersionRequest{
+		OwnerFullName: "demo-allocsvc", Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE,
+		Increment: "patch", IdempotencyKey: "adopt-alloc-allocate",
+	})
+	if err != nil {
+		t.Fatalf("AllocateVersion: %v", err)
+	}
+
+	_, err = artifactSrv.AdoptArtifact(ctx, &pb.AdoptArtifactRequest{
+		Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE, OwnerFullName: "demo-allocsvc",
+		Version: alloc.Version, Digest: "sha256:adopt-over-allocated",
+		Reason: "should be rejected", IdempotencyKey: "adopt-alloc-adopt",
+	})
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("expected FailedPrecondition adopting over an allocated row, got %v (%v)", status.Code(err), err)
+	}
+}
+
+// TestAdoptArtifact_RejectsPublishingRow proves adoption does not race a
+// live in-flight publish.
+func TestAdoptArtifact_RejectsPublishingRow(t *testing.T) {
+	// setupAllocate, not setup: BeginPublish's ∅ -> publishing branch needs
+	// a real ImageRepository (Registry/Organization/RepoName) to stamp onto
+	// the fresh row -- setup()'s "demo-image-app" doesn't set those.
+	_, artifactSrv := setupAllocate(t)
+	ctx := authedCtx()
+	build := recordBuild(t, artifactSrv, "run-adopt-publishing")
+
+	if _, err := artifactSrv.BeginPublish(ctx, &pb.BeginPublishRequest{
+		Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE, OwnerFullName: "demo-image-app",
+		Version: "v1.0.0", BuildId: build.BuildId, IdempotencyKey: "adopt-publishing-begin",
+	}); err != nil {
+		t.Fatalf("BeginPublish: %v", err)
+	}
+
+	_, err := artifactSrv.AdoptArtifact(ctx, &pb.AdoptArtifactRequest{
+		Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE, OwnerFullName: "demo-image-app",
+		Version: "v1.0.0", Digest: "sha256:adopt-over-publishing",
+		Reason: "should be rejected", IdempotencyKey: "adopt-publishing-adopt",
+	})
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("expected FailedPrecondition adopting over a publishing row, got %v (%v)", status.Code(err), err)
+	}
+}
+
+// TestAdoptArtifact_FailedRowBecomesPublished_ReusesBuildID is the
+// disaster-recovery case: a run already tried and failed (or was reaped),
+// but the artifact demonstrably exists. The existing row's REAL build_id
+// (from the run that actually attempted the push) is reused rather than a
+// synthetic one being minted.
+func TestAdoptArtifact_FailedRowBecomesPublished_ReusesBuildID(t *testing.T) {
+	// setupAllocate, not setup -- see TestAdoptArtifact_RejectsPublishingRow.
+	_, artifactSrv := setupAllocate(t)
+	ctx := authedCtx()
+	build := recordBuild(t, artifactSrv, "run-adopt-failed")
+
+	if _, err := artifactSrv.BeginPublish(ctx, &pb.BeginPublishRequest{
+		Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE, OwnerFullName: "demo-image-app",
+		Version: "v1.0.0", BuildId: build.BuildId, IdempotencyKey: "adopt-failed-begin",
+	}); err != nil {
+		t.Fatalf("BeginPublish: %v", err)
+	}
+	if _, err := artifactSrv.FailPublish(ctx, &pb.FailPublishRequest{
+		Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE, OwnerFullName: "demo-image-app",
+		Version: "v1.0.0", Reason: "push failed", IdempotencyKey: "adopt-failed-fail",
+	}); err != nil {
+		t.Fatalf("FailPublish: %v", err)
+	}
+
+	adopted, err := artifactSrv.AdoptArtifact(ctx, &pb.AdoptArtifactRequest{
+		Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE, OwnerFullName: "demo-image-app",
+		Version: "v1.0.0", Digest: "sha256:adopted-after-failure",
+		Reason: "confirmed pushed despite recording failure", IdempotencyKey: "adopt-failed-adopt",
+	})
+	if err != nil {
+		t.Fatalf("AdoptArtifact over a failed row: %v", err)
+	}
+	if adopted.Artifact.State != pb.ArtifactState_ARTIFACT_STATE_PUBLISHED {
+		t.Fatalf("expected PUBLISHED, got %v", adopted.Artifact.State)
+	}
+	if adopted.Artifact.Provenance != pb.ArtifactProvenance_ARTIFACT_PROVENANCE_ADOPTED {
+		t.Fatalf("expected ADOPTED provenance, got %v", adopted.Artifact.Provenance)
+	}
+	if adopted.Artifact.BuildId != build.BuildId {
+		t.Fatalf("expected the REAL CI build_id %q to be reused (not a synthetic one), got %q", build.BuildId, adopted.Artifact.BuildId)
+	}
+}
+
+// TestAdoptArtifact_ChartWithContains proves AdoptArtifact supports charts
+// too, with the same contains-linking RecordArtifact provides.
+func TestAdoptArtifact_ChartWithContains(t *testing.T) {
+	_, artifactSrv, _ := setup(t)
+	ctx := authedCtx()
+	build := recordBuild(t, artifactSrv, "run-adopt-chart-contains")
+
+	imgResp, err := artifactSrv.RecordArtifact(ctx, &pb.RecordArtifactRequest{
+		BuildId: build.BuildId, Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE,
+		OwnerFullName: "demo-chart-app", Digest: "sha256:chart-contains-image", Version: "v1.0.0",
+		IdempotencyKey: "chart-contains-image-1",
+	})
+	if err != nil {
+		t.Fatalf("record image: %v", err)
+	}
+
+	adopted, err := artifactSrv.AdoptArtifact(ctx, &pb.AdoptArtifactRequest{
+		Kind: pb.ArtifactKind_ARTIFACT_KIND_CHART, OwnerFullName: "demo-achart",
+		Version: "v1.0.0", Digest: "sha256:chart-contains-chart",
+		Contains: []*pb.ContainedImage{
+			{AppFullName: "demo-chart-app", Repository: "repo", Version: "v1.0.0", Digest: imgResp.Artifact.Digest},
+		},
+		Reason: "pre-registry chart", IdempotencyKey: "chart-contains-adopt-1",
+	})
+	if err != nil {
+		t.Fatalf("AdoptArtifact chart: %v", err)
+	}
+	if len(adopted.Artifact.Contains) != 1 || adopted.Artifact.Contains[0].Digest != imgResp.Artifact.Digest {
+		t.Fatalf("expected 1 contains link to the recorded image, got %+v", adopted.Artifact.Contains)
+	}
+}
+
+// TestListArtifacts_ProvenanceFilter is AR-7e's "distinguishable in one
+// query" exit criterion half.
+func TestListArtifacts_ProvenanceFilter(t *testing.T) {
+	_, artifactSrv, _ := setup(t)
+	ctx := authedCtx()
+	build := recordBuild(t, artifactSrv, "run-adopt-provenance")
+
+	if _, err := artifactSrv.RecordArtifact(ctx, &pb.RecordArtifactRequest{
+		BuildId: build.BuildId, Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE,
+		OwnerFullName: "demo-image-app", Digest: "sha256:prov-observed", Version: "v1.0.0",
+		IdempotencyKey: "prov-observed-1",
+	}); err != nil {
+		t.Fatalf("record observed: %v", err)
+	}
+	if _, err := artifactSrv.AdoptArtifact(ctx, &pb.AdoptArtifactRequest{
+		Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE, OwnerFullName: "demo-image-app",
+		Version: "v2.0.0", Digest: "sha256:prov-adopted",
+		Reason: "pre-registry", IdempotencyKey: "prov-adopted-1",
+	}); err != nil {
+		t.Fatalf("adopt: %v", err)
+	}
+
+	resp, err := artifactSrv.ListArtifacts(ctx, &pb.ListArtifactsRequest{
+		OwnerFullName: "demo-image-app", Provenance: pb.ArtifactProvenance_ARTIFACT_PROVENANCE_ADOPTED,
+	})
+	if err != nil {
+		t.Fatalf("ListArtifacts: %v", err)
+	}
+	if len(resp.Artifacts) != 1 || resp.Artifacts[0].Digest != "sha256:prov-adopted" {
+		t.Fatalf("expected exactly the adopted artifact, got %+v", resp.Artifacts)
+	}
+}
+
+// TestAdoptArtifact_ValidatesRequiredFields covers the handler's own
+// validation, independent of authorization (authz_test.go) or repository
+// state-machine rejections (the tests above).
+func TestAdoptArtifact_ValidatesRequiredFields(t *testing.T) {
+	_, artifactSrv, _ := setup(t)
+	ctx := authedCtx()
+
+	base := func() *pb.AdoptArtifactRequest {
+		return &pb.AdoptArtifactRequest{
+			Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE, OwnerFullName: "demo-image-app",
+			Version: "v1.0.0", Digest: "sha256:validate", Reason: "test", IdempotencyKey: "validate-1",
+		}
+	}
+
+	t.Run("missing reason", func(t *testing.T) {
+		req := base()
+		req.Reason = ""
+		_, err := artifactSrv.AdoptArtifact(ctx, req)
+		requireCode(t, err, codes.InvalidArgument, "AdoptArtifact missing reason")
+	})
+
+	t.Run("missing digest", func(t *testing.T) {
+		req := base()
+		req.Digest = ""
+		_, err := artifactSrv.AdoptArtifact(ctx, req)
+		requireCode(t, err, codes.InvalidArgument, "AdoptArtifact missing digest")
+	})
+
+	t.Run("bad version", func(t *testing.T) {
+		req := base()
+		req.Version = "not-semver"
+		_, err := artifactSrv.AdoptArtifact(ctx, req)
+		requireCode(t, err, codes.InvalidArgument, "AdoptArtifact bad version")
+	})
+
+	t.Run("missing idempotency key", func(t *testing.T) {
+		req := base()
+		req.IdempotencyKey = ""
+		_, err := artifactSrv.AdoptArtifact(ctx, req)
+		requireCode(t, err, codes.InvalidArgument, "AdoptArtifact missing idempotency key")
+	})
+
+	t.Run("contains on an image", func(t *testing.T) {
+		req := base()
+		req.Contains = []*pb.ContainedImage{{AppFullName: "demo-image-app", Digest: "sha256:x"}}
+		_, err := artifactSrv.AdoptArtifact(ctx, req)
+		requireCode(t, err, codes.InvalidArgument, "AdoptArtifact contains on an image")
+	})
+}

--- a/tools/app_registry/server/handlers/authz_test.go
+++ b/tools/app_registry/server/handlers/authz_test.go
@@ -280,6 +280,47 @@ func TestFailPublish_Authorization(t *testing.T) {
 	// artifact_test.go (owner resolution requires a real app).
 }
 
+// TestAdoptArtifact_Authorization covers ArtifactRegistry.AdoptArtifact
+// (AR-7e, issue #558), which requires RoleAdmin -- deliberately NOT
+// RoleBuilder, unlike RecordBuild/RecordArtifact/BeginPublish/FailPublish
+// above. This is the security-critical line of the whole phase: the builder
+// credential is what every CI job holds, and CI must never be able to
+// assert an artifact into existence that it did not observe being
+// published -- see ARCHITECTURE.md "Authorization" and "Adoption and
+// disaster recovery".
+func TestAdoptArtifact_Authorization(t *testing.T) {
+	req := &pb.AdoptArtifactRequest{
+		Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE, OwnerFullName: "demo-svc",
+		Version: "v1.0.0", Digest: "sha256:authz-adopt", Reason: "authz test",
+		IdempotencyKey: "authz-adopt",
+	}
+
+	t.Run("builder credential is PermissionDenied", func(t *testing.T) {
+		srv := NewArtifactServer(fake.New())
+		// The builder credential holds real power over RecordBuild/
+		// RecordArtifact/BeginPublish/FailPublish -- none over AdoptArtifact.
+		_, err := srv.AdoptArtifact(ctxWithRoles(auth.RoleBuilder), req)
+		requireCode(t, err, codes.PermissionDenied, "AdoptArtifact as builder")
+	})
+
+	t.Run("admin credential allowed through to business logic", func(t *testing.T) {
+		srv := NewArtifactServer(fake.New())
+		// The request fails downstream (unknown owner -- no app named
+		// "demo-svc" was ever reconciled in this fake), which is exactly how
+		// we know auth let it through instead of stopping it.
+		_, err := srv.AdoptArtifact(ctxWithRoles(auth.RoleAdmin), req)
+		if status.Code(err) == codes.Unauthenticated || status.Code(err) == codes.PermissionDenied {
+			t.Fatalf("expected admin to pass authorization for AdoptArtifact, got %v", err)
+		}
+	})
+
+	t.Run("no claims is Unauthenticated", func(t *testing.T) {
+		srv := NewArtifactServer(fake.New())
+		_, err := srv.AdoptArtifact(context.Background(), req)
+		requireCode(t, err, codes.Unauthenticated, "AdoptArtifact")
+	})
+}
+
 // TestArtifactReads_RequireAuthenticationOnly covers ListArtifacts,
 // GetArtifact, and ResolveArtifact: any authenticated principal, no
 // specific role.

--- a/tools/app_registry/server/handlers/convert.go
+++ b/tools/app_registry/server/handlers/convert.go
@@ -111,6 +111,22 @@ func artifactProvenanceToPB(p repository.ArtifactProvenance) pb.ArtifactProvenan
 	}
 }
 
+// artifactProvenanceFromPB is the inverse of artifactProvenanceToPB --
+// AR-7e (issue #558), backing ListArtifactsRequest.provenance /
+// ArtifactListFilter.Provenance. UNSPECIFIED maps to "" (every provenance,
+// no filter), matching every other *FromPB "no filter" convention in this
+// file (e.g. artifactKindFromPB).
+func artifactProvenanceFromPB(p pb.ArtifactProvenance) repository.ArtifactProvenance {
+	switch p {
+	case pb.ArtifactProvenance_ARTIFACT_PROVENANCE_OBSERVED:
+		return repository.ArtifactProvenanceObserved
+	case pb.ArtifactProvenance_ARTIFACT_PROVENANCE_ADOPTED:
+		return repository.ArtifactProvenanceAdopted
+	default:
+		return ""
+	}
+}
+
 func versionSourceToPB(v repository.VersionSource) pb.VersionSource {
 	switch v {
 	case repository.VersionSourceRegistry:

--- a/tools/app_registry/server/repository/fake/fake.go
+++ b/tools/app_registry/server/repository/fake/fake.go
@@ -374,7 +374,7 @@ func (r *Registry) RecordArtifact(ctx context.Context, a repository.Artifact, co
 			return nil, false, fmt.Errorf("%w: no publishing artifact found for %s %s -- BeginPublish must run before RecordArtifact once a domain has left adoption stage \"observe\"",
 				repository.ErrFailedPrecondition, r.ownerFullName(a), a.Version)
 		}
-		out, err := r.insertArtifact(a, contains, repository.ArtifactStatePublished, repository.VersionSourceTag)
+		out, err := r.insertArtifact(a, contains, repository.ArtifactStatePublished, repository.VersionSourceTag, repository.ArtifactProvenanceObserved)
 		return out, false, err
 	}
 
@@ -415,18 +415,19 @@ func ownerID(a repository.Artifact) string {
 }
 
 // insertArtifact mirrors postgres's artifactRepo.insertArtifact: writes a
-// brand-new artifact row directly in state, with versionSource and
-// Provenance "observed" -- shared by RecordArtifact's direct-create path,
-// BeginPublish's ∅ -> publishing branch, and AllocateVersion's ∅ ->
-// allocated write. As of AR-7c (migration 008), Promotability is resolved
-// and STORED here -- once, only when state is reaching
-// ArtifactStatePublished -- never re-derived on a later read. See
-// repository.Artifact.Promotability's doc comment for why this is the
-// retroactivity fix, not just a refactor.
-func (r *Registry) insertArtifact(a repository.Artifact, contains []repository.ContainedImageInput, state repository.ArtifactState, versionSource repository.VersionSource) (*repository.Artifact, error) {
+// brand-new artifact row directly in state, with the given versionSource/
+// provenance -- shared by RecordArtifact's direct-create path (always
+// ArtifactProvenanceObserved), BeginPublish's ∅ -> publishing branch,
+// AllocateVersion's ∅ -> allocated write, and AdoptArtifact's (AR-7e, issue
+// #558) ∅ -> published branch (ArtifactProvenanceAdopted). As of AR-7c
+// (migration 008), Promotability is resolved and STORED here -- once, only
+// when state is reaching ArtifactStatePublished -- never re-derived on a
+// later read. See repository.Artifact.Promotability's doc comment for why
+// this is the retroactivity fix, not just a refactor.
+func (r *Registry) insertArtifact(a repository.Artifact, contains []repository.ContainedImageInput, state repository.ArtifactState, versionSource repository.VersionSource, provenance repository.ArtifactProvenance) (*repository.Artifact, error) {
 	a.ArtifactID = uuid.NewString()
 	a.State = state
-	a.Provenance = repository.ArtifactProvenanceObserved
+	a.Provenance = provenance
 	a.VersionSource = versionSource
 	a.StateChangedAt = timeNow()
 	if state == repository.ArtifactStatePublished {
@@ -467,6 +468,101 @@ func (r *Registry) completePublish(existing, a repository.Artifact, contains []r
 	}
 	updated.State = repository.ArtifactStatePublished
 	updated.StateChangedAt = timeNow()
+	updated.Promotability = r.derivePromotability(updated)
+
+	if updated.Kind == repository.ArtifactKindChart {
+		links, err := r.linkContains(contains)
+		if err != nil {
+			return nil, err
+		}
+		updated.Contains = links
+	}
+
+	r.state.Artifacts[updated.ArtifactID] = updated
+	out := updated
+	return &out, nil
+}
+
+// ============================================================================
+// AdoptArtifact (AR-7e, issue #558)
+// ============================================================================
+
+// AdoptArtifact mirrors postgres's artifactRepo.AdoptArtifact -- the
+// admin-only adoption / disaster-recovery path. See
+// repository.ArtifactRepository.AdoptArtifact's doc comment for the full
+// state-collision contract.
+func (r *Registry) AdoptArtifact(ctx context.Context, a repository.Artifact, contains []repository.ContainedImageInput, reason, actor string) (*repository.Artifact, bool, error) {
+	// 1. Idempotent replay by digest -- see postgres's AdoptArtifact step 1
+	// for why Provenance/State are never rewritten here.
+	for _, existing := range r.state.Artifacts {
+		if existing.Digest != "" && existing.Digest == a.Digest {
+			out := existing
+			return &out, true, nil
+		}
+	}
+
+	existing, found := r.findByOwnerKindVersion(a.Kind, ownerID(a), a.Version)
+	if !found {
+		out, err := r.adoptNew(a, contains, actor)
+		return out, false, err
+	}
+
+	switch existing.State {
+	case repository.ArtifactStateFailed:
+		out, err := r.completeAdoption(existing, a, contains, actor)
+		return out, false, err
+	case repository.ArtifactStatePublished:
+		return nil, false, fmt.Errorf("%w: artifact %s %s already published with digest %s",
+			repository.ErrAlreadyExists, r.ownerFullName(existing), a.Version, existing.Digest)
+	default: // allocated, publishing
+		return nil, false, fmt.Errorf("%w: artifact %s %s is %q -- AdoptArtifact only applies when there is no row, or the row is \"failed\"; a live allocation/publish must be let run its course (or explicitly failed via FailPublish) before it can be adopted",
+			repository.ErrFailedPrecondition, r.ownerFullName(existing), a.Version, existing.State)
+	}
+}
+
+// createAdoptionBuild mirrors postgres's artifactRepo.createAdoptionBuild:
+// a synthetic `build` row backing an adopted artifact, since by definition
+// there is no real CI run behind a pre-registry artifact.
+func (r *Registry) createAdoptionBuild(actor string) string {
+	buildID := uuid.NewString()
+	r.state.Builds[buildID] = repository.Build{
+		BuildID:         buildID,
+		GitRef:          "adopted",
+		WorkflowRunID:   "adopted:" + uuid.NewString(),
+		WorkflowAttempt: 1,
+		Actor:           actor,
+		RecordedAt:      timeNow(),
+	}
+	return buildID
+}
+
+// adoptNew mirrors postgres's artifactRepo.adoptNew: AdoptArtifact's ∅ ->
+// published(adopted) branch.
+func (r *Registry) adoptNew(a repository.Artifact, contains []repository.ContainedImageInput, actor string) (*repository.Artifact, error) {
+	a.BuildID = r.createAdoptionBuild(actor)
+	return r.insertArtifact(a, contains, repository.ArtifactStatePublished, repository.VersionSourceTag, repository.ArtifactProvenanceAdopted)
+}
+
+// completeAdoption mirrors postgres's artifactRepo.completeAdoption:
+// AdoptArtifact's failed -> published(adopted) branch, reusing the existing
+// row's build_id when it already has one (a "failed" row reaped from
+// "publishing" does; one reaped from "allocated" does not).
+func (r *Registry) completeAdoption(existing, a repository.Artifact, contains []repository.ContainedImageInput, actor string) (*repository.Artifact, error) {
+	updated := existing
+	updated.Digest = a.Digest
+	if existing.BuildID != "" {
+		updated.BuildID = existing.BuildID
+	} else {
+		updated.BuildID = r.createAdoptionBuild(actor)
+	}
+	updated.PublishedAt = a.PublishedAt
+	if updated.PublishedAt.IsZero() {
+		updated.PublishedAt = timeNow()
+	}
+	updated.State = repository.ArtifactStatePublished
+	updated.Provenance = repository.ArtifactProvenanceAdopted
+	updated.StateChangedAt = timeNow()
+	updated.FailReason = ""
 	updated.Promotability = r.derivePromotability(updated)
 
 	if updated.Kind == repository.ArtifactKindChart {
@@ -563,7 +659,7 @@ func (r *Registry) AllocateVersion(ctx context.Context, kind repository.Artifact
 	} else {
 		a.ChartID = owner
 	}
-	if _, err := r.insertArtifact(a, nil, repository.ArtifactStateAllocated, repository.VersionSourceRegistry); err != nil {
+	if _, err := r.insertArtifact(a, nil, repository.ArtifactStateAllocated, repository.VersionSourceRegistry, repository.ArtifactProvenanceObserved); err != nil {
 		return nil, err
 	}
 
@@ -588,7 +684,7 @@ func (r *Registry) BeginPublish(ctx context.Context, kind repository.ArtifactKin
 		} else {
 			a.ChartID = owner
 		}
-		return r.insertArtifact(a, nil, repository.ArtifactStatePublishing, versionSource)
+		return r.insertArtifact(a, nil, repository.ArtifactStatePublishing, versionSource, repository.ArtifactProvenanceObserved)
 	}
 
 	// AR-7d (issue #558): publishing -> publishing is a legal, idempotent
@@ -676,6 +772,10 @@ func (r *Registry) ListArtifacts(ctx context.Context, filter repository.Artifact
 		// GetReleaseRun's (AR-7d, issue #558) filter -- every artifact
 		// hanging off one build, any state.
 		if filter.BuildID != "" && a.BuildID != filter.BuildID {
+			continue
+		}
+		// AR-7e (issue #558): "which rows did we take on faith?" as a query.
+		if filter.Provenance != "" && a.Provenance != filter.Provenance {
 			continue
 		}
 		// Promotability is read directly off the stored row -- see

--- a/tools/app_registry/server/repository/models.go
+++ b/tools/app_registry/server/repository/models.go
@@ -231,6 +231,14 @@ type ArtifactLink struct {
 // heartbeat/re-arm of state_changed_at, not a no-op; see BeginPublish's own
 // doc comment for why this exists). published is terminal; anything else
 // is FailedPrecondition.
+//
+// AR-7e (issue #558) adds two more transitions, reachable ONLY through
+// ArtifactRepository.AdoptArtifact, never through BeginPublish/
+// RecordArtifact: ∅ -> published and failed -> published, both stamping
+// Provenance ArtifactProvenanceAdopted instead of ArtifactProvenanceObserved.
+// See AdoptArtifact's doc comment for the full state-collision table
+// (including why allocated/publishing reject, and why a same-digest
+// published row is an idempotent no-op rather than a rewrite).
 type ArtifactState string
 
 const (
@@ -341,6 +349,11 @@ type ArtifactListFilter struct {
 	Kind           ArtifactKind
 	PromotableOnly bool
 	BuildID        string
+	// Provenance filters to exactly one of ArtifactProvenanceObserved /
+	// ArtifactProvenanceAdopted when set; empty means every provenance —
+	// AR-7e (issue #558), the query "which rows did we take on faith?" the
+	// exit criterion asks for. See ListArtifactsRequest.provenance.
+	Provenance ArtifactProvenance
 }
 
 // ArtifactLookup identifies an artifact by exactly one of the supported

--- a/tools/app_registry/server/repository/postgres/artifact.go
+++ b/tools/app_registry/server/repository/postgres/artifact.go
@@ -212,7 +212,7 @@ func (r *artifactRepo) RecordArtifact(ctx context.Context, a repository.Artifact
 			return nil, false, fmt.Errorf("%w: no publishing artifact found for %s %s -- BeginPublish must run before RecordArtifact once a domain has left adoption stage \"observe\"",
 				repository.ErrFailedPrecondition, r.ownerFullName(ctx, a), a.Version)
 		}
-		out, _, err := r.insertArtifact(ctx, a, contains, repository.ArtifactStatePublished, repository.VersionSourceTag)
+		out, _, err := r.insertArtifact(ctx, a, contains, repository.ArtifactStatePublished, repository.VersionSourceTag, repository.ArtifactProvenanceObserved)
 		return out, false, err
 	case everr != nil:
 		return nil, false, everr
@@ -360,19 +360,21 @@ func (r *artifactRepo) latestChartManifestID(ctx context.Context, ownerID, prefe
 	return id, nil
 }
 
-// insertArtifact writes a brand-new artifact row directly in state, with
-// versionSource and Provenance "observed" (the only provenance this phase
-// ever writes -- see ArtifactProvenance's doc comment). digest/build_id/
-// published_at are written NULL when the corresponding field on a is empty
-// -- correct for "allocated" (neither) and "publishing" (build_id only);
-// contains is only consulted when state == published (RecordArtifact's
-// direct-create path); BeginPublish and AllocateVersion always pass nil.
-// Shared by RecordArtifact's direct-create path, BeginPublish's ∅ ->
-// publishing branch, and AllocateVersion's ∅ -> allocated write.
-func (r *artifactRepo) insertArtifact(ctx context.Context, a repository.Artifact, contains []repository.ContainedImageInput, state repository.ArtifactState, versionSource repository.VersionSource) (*repository.Artifact, bool, error) {
+// insertArtifact writes a brand-new artifact row directly in state, with the
+// given versionSource/provenance. digest/build_id/published_at are written
+// NULL when the corresponding field on a is empty -- correct for "allocated"
+// (neither) and "publishing" (build_id only); contains is only consulted
+// when state == published (RecordArtifact's direct-create path and
+// AdoptArtifact's ∅ -> published path); BeginPublish and AllocateVersion
+// always pass nil. Shared by RecordArtifact's direct-create path (provenance
+// always ArtifactProvenanceObserved -- the only value this phase ever wrote
+// before AR-7e), BeginPublish's ∅ -> publishing branch, AllocateVersion's
+// ∅ -> allocated write, and AdoptArtifact's (AR-7e, issue #558) ∅ ->
+// published branch (provenance ArtifactProvenanceAdopted).
+func (r *artifactRepo) insertArtifact(ctx context.Context, a repository.Artifact, contains []repository.ContainedImageInput, state repository.ArtifactState, versionSource repository.VersionSource, provenance repository.ArtifactProvenance) (*repository.Artifact, bool, error) {
 	a.ArtifactID = uuid.NewString()
 	a.State = state
-	a.Provenance = repository.ArtifactProvenanceObserved
+	a.Provenance = provenance
 	a.VersionSource = versionSource
 	a.StateChangedAt = time.Now().UTC()
 	if state == repository.ArtifactStatePublished && a.PublishedAt.IsZero() {
@@ -492,6 +494,150 @@ func (r *artifactRepo) completePublish(ctx context.Context, existing, a reposito
 	return r.GetArtifact(ctx, repository.ArtifactLookup{ArtifactID: existing.ArtifactID})
 }
 
+// ============================================================================
+// AdoptArtifact (AR-7e, issue #558)
+// ============================================================================
+
+// AdoptArtifact implements repository.ArtifactRepository.AdoptArtifact --
+// the admin-only adoption / disaster-recovery path. See the interface doc
+// comment for the full state-collision contract this method enforces.
+func (r *artifactRepo) AdoptArtifact(ctx context.Context, a repository.Artifact, contains []repository.ContainedImageInput, reason, actor string) (*repository.Artifact, bool, error) {
+	// 1. Idempotent replay by digest, same shape as RecordArtifact's step 1:
+	// an existing PUBLISHED row (observed OR previously adopted) with this
+	// EXACT digest is "already recorded" -- returned completely unchanged.
+	// Provenance/State are never rewritten here, on purpose: adopting a
+	// digest that turns out to already be an "observed" row must not
+	// downgrade it to "adopted" -- that would corrupt the exact audit trail
+	// this RPC exists to provide.
+	row := r.ex.QueryRow(ctx, artifactSelectBase+` WHERE a.digest = $1`, a.Digest)
+	if existing, err := scanArtifact(row); err == nil {
+		if existing.Kind == repository.ArtifactKindChart {
+			links, lerr := r.loadContains(ctx, existing.ArtifactID)
+			if lerr != nil {
+				return nil, false, lerr
+			}
+			existing.Contains = links
+		}
+		return &existing, true, nil
+	} else if !errors.Is(err, pgx.ErrNoRows) {
+		return nil, false, err
+	}
+
+	// 2. No row shares this digest. Look for one by (owner, kind, version).
+	existing, everr := r.findByOwnerKindVersion(ctx, a.Kind, ownerIDOf(a), a.Version)
+	switch {
+	case errors.Is(everr, pgx.ErrNoRows):
+		// ∅ -> published (adopted): the primary case.
+		out, err := r.adoptNew(ctx, a, contains, actor)
+		return out, false, err
+	case everr != nil:
+		return nil, false, everr
+	}
+
+	switch existing.State {
+	case repository.ArtifactStateFailed:
+		// failed -> published (adopted): the disaster-recovery case -- a run
+		// already tried and gave up (or the reaper reaped it), but the
+		// artifact demonstrably exists. See ArtifactRepository.AdoptArtifact's
+		// doc comment for why the existing build_id is reused when present.
+		out, err := r.completeAdoption(ctx, existing, a, contains, actor)
+		return out, false, err
+	case repository.ArtifactStatePublished:
+		// Reached only when the digest lookup in step 1 missed -- a
+		// DIFFERENT digest than what is already published for this
+		// (owner, kind, version). A real conflict, not a retry -- adoption
+		// must not silently overwrite a different recorded digest.
+		return nil, false, fmt.Errorf("%w: artifact %s %s already published with digest %s",
+			repository.ErrAlreadyExists, r.ownerFullName(ctx, existing), a.Version, existing.Digest)
+	default: // allocated, publishing
+		return nil, false, fmt.Errorf("%w: artifact %s %s is %q -- AdoptArtifact only applies when there is no row, or the row is \"failed\"; a live allocation/publish must be let run its course (or explicitly failed via FailPublish) before it can be adopted",
+			repository.ErrFailedPrecondition, r.ownerFullName(ctx, existing), a.Version, existing.State)
+	}
+}
+
+// createAdoptionBuild inserts a synthetic `build` row backing an adopted
+// artifact. AdoptArtifact still needs SOME build_id: migration 007's
+// artifact_state_shape CHECK requires one once a row reaches "published",
+// and artifact.build_id is a real foreign key into `build` -- but by
+// definition there is no CI run behind a pre-registry artifact.
+// workflow_run_id is stamped "adopted:<uuid>", deliberately non-numeric so
+// it can never collide with a real GitHub Actions run id and reads as
+// synthetic at a glance in `builds status`/GetReleaseRun output; git_ref
+// carries the same "adopted" marker. git_sha is empty -- genuinely unknown
+// for a pre-registry artifact. actor is the calling admin's own identity
+// (grpcauth Subject), not a service account.
+func (r *artifactRepo) createAdoptionBuild(ctx context.Context, actor string) (string, error) {
+	buildID := uuid.NewString()
+	now := time.Now().UTC()
+	if _, err := r.ex.Exec(ctx, `
+		INSERT INTO build (build_id, git_sha, git_ref, workflow_run_id, workflow_attempt, actor, recorded_at)
+		VALUES ($1, '', 'adopted', $2, 1, $3, $4)`,
+		buildID, "adopted:"+uuid.NewString(), actor, now); err != nil {
+		return "", fmt.Errorf("create synthetic build for adoption: %w", err)
+	}
+	return buildID, nil
+}
+
+// adoptNew is AdoptArtifact's ∅ -> published(adopted) branch: no row exists
+// at all for (owner, kind, version) yet.
+func (r *artifactRepo) adoptNew(ctx context.Context, a repository.Artifact, contains []repository.ContainedImageInput, actor string) (*repository.Artifact, error) {
+	buildID, err := r.createAdoptionBuild(ctx, actor)
+	if err != nil {
+		return nil, err
+	}
+	a.BuildID = buildID
+	out, _, err := r.insertArtifact(ctx, a, contains, repository.ArtifactStatePublished, repository.VersionSourceTag, repository.ArtifactProvenanceAdopted)
+	return out, err
+}
+
+// completeAdoption is AdoptArtifact's failed -> published(adopted) branch,
+// against an EXISTING "failed" row. If that row already carries a build_id
+// (true whenever the reaper reaped a "publishing" row; false when it reaped
+// an "allocated" row, which never had one), it is reused rather than
+// minting a synthetic one -- the real CI run that actually attempted the
+// push is more honest provenance than a synthetic placeholder. Otherwise
+// falls back to a synthetic build row, same as adoptNew.
+func (r *artifactRepo) completeAdoption(ctx context.Context, existing, a repository.Artifact, contains []repository.ContainedImageInput, actor string) (*repository.Artifact, error) {
+	buildID := existing.BuildID
+	if buildID == "" {
+		var err error
+		buildID, err = r.createAdoptionBuild(ctx, actor)
+		if err != nil {
+			return nil, err
+		}
+	}
+	publishedAt := a.PublishedAt
+	if publishedAt.IsZero() {
+		publishedAt = time.Now().UTC()
+	}
+	now := time.Now().UTC()
+
+	manifestID, promotability, err := r.resolveManifestForPublish(ctx, existing.Kind, ownerIDOf(existing), buildID)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := r.ex.Exec(ctx, `
+		UPDATE artifact SET digest = $1, build_id = $2, published_at = $3, state = 'published', state_changed_at = $4,
+		                     provenance = 'adopted', manifest_id = $5, promotability = $6, fail_reason = ''
+		WHERE artifact_id = $7`,
+		a.Digest, buildID, publishedAt, now, manifestID, string(promotability), existing.ArtifactID); err != nil {
+		msg := fmt.Sprintf("artifact %s already recorded", a.Digest)
+		if de, ok := translatePgError(err, msg); ok {
+			return nil, de
+		}
+		return nil, fmt.Errorf("complete adoption for artifact %s: %w", existing.ArtifactID, err)
+	}
+
+	if existing.Kind == repository.ArtifactKindChart {
+		if err := r.linkContains(ctx, existing.ArtifactID, a.Digest, contains); err != nil {
+			return nil, err
+		}
+	}
+
+	return r.GetArtifact(ctx, repository.ArtifactLookup{ArtifactID: existing.ArtifactID})
+}
+
 // linkContains inserts one artifact_link row per entry in contains,
 // pinning chartArtifactID to each already-PUBLISHED image digest. A chart
 // may not pin an image that either doesn't exist or hasn't reached
@@ -550,7 +696,7 @@ func (r *artifactRepo) BeginPublish(ctx context.Context, kind repository.Artifac
 		} else {
 			a.ChartID = ownerID
 		}
-		out, _, err := r.insertArtifact(ctx, a, nil, repository.ArtifactStatePublishing, versionSource)
+		out, _, err := r.insertArtifact(ctx, a, nil, repository.ArtifactStatePublishing, versionSource, repository.ArtifactProvenanceObserved)
 		return out, err
 	case everr != nil:
 		return nil, everr
@@ -673,6 +819,12 @@ func (r *artifactRepo) ListArtifacts(ctx context.Context, filter repository.Arti
 	if filter.OwnerFullName != "" {
 		args = append(args, filter.OwnerFullName)
 		query += fmt.Sprintf(" AND (app.domain || '-' || app.name = $%d OR chart.domain || '-' || chart.name = $%d)", len(args), len(args))
+	}
+	// AR-7e (issue #558): "which rows did we take on faith?" as a query --
+	// the exit criterion's "distinguishable in one query" half.
+	if filter.Provenance != "" {
+		args = append(args, string(filter.Provenance))
+		query += fmt.Sprintf(" AND a.provenance = $%d", len(args))
 	}
 	// GetReleaseRun's (AR-7d, issue #558) query: every artifact hanging off
 	// one build, any state. Ordered by state_changed_at rather than
@@ -854,7 +1006,7 @@ func (r *artifactRepo) AllocateVersion(ctx context.Context, kind repository.Arti
 	} else {
 		a.ChartID = ownerID
 	}
-	if _, _, err := r.insertArtifact(ctx, a, nil, repository.ArtifactStateAllocated, repository.VersionSourceRegistry); err != nil {
+	if _, _, err := r.insertArtifact(ctx, a, nil, repository.ArtifactStateAllocated, repository.VersionSourceRegistry, repository.ArtifactProvenanceObserved); err != nil {
 		return nil, err
 	}
 

--- a/tools/app_registry/server/repository/postgres/postgres_integration_test.go
+++ b/tools/app_registry/server/repository/postgres/postgres_integration_test.go
@@ -20,6 +20,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -3362,4 +3363,314 @@ func TestBeginPublish_ReapThenRevive_Postgres(t *testing.T) {
 	if published.Digest != "sha256:reap-revive" {
 		t.Fatalf("expected digest stamped, got %q", published.Digest)
 	}
+}
+
+// ============================================================================
+// AdoptArtifact (AR-7e, issue #558)
+// ============================================================================
+
+// adoptArtifactTx runs Artifacts().AdoptArtifact inside a real WithTx
+// transaction, exactly as handlers.ArtifactServer.AdoptArtifact does in
+// production.
+func adoptArtifactTx(t *testing.T, reg *Registry, a repository.Artifact, contains []repository.ContainedImageInput, reason, actor string) (*repository.Artifact, bool, error) {
+	t.Helper()
+	var out *repository.Artifact
+	var already bool
+	err := reg.WithTx(context.Background(), func(ctx context.Context, r repository.Registry) error {
+		var ferr error
+		out, already, ferr = r.Artifacts().AdoptArtifact(ctx, a, contains, reason, actor)
+		return ferr
+	})
+	return out, already, err
+}
+
+// TestAdoptArtifact_NewRow_CreatesSyntheticBuild_Postgres is AdoptArtifact's
+// primary case against real Postgres: no row exists for (owner, kind,
+// version) yet, so a synthetic `build` row is created to satisfy
+// artifact.build_id's real foreign key and migration 007's
+// artifact_state_shape CHECK (build_id NOT NULL once "published"). Proves
+// the synthetic row's shape: a non-numeric workflow_run_id that can never
+// collide with a real GitHub Actions run id, and git_ref "adopted" as the
+// same at-a-glance marker.
+func TestAdoptArtifact_NewRow_CreatesSyntheticBuild_Postgres(t *testing.T) {
+	reg, pool := newTestRegistry(t)
+	appID := seedApp(t, pool, "acme", "adopt-new", "image")
+
+	adopted, alreadyRecorded, err := adoptArtifactTx(t, reg, repository.Artifact{
+		Kind: repository.ArtifactKindImage, AppID: appID,
+		Repository: "ghcr.io/acme/adopt-new", Version: "v0.9.0", Digest: "sha256:adopt-new-pg",
+	}, nil, "pre-dates the registry", "admin@example.com")
+	if err != nil {
+		t.Fatalf("AdoptArtifact (∅ -> published): %v", err)
+	}
+	if alreadyRecorded {
+		t.Fatal("expected alreadyRecorded=false for a brand-new adoption")
+	}
+	if adopted.State != repository.ArtifactStatePublished {
+		t.Fatalf("expected state published, got %q", adopted.State)
+	}
+	if adopted.Provenance != repository.ArtifactProvenanceAdopted {
+		t.Fatalf("expected provenance adopted, got %q", adopted.Provenance)
+	}
+	if adopted.BuildID == "" {
+		t.Fatal("expected a build_id to be stamped")
+	}
+
+	var gitRef, workflowRunID, actor string
+	if err := pool.QueryRow(context.Background(),
+		`SELECT git_ref, workflow_run_id, actor FROM build WHERE build_id = $1`, adopted.BuildID,
+	).Scan(&gitRef, &workflowRunID, &actor); err != nil {
+		t.Fatalf("read synthetic build row: %v", err)
+	}
+	if gitRef != "adopted" {
+		t.Fatalf("expected synthetic build's git_ref = %q, got %q", "adopted", gitRef)
+	}
+	if !strings.HasPrefix(workflowRunID, "adopted:") {
+		t.Fatalf("expected synthetic build's workflow_run_id to start with %q, got %q", "adopted:", workflowRunID)
+	}
+	if actor != "admin@example.com" {
+		t.Fatalf("expected synthetic build's actor to be the calling admin, got %q", actor)
+	}
+}
+
+// TestAdoptArtifact_UnblocksChartPin_Postgres is PLAN.md's AR-7e exit
+// criterion against real Postgres, exercised through the handler layer end
+// to end: a chart record fails on an unrecorded pin (simulating an image
+// published before the registry existed), and adopting the image unblocks
+// the SAME chart record -- one documented, audited command.
+func TestAdoptArtifact_UnblocksChartPin_Postgres(t *testing.T) {
+	reg, _ := newTestRegistry(t)
+	ctx := authedCtx()
+	appSrv := handlers.NewAppServer(reg)
+	artSrv := handlers.NewArtifactServer(reg)
+
+	if _, err := appSrv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
+		Manifests: reconcileManifests("sha-adopt-unblock", 100, 100,
+			[]*appmetapb.AppManifest{oneAppManifest("acme", "adopt-unblock-app")},
+			[]*appmetapb.ChartManifest{{Domain: "acme", Name: "adopt-unblock-chart", Apps: []string{"adopt-unblock-app"}}}),
+		IdempotencyKey: "adopt-unblock-reconcile",
+	}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	build, err := artSrv.RecordBuild(ctx, &pb.RecordBuildRequest{
+		GitSha: "sha-adopt-unblock", WorkflowRunId: "run-adopt-unblock-pg", IdempotencyKey: "adopt-unblock-build",
+	})
+	if err != nil {
+		t.Fatalf("record build: %v", err)
+	}
+
+	// Fails first: the pinned image was never recorded.
+	_, err = artSrv.RecordArtifact(ctx, &pb.RecordArtifactRequest{
+		BuildId: build.Build.BuildId, Kind: pb.ArtifactKind_ARTIFACT_KIND_CHART,
+		OwnerFullName: "acme-adopt-unblock-chart", Digest: "sha256:adopt-unblock-chart-pg", Version: "v1.0.0",
+		Contains: []*pb.ContainedImage{
+			{AppFullName: "acme-adopt-unblock-app", Repository: "ghcr.io/acme/adopt-unblock-app", Version: "v0.9.0", Digest: "sha256:adopt-unblock-image-pg"},
+		},
+		IdempotencyKey: "adopt-unblock-chart-1",
+	})
+	if err == nil || status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("expected the chart record to reject the unrecorded pin first, got %v", err)
+	}
+
+	// Adopt the pre-registry image.
+	adoptResp, err := artSrv.AdoptArtifact(ctx, &pb.AdoptArtifactRequest{
+		Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE, OwnerFullName: "acme-adopt-unblock-app",
+		Repository: "ghcr.io/acme/adopt-unblock-app", Version: "v0.9.0", Digest: "sha256:adopt-unblock-image-pg",
+		Reason: "pre-dates the registry", IdempotencyKey: "adopt-unblock-adopt-1",
+	})
+	if err != nil {
+		t.Fatalf("AdoptArtifact: %v", err)
+	}
+	if adoptResp.Artifact.Provenance != pb.ArtifactProvenance_ARTIFACT_PROVENANCE_ADOPTED {
+		t.Fatalf("expected ADOPTED provenance, got %v", adoptResp.Artifact.Provenance)
+	}
+
+	// The SAME chart record now succeeds.
+	chartResp, err := artSrv.RecordArtifact(ctx, &pb.RecordArtifactRequest{
+		BuildId: build.Build.BuildId, Kind: pb.ArtifactKind_ARTIFACT_KIND_CHART,
+		OwnerFullName: "acme-adopt-unblock-chart", Digest: "sha256:adopt-unblock-chart-pg", Version: "v1.0.0",
+		Contains: []*pb.ContainedImage{
+			{AppFullName: "acme-adopt-unblock-app", Repository: "ghcr.io/acme/adopt-unblock-app", Version: "v0.9.0", Digest: "sha256:adopt-unblock-image-pg"},
+		},
+		IdempotencyKey: "adopt-unblock-chart-2",
+	})
+	if err != nil {
+		t.Fatalf("RecordArtifact after adoption should succeed: %v", err)
+	}
+	if len(chartResp.Artifact.Contains) != 1 || chartResp.Artifact.Contains[0].Digest != "sha256:adopt-unblock-image-pg" {
+		t.Fatalf("expected the chart to pin the adopted image, got %+v", chartResp.Artifact.Contains)
+	}
+
+	// "distinguishable in one query": the image is ADOPTED, the chart is
+	// OBSERVED, in one ListArtifacts(Provenance=ADOPTED) call.
+	adoptedOnly, err := reg.Artifacts().ListArtifacts(context.Background(), repository.ArtifactListFilter{Provenance: repository.ArtifactProvenanceAdopted})
+	if err != nil {
+		t.Fatalf("ListArtifacts(Provenance=adopted): %v", err)
+	}
+	if len(adoptedOnly) != 1 || adoptedOnly[0].Digest != "sha256:adopt-unblock-image-pg" {
+		t.Fatalf("expected exactly the adopted image, got %+v", adoptedOnly)
+	}
+}
+
+// TestAdoptArtifact_NeverDowngradesObservedProvenance_Postgres is the
+// critical invariant against real Postgres: adopting a digest that turns
+// out to already be an "observed" row must be an idempotent no-op, never a
+// rewrite.
+func TestAdoptArtifact_NeverDowngradesObservedProvenance_Postgres(t *testing.T) {
+	reg, pool := newTestRegistry(t)
+	appID := seedApp(t, pool, "acme", "adopt-no-downgrade", "image")
+	buildID := seedBuild(t, pool, "run-adopt-no-downgrade")
+
+	recorded, _, err := recordArtifactTx(t, reg, repository.Artifact{
+		Kind: repository.ArtifactKindImage, AppID: appID,
+		Repository: "ghcr.io/acme/adopt-no-downgrade", Version: "v1.0.0",
+		Digest: "sha256:observed-not-downgraded-pg", BuildID: buildID,
+	}, nil)
+	if err != nil {
+		t.Fatalf("seed observed artifact: %v", err)
+	}
+	if recorded.Provenance != repository.ArtifactProvenanceObserved {
+		t.Fatalf("expected provenance observed, got %q", recorded.Provenance)
+	}
+
+	adopted, alreadyRecorded, err := adoptArtifactTx(t, reg, repository.Artifact{
+		Kind: repository.ArtifactKindImage, AppID: appID,
+		Repository: "ghcr.io/acme/adopt-no-downgrade", Version: "v1.0.0",
+		Digest: "sha256:observed-not-downgraded-pg",
+	}, nil, "operator mistake -- already observed", "admin@example.com")
+	if err != nil {
+		t.Fatalf("AdoptArtifact against an already-observed digest should be an idempotent no-op, got %v", err)
+	}
+	if !alreadyRecorded {
+		t.Fatal("expected alreadyRecorded=true")
+	}
+	if adopted.Provenance != repository.ArtifactProvenanceObserved {
+		t.Fatalf("expected provenance to STAY observed (never downgraded to adopted), got %q", adopted.Provenance)
+	}
+	if adopted.BuildID != buildID {
+		t.Fatalf("expected the original build_id to be untouched, got %q vs %q", adopted.BuildID, buildID)
+	}
+}
+
+// TestAdoptArtifact_DifferentDigestConflict_Postgres proves adoption cannot
+// silently overwrite an already-published version with a different digest.
+func TestAdoptArtifact_DifferentDigestConflict_Postgres(t *testing.T) {
+	reg, pool := newTestRegistry(t)
+	appID := seedApp(t, pool, "acme", "adopt-conflict", "image")
+	buildID := seedBuild(t, pool, "run-adopt-conflict")
+
+	if _, _, err := recordArtifactTx(t, reg, repository.Artifact{
+		Kind: repository.ArtifactKindImage, AppID: appID,
+		Repository: "ghcr.io/acme/adopt-conflict", Version: "v1.0.0",
+		Digest: "sha256:adopt-conflict-original", BuildID: buildID,
+	}, nil); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	_, _, err := adoptArtifactTx(t, reg, repository.Artifact{
+		Kind: repository.ArtifactKindImage, AppID: appID,
+		Repository: "ghcr.io/acme/adopt-conflict", Version: "v1.0.0",
+		Digest: "sha256:adopt-conflict-different",
+	}, nil, "trying to overwrite", "admin@example.com")
+	if !errors.Is(err, repository.ErrAlreadyExists) {
+		t.Fatalf("expected ErrAlreadyExists, got %v", err)
+	}
+}
+
+// TestAdoptArtifact_RejectsLiveStateRows_Postgres proves adoption rejects
+// both an "allocated" row (a live version reservation) and a "publishing"
+// row (a live in-flight publish) -- adoption is for when there is NO row,
+// or a "failed" one, never a race against something still live.
+func TestAdoptArtifact_RejectsLiveStateRows_Postgres(t *testing.T) {
+	reg, pool := newTestRegistry(t)
+	appID := seedApp(t, pool, "acme", "adopt-live", "image")
+	buildID := seedBuild(t, pool, "run-adopt-live")
+
+	t.Run("allocated", func(t *testing.T) {
+		seedRawArtifact(t, pool, appID, repository.ArtifactStateAllocated, "v1.0.0", "")
+		_, _, err := adoptArtifactTx(t, reg, repository.Artifact{
+			Kind: repository.ArtifactKindImage, AppID: appID,
+			Repository: "ghcr.io/acme/adopt-live", Version: "v1.0.0",
+			Digest: "sha256:adopt-over-allocated-pg",
+		}, nil, "should be rejected", "admin@example.com")
+		if !errors.Is(err, repository.ErrFailedPrecondition) {
+			t.Fatalf("expected ErrFailedPrecondition adopting over an allocated row, got %v", err)
+		}
+	})
+
+	t.Run("publishing", func(t *testing.T) {
+		seedRawArtifact(t, pool, appID, repository.ArtifactStatePublishing, "v2.0.0", buildID)
+		_, _, err := adoptArtifactTx(t, reg, repository.Artifact{
+			Kind: repository.ArtifactKindImage, AppID: appID,
+			Repository: "ghcr.io/acme/adopt-live", Version: "v2.0.0",
+			Digest: "sha256:adopt-over-publishing-pg",
+		}, nil, "should be rejected", "admin@example.com")
+		if !errors.Is(err, repository.ErrFailedPrecondition) {
+			t.Fatalf("expected ErrFailedPrecondition adopting over a publishing row, got %v", err)
+		}
+	})
+}
+
+// TestAdoptArtifact_FailedRow_Postgres is the disaster-recovery case against
+// real Postgres: a run already tried and failed (or was reaped), but the
+// artifact demonstrably exists. Covers BOTH sub-cases of "does the failed
+// row already carry a build_id": a row reaped from "publishing" does (that
+// REAL build_id is reused); a row reaped from "allocated" does not (a
+// synthetic one is minted, same as the ∅ -> published branch).
+func TestAdoptArtifact_FailedRow_Postgres(t *testing.T) {
+	reg, pool := newTestRegistry(t)
+	appID := seedApp(t, pool, "acme", "adopt-failed", "image")
+	buildID := seedBuild(t, pool, "run-adopt-failed")
+
+	t.Run("reuses existing build_id when the failed row has one", func(t *testing.T) {
+		seedRawArtifact(t, pool, appID, repository.ArtifactStateFailed, "v1.0.0", buildID)
+		adopted, alreadyRecorded, err := adoptArtifactTx(t, reg, repository.Artifact{
+			Kind: repository.ArtifactKindImage, AppID: appID,
+			Repository: "ghcr.io/acme/adopt-failed", Version: "v1.0.0",
+			Digest: "sha256:adopt-failed-reuse-pg",
+		}, nil, "confirmed pushed despite recording failure", "admin@example.com")
+		if err != nil {
+			t.Fatalf("AdoptArtifact over a failed row with a build_id: %v", err)
+		}
+		if alreadyRecorded {
+			t.Fatal("expected alreadyRecorded=false")
+		}
+		if adopted.State != repository.ArtifactStatePublished {
+			t.Fatalf("expected state published, got %q", adopted.State)
+		}
+		if adopted.Provenance != repository.ArtifactProvenanceAdopted {
+			t.Fatalf("expected provenance adopted, got %q", adopted.Provenance)
+		}
+		if adopted.BuildID != buildID {
+			t.Fatalf("expected the REAL CI build_id %q to be reused (not a synthetic one), got %q", buildID, adopted.BuildID)
+		}
+	})
+
+	t.Run("mints a synthetic build_id when the failed row has none", func(t *testing.T) {
+		// A "failed" row reaped from "allocated" (not "publishing") never
+		// had a build_id -- see ArtifactRepository.AdoptArtifact's doc
+		// comment.
+		seedRawArtifact(t, pool, appID, repository.ArtifactStateFailed, "v2.0.0", "")
+		adopted, _, err := adoptArtifactTx(t, reg, repository.Artifact{
+			Kind: repository.ArtifactKindImage, AppID: appID,
+			Repository: "ghcr.io/acme/adopt-failed", Version: "v2.0.0",
+			Digest: "sha256:adopt-failed-synthetic-pg",
+		}, nil, "confirmed pushed despite recording failure", "admin@example.com")
+		if err != nil {
+			t.Fatalf("AdoptArtifact over a failed row with no build_id: %v", err)
+		}
+		if adopted.BuildID == "" {
+			t.Fatal("expected a synthetic build_id to be stamped")
+		}
+		if adopted.BuildID == buildID {
+			t.Fatal("expected a DIFFERENT (synthetic) build_id, not the other subtest's real one")
+		}
+		var gitRef string
+		if err := pool.QueryRow(context.Background(), `SELECT git_ref FROM build WHERE build_id = $1`, adopted.BuildID).Scan(&gitRef); err != nil {
+			t.Fatalf("read synthetic build row: %v", err)
+		}
+		if gitRef != "adopted" {
+			t.Fatalf("expected synthetic build's git_ref = %q, got %q", "adopted", gitRef)
+		}
+	})
 }

--- a/tools/app_registry/server/repository/repository.go
+++ b/tools/app_registry/server/repository/repository.go
@@ -272,6 +272,58 @@ type ArtifactRepository interface {
 	// pattern as WritebackRepository.ClaimBatch, a standalone maintenance
 	// sweep with no other write to be atomic with.
 	ExpireStale(ctx context.Context, olderThan time.Duration) (int, error)
+
+	// AdoptArtifact is AR-7e's (issue #558) admin-only adoption /
+	// disaster-recovery path: records a pre-existing GHCR image or chart as
+	// "published" with Provenance ArtifactProvenanceAdopted, for when there
+	// is no run to resume — the artifact was published before the registry
+	// existed, or while the opt-in was off. See ARCHITECTURE.md "Adoption
+	// and disaster recovery". a.Digest identifies the artifact; reason is
+	// required at the handler layer (validated there, not persisted here —
+	// same shape as AppRepository.SetAppStatus's reason parameter) and
+	// actor authors any synthetic `build` row this call creates (see below).
+	//
+	// State-collision semantics, decided for this phase (there is no prior
+	// art to extend — AdoptArtifact is the only writer of Provenance
+	// ArtifactProvenanceAdopted):
+	//
+	//   - Idempotent replay: an existing PUBLISHED row (observed OR
+	//     previously adopted) with this EXACT digest is "already recorded" —
+	//     returned unchanged, alreadyRecorded=true. Adoption must NEVER
+	//     rewrite an existing row's Provenance/State: downgrading an
+	//     "observed" row to "adopted" after the fact would corrupt the exact
+	//     audit trail this RPC exists to provide.
+	//   - ∅ -> published (adopted): the primary case — no row of any kind
+	//     exists yet for (owner, kind, version). A synthetic `build` row is
+	//     created to satisfy artifact.build_id's NOT NULL-once-published
+	//     constraint (migration 007's artifact_state_shape) and its foreign
+	//     key, since by definition there is no real CI run behind a
+	//     pre-registry artifact.
+	//   - failed -> published (adopted): the disaster-recovery case — a run
+	//     already tried (BeginPublish ran, then FailPublish or the reaper
+	//     marked it "failed"), but the artifact demonstrably exists (an
+	//     operator confirms it against GHCR/the chart repo by hand — this
+	//     method never checks). If the failed row already carries a
+	//     build_id (it does whenever the reaper reaped a "publishing" row;
+	//     it does NOT when the reaper reaped an "allocated" row, which never
+	//     had one), that REAL build_id is reused rather than minting a
+	//     synthetic one — the CI run that actually attempted the push is the
+	//     more honest provenance than a synthetic placeholder.
+	//   - published (same digest): folded into the idempotent-replay case
+	//     above.
+	//   - published (different digest): ErrAlreadyExists — a real conflict.
+	//     Adoption must not silently overwrite a different already-recorded
+	//     digest, whether that row is observed or itself previously adopted;
+	//     an operator must investigate by hand.
+	//   - allocated or publishing: ErrFailedPrecondition. A live
+	//     reservation or in-flight publish is not what adoption is for —
+	//     let it complete, fail, or be reaped first (or FailPublish it
+	//     explicitly), then retry. Adopting over live state would silently
+	//     discard whatever process holds it.
+	//
+	// Must be called inside Registry.WithTx — same transactional-write shape
+	// as every other write method here.
+	AdoptArtifact(ctx context.Context, a Artifact, contains []ContainedImageInput, reason, actor string) (artifact *Artifact, alreadyRecorded bool, err error)
 }
 
 // DomainAdoptionRepository covers the `domain_adoption` table (migration


### PR DESCRIPTION
Implements **AR-7e — Adoption and disaster recovery** from `tools/app_registry/PLAN.md` (issue #558). Bottom of a 2-PR stack — #572 (AR-7f) sits on top. **No schema change** — `artifact.provenance` and its CHECK already shipped in migration `007`.

Charts pin digests resolved from GHCR by tag, so a chart can pin an image published before the registry existed, or while the opt-in was off. There is no run to resume for those, they will never be in the registry, and under "the registry is the source of truth for the pipeline" the chart correctly — and permanently — fails. This is the bounded way out.

## What changed

**`ArtifactRegistry.AdoptArtifact`** records a pre-existing GHCR image or chart as `published` with `provenance = 'adopted'` and a required reason. **Admin role only, never the builder credential** — that is the security-critical line here: CI must not be able to assert into existence an artifact it did not publish. `authz_test.go` proves a builder is rejected and an admin accepted.

CLI: `app-registry artifacts adopt` and `artifacts list --provenance adopted`, so "which rows did we take on faith?" is one query rather than an archaeology exercise.

`OPERATIONS.md` gains the disaster-recovery runbook: registry restored behind or lost, a chart release failing on a pre-registry pin, and the explicit statement that this is a rare, deliberate operation — every other part of AR-7 exists to keep it that way.

## State-collision semantics

Documented on the `ArtifactRepository.AdoptArtifact` interface:

| Existing row | Behaviour |
|---|---|
| ∅ | `→ published(adopted)` — the primary case |
| `failed` | `→ published(adopted)` — the DR case; reuses the failed row's `build_id` when it has one (true if reaped from `publishing`, false if reaped from `allocated`) |
| `published`, same digest | idempotent replay — and **never** downgrades an `observed` row to `adopted` |
| `published`, different digest | `AlreadyExists` — a real conflict |
| `allocated` / `publishing` | `FailedPrecondition` — live state, not adoption's job |

`artifact.build_id` is a real FK and by definition no CI run exists for a pre-registry artifact, so the ∅ case creates a synthetic `build` row (`workflow_run_id = "adopted:<uuid>"`, `git_ref = "adopted"`). That is visible in the run log rather than hidden, which seems right for an audited manual action.

## Worth a reviewer's opinion

**The required `reason` is logged structurally but not persisted to a column.** This mirrors `SetAppStatus`'s identical `reason` shape, so there is precedent — but it means `provenance = 'adopted'` is queryable while *why* each row was adopted is only in logs. For a path whose entire justification is auditability, persisting the reason may be worth a column. Deliberately not decided unilaterally, since it would mean a migration in a phase specified as needing none.

## Design constraints honoured

No bulk backfill of historical GHCR artifacts ("Resolved questions" #3 still rejects it) — adoption is lazy and per-artifact. No live GHCR existence verifier: `published` is proof-of-existence at write time and deliberately not a liveness check. No domain-adoption-stage gate on `AdoptArtifact`.

## Tests

Six new Postgres integration tests against real Docker Postgres, including the exit-criterion scenario end to end: a chart record that previously failed on an unrecorded pin succeeds after the image is adopted. Plus fake-backed handler tests, `authz_test.go`, and CLI flag-surface tests.

Verified by deliberately breaking and reverting: the admin-only role check, the never-downgrade-`observed` invariant, the `build_id`-reuse-on-`failed` branch, and the `allocated`/`publishing` rejection. The CLI flag test also caught a missing `BUILD.bazel` `srcs` entry.

## Verification

`bazel build //tools/...` and `bazel test //tools/...` green (14/14). `postgres_integration_test` passes against real Postgres — **126.1s on the combined stack tip with #572's tests included**.

Ref: #558, #559
