### PR TITLE
feat(app-registry): AR-7f compose-time chart hermeticity, gated per domain (#558)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -994,6 +994,18 @@ jobs:
         DRY_RUN: ${{ github.event.inputs.dry_run }}
         INCREMENT_MINOR: ${{ github.event.inputs.increment_minor }}
         INCREMENT_PATCH: ${{ github.event.inputs.increment_patch }}
+        # AR-7f (issue #558): compose-time chart hermeticity. build-helm-chart
+        # is a no-op here unless APP_REGISTRY_CICD_OPT_IN is exactly "true" --
+        # see tools/release_helper_go/cmd/chart_hermeticity.go's doc comment
+        # and ARCHITECTURE.md "APP_REGISTRY_CICD_OPT_IN". Same builder
+        # credential and env var names as every other App Registry step in
+        # this job below, so this dials the same server.
+        APP_REGISTRY_CICD_OPT_IN: ${{ vars.APP_REGISTRY_CICD_OPT_IN }}
+        APP_REGISTRY_ADDRESS: ${{ vars.APP_REGISTRY_ADDRESS }}
+        GRPC_AUTH_MODE: oidc
+        GRPC_AUTH_TOKEN_URL: ${{ vars.APP_REGISTRY_AUTH_TOKEN_URL }}
+        GRPC_AUTH_CLIENT_ID: app-registry-builder-${{ vars.APP_REGISTRY_BUILDER_ENV || 'dev' }}
+        GRPC_AUTH_CLIENT_SECRET: ${{ secrets.APP_REGISTRY_BUILDER_CLIENT_SECRET }}
       run: |
         echo "Building helm charts with version $VERSION"
         

--- a/tools/app_registry/ARCHITECTURE.md
+++ b/tools/app_registry/ARCHITECTURE.md
@@ -398,8 +398,8 @@ tradeoff above, not a separate gap to close.
 ## Release lifecycle (issue #558)
 
 **Status: AR-7a and AR-7b built and merged to `main` (#561, #562); AR-7c,
-AR-7d, and AR-7e built, not yet merged; AR-7f designed, not built.** Delivery
-is PLAN.md's AR-7. Five slices of this section describe real code: AR-7a's —
+AR-7d, AR-7e, and AR-7f built, not yet merged.** Delivery is PLAN.md's
+AR-7. Six slices of this section describe real code: AR-7a's —
 ordering 4, partial-apply reconcile, domain-qualified chart app references,
 and the `continue-on-error` drop on `ci.yml`'s sweep job — AR-7b's — the
 artifact lifecycle (`allocated → publishing → published → failed`),
@@ -408,14 +408,15 @@ migration `007`, `BeginPublish`/`FailPublish`, `RecordArtifact`'s
 migration `008`, the app identity / manifest-snapshot split, `AssertApps`,
 and `artifact`'s stored `manifest_id`/`promotability` — AR-7d's —
 `GetReleaseRun`, the up-front intent write, `builds status --incomplete`,
-and re-run-as-resume — and AR-7e's — `AdoptArtifact`, its admin-only
+and re-run-as-resume — AR-7e's — `AdoptArtifact`, its admin-only
 authorization, the `∅|failed → published(adopted)` state-collision rules,
-and `ListArtifacts`' provenance filter. Compose-time chart hermeticity
-(AR-7f) remains proposed: every table, column and RPC named in that
-subsection is unbuilt. This section supersedes "Release-vs-reconcile gap
-(issue #547)" above — AR-7c closes that gap for real, see the callout there
-— and changes what "Availability and bootstrap" below promises; both are
-cross-referenced where that happens.
+and `ListArtifacts`' provenance filter — and AR-7f's —
+`ArtifactRegistry.CheckChartHermeticity` and its call site in
+`tools/release_helper_go`'s `build-helm-chart`, see "Compose-time chart
+hermeticity" below. Every sub-phase of AR-7 is now implemented. This section
+supersedes "Release-vs-reconcile gap (issue #547)" above — AR-7c closes that
+gap for real, see the callout there — and changes what "Availability and
+bootstrap" below promises; both are cross-referenced where that happens.
 
 ### The problem: four cross-run orderings, three of them unenforced
 
@@ -965,6 +966,63 @@ this writing; that cutover is a separate, explicit operational action (see
 "Per-domain cutover gate" in the Version model section above), not part of
 this change.
 
+### Compose-time chart hermeticity (AR-7f, issue #558)
+
+**Built.** The reject in "Chart → image lockfile" below ("a chart may not
+pin an unknown artifact") only fires at *record* time — after the chart has
+already been packaged and pushed to ChartMuseum. AR-7f moves the same rule
+earlier, to *compose* time, for domains that have earned the stricter
+guarantee: `domain_adoption.stage = 'allocate'` (see "Availability, restated
+per adoption stage" above — the same per-domain gate every other AR-7
+tightening in this document uses, and "Rejected alternatives" below for why
+it is per-domain and not repo-wide).
+
+**Where the check runs, and why that is hermetic.** `ArtifactRegistry`
+gained one new read-only RPC, `CheckChartHermeticity(chart_domain, pins)`.
+Server-side (`server/handlers/chart_hermeticity.go`) it reads
+`chart_domain`'s adoption stage; at anything other than `allocate` it
+returns `enforced = false` and does no further work. At `allocate` it looks
+up each pin (`app_full_name`, `version`) via the same `Artifacts().
+GetArtifact` the CLI's `artifacts get` already exposes, and reports a
+violation for anything not found or not yet `ArtifactStatePublished`.
+
+The caller is `tools/release_helper_go`'s `build-helm-chart` command
+(`cmd/chart_hermeticity.go`), called right after it resolves each member
+app's release version and before it packages the chart or anything is
+pushed. This is deliberately **not** inside `tools/helm/composer.go` or any
+Bazel action: `composer.go` runs inside `bazel build` as part of
+`build-helm-chart` a few lines earlier, with zero code changed and zero
+registry access added — it still only bakes `AppMetadata.Version` (usually
+the "latest" placeholder; see "Chart → image lockfile") into the compose-time
+image lockfile, exactly as before AR-7f. `build-helm-chart` itself is a CLI
+binary the release workflow invokes as its own step, outside any Bazel
+action's sandbox — the same place `read-chart-lockfile` and the digest
+resolution it feeds already make a registry call today (AR-2c). Putting the
+new check there keeps the Bazel graph exactly as reproducible as it was:
+no chart build result depends on network state, so nothing poisons the
+remote cache and nothing breaks on a machine with no registry access.
+
+**No-op posture.** `checkChartHermeticity` reads `APP_REGISTRY_CICD_OPT_IN`
+directly and returns immediately — no dial, no RPC — unless it is exactly
+`"true"`, the same bootstrap kill switch every other integration point in
+this document already hangs on (see "`APP_REGISTRY_CICD_OPT_IN`" below).
+That is what keeps `bazel build` — and `build-helm-chart` run without
+`--use-released`, i.e. every contributor's laptop — untouched. A transport
+or auth error talking to the registry (opt-in on, registry unreachable) is
+also **not** fatal: it is logged as a warning and the build proceeds, the
+same best-effort posture release.yml's other App Registry steps have at
+adoption stage `observe`/`promote`. Only an actual `enforced = true`
+response naming violations fails the chart build, and it fails naming every
+offending `app_full_name`/version pair.
+
+**Ships inert.** No domain is at adoption stage `allocate` today (see
+"Relationship to AR-5" above) — `CheckChartHermeticity` always returns
+`enforced = false` in every environment that exists right now, the same way
+AR-5a shipped `AllocateVersion` fully implemented but unreachable. It starts
+to bite the first time a domain's `domain_adoption.stage` row is moved to
+`allocate`, which is a separate, explicit operational action, not part of
+this change.
+
 ### Rejected alternatives (issue #558)
 
 | Approach | Why rejected |
@@ -975,7 +1033,7 @@ this change.
 | Registry orchestrates the release saga (inbound Temporal workflow) | Breaks "Record, don't act" — the registry would become a deployment system. CI orchestrates; the registry logs. Temporal stays on the outbound writeback path only. |
 | SCD2 on `app` for "what did this app look like at time T" | The append-only per-build manifest snapshot already *is* the history and matches the rest of the schema; SCD2 on identity would add a second history mechanism. Consistent with #553. |
 | A `build_target` table declaring the run's intended children up front | Rejected: the plan step writes `allocated` rows at every adoption stage (see "The run log"), so that state already *is* the declaration. A second table would restate it in a shape that can disagree with the run. |
-| Enforce "charts may only pin registry-known images" at chart **compose** time, repo-wide | Rejected as a repo-wide switch, kept as a per-domain one (AR-7f): gated on `domain_adoption.stage = 'allocate'`, exactly like every other tightening here. Repo-wide, no chart could build until every member app had released through the registry once; per-domain, a domain only meets the strict rule after it has been releasing through the registry anyway, and chart builds fail before anything is pushed instead of after. |
+| Enforce "charts may only pin registry-known images" at chart **compose** time, repo-wide | Rejected as a repo-wide switch, kept as a per-domain one (**built as AR-7f**): gated on `domain_adoption.stage = 'allocate'`, exactly like every other tightening here. Repo-wide, no chart could build until every member app had released through the registry once; per-domain, a domain only meets the strict rule after it has been releasing through the registry anyway, and chart builds fail before anything is pushed instead of after. |
 
 ## Promotability
 
@@ -1043,6 +1101,12 @@ future chart release containing it, permanently. The artifact lifecycle in
 "Release lifecycle (issue #558)" is what makes the reject safe to keep — the
 image's row exists from `publishing` onward, so failing here means the image
 genuinely was never published.
+
+This reject fires at *record* time, after the chart is already packaged and
+pushed. "Compose-time chart hermeticity (AR-7f, issue #558)" above moves the
+same rule earlier, before anything is pushed, for domains at adoption stage
+`allocate` — still without a registry call inside the Bazel action that
+composes the chart, for the reason stated at the top of this section.
 
 **This is also the deploy-time idempotency guarantee for a promoted chart's
 app list — see "Resolved questions" #4.** `contains` is a pure function of

--- a/tools/app_registry/ENV.md
+++ b/tools/app_registry/ENV.md
@@ -91,9 +91,17 @@ placement rationale:
 |---|---|---|---|
 | `vars.APP_REGISTRY_ADDRESS` | Repository variable | `APP_REGISTRY_ADDRESS` | both |
 | `vars.APP_REGISTRY_AUTH_TOKEN_URL` | Repository variable | `GRPC_AUTH_TOKEN_URL` | both |
-| `vars.APP_REGISTRY_BUILDER_ENV` | Repository variable | `GRPC_AUTH_CLIENT_ID=app-registry-builder-<value>`, falls back to `dev` when unset | `release.yml` recording steps only |
-| `secrets.APP_REGISTRY_BUILDER_CLIENT_SECRET` | Repository secret | `GRPC_AUTH_CLIENT_SECRET` | `release.yml` recording steps only |
+| `vars.APP_REGISTRY_BUILDER_ENV` | Repository variable | `GRPC_AUTH_CLIENT_ID=app-registry-builder-<value>`, falls back to `dev` when unset | `release.yml` recording steps, plus (AR-7f) "Build helm charts with versioning" |
+| `secrets.APP_REGISTRY_BUILDER_CLIENT_SECRET` | Repository secret | `GRPC_AUTH_CLIENT_SECRET` | `release.yml` recording steps, plus (AR-7f) "Build helm charts with versioning" |
 | `secrets.APP_REGISTRY_PROMOTER_CLIENT_SECRET` | Environment secret, one per GitHub Environment (e.g. `promotion-dev`/`promotion-prod`) | `GRPC_AUTH_CLIENT_SECRET` (`GRPC_AUTH_CLIENT_ID=app-registry-promoter-<registry_environment>`) | `promote.yml` only |
+
+AR-7f (issue #558) adds one more consumer of the builder credential: the
+release plan step's "Build helm charts with versioning" reuses these same
+four variables so `tools/release_helper_go`'s `build-helm-chart` can call
+`ArtifactRegistry.CheckChartHermeticity` when `APP_REGISTRY_CICD_OPT_IN` is
+`true` — see ARCHITECTURE.md "Compose-time chart hermeticity (AR-7f, issue
+#558)". No new variable was introduced for this; it dials the same server
+with the same credential the later steps in that job already use.
 
 `GRPC_AUTH_MODE=oidc` is hardcoded in both workflows rather than read from a
 variable — the CLI must match whatever the server runs, and the server is

--- a/tools/app_registry/PLAN.md
+++ b/tools/app_registry/PLAN.md
@@ -16,7 +16,7 @@ Read [ARCHITECTURE.md](ARCHITECTURE.md) before executing any phase.
 
 ## Current status
 
-*Last updated finishing AR-7e (issue #558). **AR-M through AR-7b are all
+*Last updated finishing AR-7f (issue #558). **AR-M through AR-7b are all
 merged to `main`** — see the table below.*
 
 | Phase | PR | State |
@@ -37,7 +37,8 @@ merged to `main`** — see the table below.*
 | AR-7b | [#562](https://github.com/whale-net/everything/pull/562) | merged — artifact lifecycle, migration `007`, `BeginPublish`/`FailPublish`, stale-row reaper |
 | AR-7c | branch `ar-7c-manifest-snapshot`, not yet merged | **implemented** — app identity/manifest-snapshot split, migration `008`, `AssertApps` |
 | AR-7d | branch `ar-7d-run-log`, stacked on `ar-7c-manifest-snapshot`, not yet merged | **implemented** — `GetReleaseRun`, `BeginPublishBatch`, `app-registry builds status`, `release.yml` resume, no schema change |
-| AR-7e | branch `ar-7e-adopt-artifact`, stacked on `ar-7d-run-log`, not yet merged | **implemented** — `AdoptArtifact` (admin-only), `app-registry artifacts adopt`/`list --provenance`, OPERATIONS.md disaster-recovery runbook, no schema change |
+| AR-7e | branch `ar-7e-adopt-artifact`, not yet merged | **implemented** — `AdoptArtifact` (admin-only), `app-registry artifacts adopt`/`list --provenance`, OPERATIONS.md disaster-recovery runbook, no schema change |
+| AR-7f | branch `ar-7f-chart-hermeticity`, stacked on `ar-7e-adopt-artifact`, not yet merged | **implemented** — `CheckChartHermeticity` RPC, `build-helm-chart` call site, no schema change, **ships inert** (no domain at stage `allocate`) |
 
 The registry is being deployed to `dev` by the repo owner. `app-registry-api`
 and `app-registry-migration` images publish from `apps=all`.
@@ -54,7 +55,7 @@ implemented and tested, wired to nothing. See "AR-5" below for what remains
 before any domain can be cut over.
 
 **AR-7 (issue #558): AR-7a and AR-7b are merged to `main`; AR-7c, AR-7d, and
-AR-7e are implemented, not yet merged.** The full phase makes a release run
+AR-7e and AR-7f are implemented, not yet merged.** The full phase makes a release run
 hermetic — no dependency on `main`'s reconcile having gone first — via an
 artifact
 `allocated → publishing → published` lifecycle, an identity/manifest-snapshot
@@ -74,9 +75,14 @@ own "Deliberately NOT done" left open (see AR-7b's section below),
 behavior. AR-7e adds `AdoptArtifact` — an admin-only, per-artifact path for
 recording an artifact the registry never observed being published, used when
 a chart release fails on a pre-registry pin, plus OPERATIONS.md's
-disaster-recovery runbook. All three phases' exit criteria are met; none has
-merged yet. AR-7f remains design-only. Design is in ARCHITECTURE.md's
-"Release lifecycle (issue #558)"; delivery is "AR-7" below.
+disaster-recovery runbook. AR-7f adds
+`ArtifactRegistry.CheckChartHermeticity` and its call site in
+`build-helm-chart`, moving the "chart may only pin published images" rule
+from record time to compose time for domains at adoption stage `allocate` —
+see its subsection for the full contract and why it ships inert. **Every
+sub-phase of AR-7 is now implemented**; AR-7c…AR-7f have not merged yet.
+Design is in ARCHITECTURE.md's "Release lifecycle (issue #558)"; delivery is
+"AR-7" below.
 
 **Where deferred work is tracked.** Three places, deliberately:
 [Carry-over items](#carry-over-items) for small cross-cutting gaps that
@@ -893,10 +899,11 @@ it carries the design, the four orderings this fixes, and the rejected
 alternatives. This section is delivery only.
 
 **AR-7a and AR-7b are merged to `main`** ([#561](https://github.com/whale-net/everything/pull/561),
-[#562](https://github.com/whale-net/everything/pull/562)). **AR-7c and AR-7d
-are implemented, not yet merged** (branches `ar-7c-manifest-snapshot` and
-`ar-7d-run-log`, stacked in that order). The remaining sub-phases (AR-7e,
-AR-7f) are ordered by dependency and still design only.
+[#562](https://github.com/whale-net/everything/pull/562)). **AR-7c, AR-7d,
+and AR-7f are implemented, not yet merged** (branches `ar-7c-manifest-snapshot`,
+`ar-7d-run-log`, and `ar-7f-chart-hermeticity`, stacked in that order — AR-7f
+was built directly on top of AR-7d rather than after AR-7e, since it does not
+depend on `AdoptArtifact`). Only AR-7e remains design only.
 
 ### AR-7a — Sweep robustness — done, merged (#561)
 
@@ -1663,30 +1670,69 @@ alternatives it does not revisit):
   `ListArtifacts(provenance=ADOPTED)` / `artifacts list --provenance
   adopted`.
 
-### AR-7f — Compose-time chart hermeticity — gated per domain
+### AR-7f — Compose-time chart hermeticity — gated per domain — done (not yet merged)
 
 Enforce "a chart may only pin images the registry has published" at chart
 **compose** time, so the failure lands before anything is pushed rather than
-after every push. This is the steady state the issue title asks for; it is
-last only because of cutover cost, which the per-domain gate bounds.
+after every push. This is the steady state the issue title asks for. It was
+built directly after AR-7d rather than after AR-7e (which it does not depend
+on) — see ARCHITECTURE.md's "Compose-time chart hermeticity (AR-7f, issue
+#558)" for the full design.
 
-**Scope**
-- `tools/helm`'s composer (or the release plan step feeding it) checks each
-  member app's pinned version against the registry and fails the chart build
-  if any is not `published`.
-- **Enforced only for domains at `domain_adoption.stage = 'allocate'`**
-  (decided in review) — the same per-domain gate every other tightening uses,
-  so a domain meets the strict rule only after it has been releasing through
-  the registry anyway. Repo-wide enforcement was rejected: it would block
-  every chart build until every member app had released through the registry
-  at least once.
-- Hermeticity constraint: the check runs in the release path, never inside a
-  Bazel action — see "Chart → image lockfile" in ARCHITECTURE.md.
+**As built.** Implemented on branch `ar-7f-chart-hermeticity`, stacked on
+`ar-7d-run-log`. No migration — no schema change, in either direction.
+
+**What shipped**
+- `ArtifactRegistry.CheckChartHermeticity(chart_domain, pins[])` (new RPC,
+  `protos/api_messages_artifact.proto`; handler in a new file,
+  `server/handlers/chart_hermeticity.go`, kept separate from `artifact.go`
+  to avoid colliding with AR-7e's parallel work on that file). Reads
+  `chart_domain`'s adoption stage; returns `enforced = false` at anything
+  other than `allocate` (nil violations, mandatory no-op for the caller).
+  At `allocate`, looks up each `(app_full_name, version)` pin via
+  `Artifacts().GetArtifact` and reports a violation for anything not found
+  or not yet `ArtifactStatePublished` — `publishing`, `allocated`, and
+  `failed` are all violations, not just "row absent."
+- `tools/release_helper_go`'s `build-helm-chart` (new file
+  `cmd/chart_hermeticity.go`) calls it right after `resolveChartAppVersions`
+  resolves each member app's release version and before the chart is
+  packaged. No-op (checker never even constructed) unless
+  `APP_REGISTRY_CICD_OPT_IN == "true"`; a transport/auth error talking to
+  the registry is logged as a warning and does not fail the build — only an
+  `enforced = true` response naming violations does, naming every offending
+  `app@version` pair in the error.
+- `release.yml`'s "Build helm charts with versioning" step gained the same
+  `APP_REGISTRY_ADDRESS` / `GRPC_AUTH_*` env vars the job's later App
+  Registry steps already use, so `build-helm-chart` can dial the same
+  server when opt-in is on.
+- **Hermeticity constraint satisfied exactly as scoped**: the check runs
+  inside `build-helm-chart`, a release-path CLI command CI invokes as its
+  own workflow step — never inside the `bazel build` two lines above it,
+  which still runs `tools/helm/composer.go` unmodified, with no registry
+  access added. See ARCHITECTURE.md "Chart → image lockfile" and
+  "Compose-time chart hermeticity" for why that split is load-bearing.
+
+**Ships inert.** No domain is at adoption stage `allocate` in any
+environment today (see "AR-5a" above and ARCHITECTURE.md's "Relationship to
+AR-5") — `CheckChartHermeticity` always returns `enforced = false` right
+now, so this phase changes no chart build's output or outcome anywhere it
+runs today. It starts to matter the first time an operator moves a domain's
+`domain_adoption.stage` row to `allocate`, a separate explicit operational
+action (see ARCHITECTURE.md "Per-domain cutover gate" in the Version model
+section) — from that point on, a chart in that domain fails to build if any
+member app's pinned version has not been recorded as `published`.
 
 **Exit criteria**
 - A chart in an `allocate`-stage domain whose member app was never published
-  fails at compose time, naming the app, with nothing pushed.
+  fails at compose time, naming the app, with nothing pushed. Proven by
+  `TestCheckChartHermeticity_AllocateRejectsUnpublishedPin` (server) and
+  `TestCheckChartHermeticity_ViolationNamesTheApp` (release_helper_go).
 - A chart in an `observe`/`promote`-stage domain builds exactly as it does
+  today. Proven by `TestCheckChartHermeticity_NotEnforcedAtObserve` /
+  `_NotEnforcedAtPromote` (server) and `TestCheckChartHermeticity_
+  NotEnforced` / `_OptInOff` / `_OptInFalse` (release_helper_go) — the last
+  two additionally prove no registry call is even attempted with the opt-in
+  off, which is every environment without `APP_REGISTRY_CICD_OPT_IN=true`
   today.
 
 ### Deliberately NOT in AR-7

--- a/tools/app_registry/protos/api.proto
+++ b/tools/app_registry/protos/api.proto
@@ -85,6 +85,14 @@ service ArtifactRegistry {
   // builder credential a CI job holds; see ARCHITECTURE.md "Authorization"
   // and "Adoption and disaster recovery".
   rpc AdoptArtifact(AdoptArtifactRequest) returns (AdoptArtifactResponse);
+
+  // Phase AR-7f (issue #558): compose-time chart hermeticity, gated per
+  // domain. Called from the release path (tools/release_helper_go's
+  // build-helm-chart, never a Bazel action -- see ARCHITECTURE.md "Chart ->
+  // image lockfile") right after a chart's member app versions are resolved
+  // and before the chart is packaged or anything is pushed. Read-only: it
+  // never writes, so it needs no idempotency_key.
+  rpc CheckChartHermeticity(CheckChartHermeticityRequest) returns (CheckChartHermeticityResponse);
 }
 
 // ============================================================================

--- a/tools/app_registry/protos/api_messages_artifact.proto
+++ b/tools/app_registry/protos/api_messages_artifact.proto
@@ -338,3 +338,48 @@ message AllocateVersionResponse {
 
   bool already_allocated = 3;
 }
+
+// ============================================================================
+// Compose-time chart hermeticity (phase AR-7f, issue #558)
+//
+// "A chart may only pin images the registry has published," enforced before
+// the chart is packaged or pushed -- not after, the way the ordering-3 reject
+// in RecordArtifact's `contains` validation already does. See
+// ARCHITECTURE.md's "Compose-time chart hermeticity" subsection.
+// ============================================================================
+
+// ChartPin is one member app's resolved image pin, as release_helper_go's
+// build-helm-chart bakes into the chart's values.yaml imageTag -- the
+// release-resolved version (from git tags today, AllocateVersion after the
+// AR-5 cutover), not the "latest" placeholder composer.go's hermetic Bazel
+// action writes to the compose-time image lockfile.
+message ChartPin {
+  string app_full_name = 1;  // "<domain>-<name>"
+  string version = 2;        // semver tag, e.g. "v1.2.3"
+}
+
+message CheckChartHermeticityRequest {
+  // The chart's own domain. domain_adoption.stage is read for THIS domain,
+  // not each pinned app's domain -- "a domain meets the strict rule after it
+  // has been releasing through the registry" means the chart's own release
+  // history, not an incidentally cross-domain-referenced app's.
+  string chart_domain = 1;
+  repeated ChartPin pins = 2;
+}
+
+// ChartPinViolation is one pin that failed the check: not recorded at all,
+// or recorded but not yet in ARTIFACT_STATE_PUBLISHED.
+message ChartPinViolation {
+  string app_full_name = 1;
+  string version = 2;
+  string reason = 3;
+}
+
+message CheckChartHermeticityResponse {
+  // False when chart_domain's adoption stage is not "allocate" -- the
+  // per-domain gate every other AR-7 tightening uses (see ARCHITECTURE.md
+  // "Rejected alternatives (issue #558)"). violations is always empty when
+  // this is false; the caller must not fail the chart build in that case.
+  bool enforced = 1;
+  repeated ChartPinViolation violations = 2;
+}

--- a/tools/app_registry/server/handlers/BUILD.bazel
+++ b/tools/app_registry/server/handlers/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "app.go",
         "artifact.go",
+        "chart_hermeticity.go",
         "convert.go",
         "environment.go",
         "errors.go",
@@ -36,6 +37,7 @@ go_test(
         "artifact_adopt_test.go",
         "artifact_test.go",
         "authz_test.go",
+        "chart_hermeticity_test.go",
         "environment_test.go",
         "promotion_test.go",
     ],

--- a/tools/app_registry/server/handlers/chart_hermeticity.go
+++ b/tools/app_registry/server/handlers/chart_hermeticity.go
@@ -1,0 +1,78 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	pb "github.com/whale-net/everything/tools/app_registry/protos"
+	"github.com/whale-net/everything/tools/app_registry/server/auth"
+	"github.com/whale-net/everything/tools/app_registry/server/repository"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// CheckChartHermeticity implements the AR-7f (issue #558) compose-time gate:
+// "a chart may only pin images the registry has published," checked before
+// release_helper_go's build-helm-chart packages the chart -- see
+// ARCHITECTURE.md "Compose-time chart hermeticity" and PLAN.md's AR-7f
+// subsection for the full contract.
+//
+// Deliberately kept in its own file rather than artifact.go, despite living
+// on ArtifactRegistry and despite server/README.md's "one file per service"
+// convention: AR-7e (AdoptArtifact) is being implemented in parallel on a
+// sibling branch that also touches artifact.go, and this file's only shared
+// surface with that work is the repository.Registry interface, not any line
+// of artifact.go itself -- see PLAN.md AR-7f's "Constraints" note.
+func (s *ArtifactServer) CheckChartHermeticity(ctx context.Context, req *pb.CheckChartHermeticityRequest) (*pb.CheckChartHermeticityResponse, error) {
+	if err := auth.RequireAuthenticated(ctx); err != nil {
+		return nil, err
+	}
+	if req.ChartDomain == "" {
+		return nil, status.Error(codes.InvalidArgument, "chart_domain is required")
+	}
+
+	stage, err := s.repo.DomainAdoption().GetStage(ctx, req.ChartDomain)
+	if err != nil {
+		return nil, mapRepoErr(err)
+	}
+
+	// The per-domain gate every other AR-7 tightening uses (see
+	// ARCHITECTURE.md "Rejected alternatives (issue #558)"): enforced only
+	// once the chart's own domain has cut over to "allocate". At every other
+	// stage this is a no-op response, not merely a response the caller is
+	// expected to ignore -- callers must not fail a build on an unenforced
+	// response, so violations is left nil rather than populated-but-ignored.
+	if stage != repository.DomainAdoptionStageAllocate {
+		return &pb.CheckChartHermeticityResponse{Enforced: false}, nil
+	}
+
+	var violations []*pb.ChartPinViolation
+	for _, pin := range req.Pins {
+		artifact, err := s.repo.Artifacts().GetArtifact(ctx, repository.ArtifactLookup{
+			OwnerFullName: pin.AppFullName,
+			Kind:          repository.ArtifactKindImage,
+			Version:       pin.Version,
+		})
+		if err != nil {
+			if errors.Is(err, repository.ErrNotFound) {
+				violations = append(violations, &pb.ChartPinViolation{
+					AppFullName: pin.AppFullName,
+					Version:     pin.Version,
+					Reason:      "not recorded in App Registry",
+				})
+				continue
+			}
+			return nil, mapRepoErr(err)
+		}
+		if artifact.State != repository.ArtifactStatePublished {
+			violations = append(violations, &pb.ChartPinViolation{
+				AppFullName: pin.AppFullName,
+				Version:     pin.Version,
+				Reason:      fmt.Sprintf("state=%s, not published", artifact.State),
+			})
+		}
+	}
+
+	return &pb.CheckChartHermeticityResponse{Enforced: true, Violations: violations}, nil
+}

--- a/tools/app_registry/server/handlers/chart_hermeticity_test.go
+++ b/tools/app_registry/server/handlers/chart_hermeticity_test.go
@@ -1,0 +1,163 @@
+package handlers
+
+import (
+	"testing"
+
+	pb "github.com/whale-net/everything/tools/app_registry/protos"
+	"github.com/whale-net/everything/tools/app_registry/server/repository"
+)
+
+// publishImage takes demo-image-app (created by setupAllocate) all the way
+// to ARTIFACT_STATE_PUBLISHED at the given version, via the same
+// allocate -> begin-publish -> record path TestArtifactLifecycle_
+// AllocateBeginPublishRecord exercises. CheckChartHermeticity only treats a
+// pin as satisfied once it reaches this state -- see ArtifactState's doc
+// comment in repository/models.go.
+func publishImage(t *testing.T, artifactSrv *ArtifactServer, version, idemPrefix string) {
+	t.Helper()
+	ctx := authedCtx()
+	build := recordBuild(t, artifactSrv, idemPrefix+"-run")
+	if _, err := artifactSrv.BeginPublish(ctx, &pb.BeginPublishRequest{
+		Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE, OwnerFullName: "demo-image-app",
+		Version: version, BuildId: build.BuildId, IdempotencyKey: idemPrefix + "-begin",
+	}); err != nil {
+		t.Fatalf("BeginPublish: %v", err)
+	}
+	if _, err := artifactSrv.RecordArtifact(ctx, &pb.RecordArtifactRequest{
+		BuildId: build.BuildId, Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE,
+		OwnerFullName: "demo-image-app", Digest: "sha256:" + idemPrefix, Version: version,
+		IdempotencyKey: idemPrefix + "-record",
+	}); err != nil {
+		t.Fatalf("RecordArtifact: %v", err)
+	}
+}
+
+// TestCheckChartHermeticity_NotEnforcedAtObserve proves the per-domain gate:
+// at the default stage ("observe", where every domain sits today per
+// ARCHITECTURE.md), the RPC reports enforced=false and never inspects
+// artifact state -- an unpublished pin must not surface as a violation.
+func TestCheckChartHermeticity_NotEnforcedAtObserve(t *testing.T) {
+	_, artifactSrv := setupAllocate(t)
+	resp, err := artifactSrv.CheckChartHermeticity(authedCtx(), &pb.CheckChartHermeticityRequest{
+		ChartDomain: "demo",
+		Pins:        []*pb.ChartPin{{AppFullName: "demo-image-app", Version: "v9.9.9"}},
+	})
+	if err != nil {
+		t.Fatalf("CheckChartHermeticity: %v", err)
+	}
+	if resp.Enforced {
+		t.Fatalf("expected enforced=false at adoption stage observe, got true")
+	}
+	if len(resp.Violations) != 0 {
+		t.Fatalf("expected no violations when not enforced, got %v", resp.Violations)
+	}
+}
+
+// TestCheckChartHermeticity_NotEnforcedAtPromote is the same proof at
+// "promote", the other stage recording is mandatory at but compose-time
+// enforcement is not (ARCHITECTURE.md "Availability, restated per adoption
+// stage").
+func TestCheckChartHermeticity_NotEnforcedAtPromote(t *testing.T) {
+	repo, artifactSrv := setupAllocate(t)
+	repo.SetDomainAdoptionStage("demo", repository.DomainAdoptionStagePromote)
+	resp, err := artifactSrv.CheckChartHermeticity(authedCtx(), &pb.CheckChartHermeticityRequest{
+		ChartDomain: "demo",
+		Pins:        []*pb.ChartPin{{AppFullName: "demo-image-app", Version: "v9.9.9"}},
+	})
+	if err != nil {
+		t.Fatalf("CheckChartHermeticity: %v", err)
+	}
+	if resp.Enforced {
+		t.Fatalf("expected enforced=false at adoption stage promote, got true")
+	}
+}
+
+// TestCheckChartHermeticity_AllocateRejectsUnpublishedPin is AR-7f's core
+// exit criterion: an allocate-stage domain whose member app was never
+// published fails the check, naming the app.
+func TestCheckChartHermeticity_AllocateRejectsUnpublishedPin(t *testing.T) {
+	repo, artifactSrv := setupAllocate(t)
+	repo.SetDomainAdoptionStage("demo", repository.DomainAdoptionStageAllocate)
+
+	resp, err := artifactSrv.CheckChartHermeticity(authedCtx(), &pb.CheckChartHermeticityRequest{
+		ChartDomain: "demo",
+		Pins:        []*pb.ChartPin{{AppFullName: "demo-image-app", Version: "v1.0.0"}},
+	})
+	if err != nil {
+		t.Fatalf("CheckChartHermeticity: %v", err)
+	}
+	if !resp.Enforced {
+		t.Fatalf("expected enforced=true at adoption stage allocate, got false")
+	}
+	if len(resp.Violations) != 1 {
+		t.Fatalf("expected exactly 1 violation, got %v", resp.Violations)
+	}
+	v := resp.Violations[0]
+	if v.AppFullName != "demo-image-app" || v.Version != "v1.0.0" {
+		t.Fatalf("violation does not name the offending app/version: %+v", v)
+	}
+}
+
+// TestCheckChartHermeticity_AllocateAcceptsPublishedPin proves the
+// mirror-image case: once the pinned version is actually published, the
+// same allocate-stage domain reports no violations.
+func TestCheckChartHermeticity_AllocateAcceptsPublishedPin(t *testing.T) {
+	repo, artifactSrv := setupAllocate(t)
+	publishImage(t, artifactSrv, "v1.0.0", "accept")
+	repo.SetDomainAdoptionStage("demo", repository.DomainAdoptionStageAllocate)
+
+	resp, err := artifactSrv.CheckChartHermeticity(authedCtx(), &pb.CheckChartHermeticityRequest{
+		ChartDomain: "demo",
+		Pins:        []*pb.ChartPin{{AppFullName: "demo-image-app", Version: "v1.0.0"}},
+	})
+	if err != nil {
+		t.Fatalf("CheckChartHermeticity: %v", err)
+	}
+	if !resp.Enforced {
+		t.Fatalf("expected enforced=true at adoption stage allocate, got false")
+	}
+	if len(resp.Violations) != 0 {
+		t.Fatalf("expected no violations for a published pin, got %v", resp.Violations)
+	}
+}
+
+// TestCheckChartHermeticity_AllocateRejectsPublishingNotYetPublished proves
+// a pin sitting in "publishing" (BeginPublish called, RecordArtifact not
+// yet) is still a violation -- only ARTIFACT_STATE_PUBLISHED satisfies the
+// check, matching ArtifactState's doc comment on what published actually
+// guarantees.
+func TestCheckChartHermeticity_AllocateRejectsPublishingNotYetPublished(t *testing.T) {
+	repo, artifactSrv := setupAllocate(t)
+	ctx := authedCtx()
+	build := recordBuild(t, artifactSrv, "inflight-run")
+	if _, err := artifactSrv.BeginPublish(ctx, &pb.BeginPublishRequest{
+		Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE, OwnerFullName: "demo-image-app",
+		Version: "v1.0.0", BuildId: build.BuildId, IdempotencyKey: "inflight-begin",
+	}); err != nil {
+		t.Fatalf("BeginPublish: %v", err)
+	}
+	repo.SetDomainAdoptionStage("demo", repository.DomainAdoptionStageAllocate)
+
+	resp, err := artifactSrv.CheckChartHermeticity(ctx, &pb.CheckChartHermeticityRequest{
+		ChartDomain: "demo",
+		Pins:        []*pb.ChartPin{{AppFullName: "demo-image-app", Version: "v1.0.0"}},
+	})
+	if err != nil {
+		t.Fatalf("CheckChartHermeticity: %v", err)
+	}
+	if len(resp.Violations) != 1 {
+		t.Fatalf("expected 1 violation for a still-publishing pin, got %v", resp.Violations)
+	}
+}
+
+// TestCheckChartHermeticity_RequiresChartDomain guards the request
+// validation.
+func TestCheckChartHermeticity_RequiresChartDomain(t *testing.T) {
+	_, artifactSrv := setupAllocate(t)
+	_, err := artifactSrv.CheckChartHermeticity(authedCtx(), &pb.CheckChartHermeticityRequest{
+		Pins: []*pb.ChartPin{{AppFullName: "demo-image-app", Version: "v1.0.0"}},
+	})
+	if err == nil {
+		t.Fatal("expected error for missing chart_domain")
+	}
+}

--- a/tools/release_helper_go/BUILD.bazel
+++ b/tools/release_helper_go/BUILD.bazel
@@ -10,7 +10,10 @@ go_library(
     ),
     importpath = "github.com/whale-net/everything/tools/release_helper_go/cmd",
     deps = [
+        "//libs/go/grpcauth",
+        "//libs/go/grpcclient",
         "//libs/go/semver",
+        "//tools/app_registry/protos:appregistrypb",
         "//tools/appmeta/proto:appmetapb",
         "//tools/helm:helm_lib",
         "@com_github_spf13_cobra//:cobra",

--- a/tools/release_helper_go/cmd/build_helm.go
+++ b/tools/release_helper_go/cmd/build_helm.go
@@ -73,6 +73,18 @@ func newBuildHelmChartCmd() *cobra.Command {
 				if err != nil {
 					return err
 				}
+				// AR-7f (issue #558): compose-time chart hermeticity, gated
+				// per domain. Runs here -- release_helper_go, a CLI the
+				// release workflow invokes as its own step -- not inside the
+				// `bazel build` below, which composes the chart via
+				// tools/helm/composer.go with no version resolution or
+				// registry access at all. See
+				// //tools/app_registry/ARCHITECTURE.md "Chart -> image
+				// lockfile" for why a registry call must never happen inside
+				// that Bazel action.
+				if err := checkChartHermeticity(cmd.Context(), func(msg string) { fmt.Fprintln(cmd.ErrOrStderr(), "::warning::"+msg) }, chart.Domain, appVersions); err != nil {
+					return err
+				}
 			} else {
 				appVersions = map[string]string{}
 				for _, appName := range chart.Apps {

--- a/tools/release_helper_go/cmd/chart_hermeticity.go
+++ b/tools/release_helper_go/cmd/chart_hermeticity.go
@@ -1,0 +1,150 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/whale-net/everything/libs/go/grpcauth"
+	"github.com/whale-net/everything/libs/go/grpcclient"
+	pb "github.com/whale-net/everything/tools/app_registry/protos"
+)
+
+// ChartPin is one member app's release-resolved image pin -- the value
+// build-helm-chart bakes into the chart's values.yaml imageTag, not the
+// "latest" placeholder tools/helm/composer.go's hermetic Bazel action writes
+// to the compose-time image lockfile (see
+// //tools/app_registry/ARCHITECTURE.md "Chart -> image lockfile").
+type ChartPin struct {
+	AppFullName string
+	Version     string
+}
+
+// ChartPinViolation is one pin CheckChartHermeticity rejected.
+type ChartPinViolation struct {
+	AppFullName string
+	Version     string
+	Reason      string
+}
+
+// ChartHermeticityChecker is AR-7f's (issue #558) compose-time gate: "a
+// chart may only pin images the registry has published." Implemented as an
+// interface so tests can substitute a fake instead of dialing a real
+// registry -- see chart_hermeticity_test.go.
+type ChartHermeticityChecker interface {
+	// Check returns enforced=false when chartDomain's adoption stage is not
+	// "allocate" (the per-domain gate; see ARCHITECTURE.md "Rejected
+	// alternatives (issue #558)") -- callers must not fail the build in that
+	// case, even if violations happens to be non-empty.
+	Check(ctx context.Context, chartDomain string, pins []ChartPin) (enforced bool, violations []ChartPinViolation, err error)
+}
+
+// defaultHermeticityChecker is replaced in tests via withHermeticityChecker.
+var defaultHermeticityChecker ChartHermeticityChecker = grpcHermeticityChecker{}
+
+// grpcHermeticityChecker calls ArtifactRegistry.CheckChartHermeticity over a
+// real gRPC connection, dialed fresh per call -- build-helm-chart runs once
+// per chart in a release, not as a long-lived process, matching
+// tools/app_registry/cli/cmd/client.go's "one dial per invocation" posture.
+// This is the ONLY place in the compose-time chart pipeline that talks to a
+// registry: tools/helm/composer.go (the Bazel action) never does, and this
+// code never runs there either -- it is called from build-helm-chart, a
+// release_helper_go CLI command that CI invokes as its own step, outside any
+// Bazel action's sandbox. See ARCHITECTURE.md "Chart -> image lockfile" for
+// why that split is load-bearing.
+type grpcHermeticityChecker struct{}
+
+func (grpcHermeticityChecker) Check(ctx context.Context, chartDomain string, pins []ChartPin) (bool, []ChartPinViolation, error) {
+	address := defaultEnv("APP_REGISTRY_ADDRESS")
+	if address == "" {
+		return false, nil, fmt.Errorf("APP_REGISTRY_ADDRESS is not set")
+	}
+
+	authOpt, err := grpcauth.NewServiceAccountDialOption(grpcauth.ClientConfig{
+		Mode:         grpcauth.AuthMode(envOrDefault("GRPC_AUTH_MODE", "none")),
+		TokenURL:     defaultEnv("GRPC_AUTH_TOKEN_URL"),
+		ClientID:     defaultEnv("GRPC_AUTH_CLIENT_ID"),
+		ClientSecret: defaultEnv("GRPC_AUTH_CLIENT_SECRET"),
+	})
+	if err != nil {
+		return false, nil, fmt.Errorf("app registry auth: %w", err)
+	}
+
+	conn, err := grpcclient.NewClient(ctx, address, authOpt)
+	if err != nil {
+		return false, nil, fmt.Errorf("dial app-registry-api at %s: %w", address, err)
+	}
+	defer conn.Close() //nolint:errcheck
+
+	client := pb.NewArtifactRegistryClient(conn.GetConnection())
+
+	req := &pb.CheckChartHermeticityRequest{ChartDomain: chartDomain}
+	for _, p := range pins {
+		req.Pins = append(req.Pins, &pb.ChartPin{AppFullName: p.AppFullName, Version: p.Version})
+	}
+
+	resp, err := client.CheckChartHermeticity(ctx, req)
+	if err != nil {
+		return false, nil, fmt.Errorf("CheckChartHermeticity: %w", err)
+	}
+
+	violations := make([]ChartPinViolation, 0, len(resp.Violations))
+	for _, v := range resp.Violations {
+		violations = append(violations, ChartPinViolation{AppFullName: v.AppFullName, Version: v.Version, Reason: v.Reason})
+	}
+	return resp.Enforced, violations, nil
+}
+
+func envOrDefault(key, fallback string) string {
+	if v := defaultEnv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+// checkChartHermeticity is build-helm-chart's call site for the AR-7f gate.
+// It is a no-op -- no registry client is even constructed -- unless
+// APP_REGISTRY_CICD_OPT_IN is exactly "true", matching every other App
+// Registry integration point in this repo (the bootstrap kill switch; see
+// ARCHITECTURE.md "APP_REGISTRY_CICD_OPT_IN"). That is also what keeps this
+// safe on a contributor's laptop or any environment with no registry
+// access: the variable defaults unset there, so this function returns
+// immediately without touching the network.
+//
+// A registry error (dial failure, auth failure, timeout) is deliberately
+// NOT fatal: it is reported as a warning and the build proceeds. Only an
+// actual CheckChartHermeticity response naming violations fails the build.
+// This mirrors the "best-effort" posture every App Registry step in
+// release.yml has at adoption stage observe/promote (continue-on-error) --
+// AR-7f does not change that posture for the chart-compose step itself, it
+// only adds a new failure mode (real violations at stage allocate) on top
+// of it. No domain is at "allocate" today, so in practice this function
+// currently never fails a build -- see PLAN.md's AR-7f "ships inert" note.
+func checkChartHermeticity(ctx context.Context, warn func(string), chartDomain string, appVersions map[string]string) error {
+	if defaultEnv("APP_REGISTRY_CICD_OPT_IN") != "true" {
+		return nil
+	}
+
+	pins := make([]ChartPin, 0, len(appVersions))
+	for appFullName, version := range appVersions {
+		pins = append(pins, ChartPin{AppFullName: appFullName, Version: version})
+	}
+	sort.Slice(pins, func(i, j int) bool { return pins[i].AppFullName < pins[j].AppFullName })
+
+	enforced, violations, err := defaultHermeticityChecker.Check(ctx, chartDomain, pins)
+	if err != nil {
+		warn(fmt.Sprintf("App Registry chart-hermeticity check skipped (registry error): %v", err))
+		return nil
+	}
+	if !enforced || len(violations) == 0 {
+		return nil
+	}
+
+	names := make([]string, 0, len(violations))
+	for _, v := range violations {
+		names = append(names, fmt.Sprintf("%s@%s (%s)", v.AppFullName, v.Version, v.Reason))
+	}
+	return fmt.Errorf("chart pins %d unpublished app(s), domain %q is at adoption stage 'allocate': %s",
+		len(violations), chartDomain, strings.Join(names, ", "))
+}

--- a/tools/release_helper_go/cmd/chart_hermeticity_test.go
+++ b/tools/release_helper_go/cmd/chart_hermeticity_test.go
@@ -1,0 +1,171 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// fakeHermeticityChecker lets tests drive checkChartHermeticity's call site
+// without dialing a real registry -- see ChartHermeticityChecker's doc
+// comment on why it is an interface at all.
+type fakeHermeticityChecker struct {
+	enforced   bool
+	violations []ChartPinViolation
+	err        error
+
+	calls int
+	// recorded captures the (chartDomain, pins) of the last call for tests
+	// that assert on what was sent, not just the response driving the
+	// outcome.
+	lastChartDomain string
+	lastPins        []ChartPin
+}
+
+func (f *fakeHermeticityChecker) Check(_ context.Context, chartDomain string, pins []ChartPin) (bool, []ChartPinViolation, error) {
+	f.calls++
+	f.lastChartDomain = chartDomain
+	f.lastPins = pins
+	return f.enforced, f.violations, f.err
+}
+
+func withHermeticityChecker(c ChartHermeticityChecker, fn func()) {
+	old := defaultHermeticityChecker
+	defaultHermeticityChecker = c
+	defer func() { defaultHermeticityChecker = old }()
+	fn()
+}
+
+func noopWarn(string) {}
+
+// TestCheckChartHermeticity_OptInOff proves the bootstrap-kill-switch no-op:
+// with APP_REGISTRY_CICD_OPT_IN unset, the checker is never even called --
+// not "called and ignored" -- so this is safe on a machine with no registry
+// access at all.
+func TestCheckChartHermeticity_OptInOff(t *testing.T) {
+	fake := &fakeHermeticityChecker{enforced: true, violations: []ChartPinViolation{{AppFullName: "demo-app", Version: "v1.0.0", Reason: "not recorded"}}}
+	withHermeticityChecker(fake, func() {
+		withEnv(map[string]string{}, func() {
+			err := checkChartHermeticity(context.Background(), noopWarn, "demo", map[string]string{"demo-app": "v1.0.0"})
+			if err != nil {
+				t.Fatalf("expected no-op with opt-in unset, got error: %v", err)
+			}
+		})
+	})
+	if fake.calls != 0 {
+		t.Fatalf("expected checker never called with opt-in unset, got %d calls", fake.calls)
+	}
+}
+
+// TestCheckChartHermeticity_OptInFalse is the explicit-false form of the
+// same no-op -- release.yml's other App Registry steps gate on the string
+// "true" specifically, and this must match.
+func TestCheckChartHermeticity_OptInFalse(t *testing.T) {
+	fake := &fakeHermeticityChecker{enforced: true, violations: []ChartPinViolation{{AppFullName: "demo-app", Version: "v1.0.0", Reason: "not recorded"}}}
+	withHermeticityChecker(fake, func() {
+		withEnv(map[string]string{"APP_REGISTRY_CICD_OPT_IN": "false"}, func() {
+			if err := checkChartHermeticity(context.Background(), noopWarn, "demo", map[string]string{"demo-app": "v1.0.0"}); err != nil {
+				t.Fatalf("expected no-op with opt-in false, got error: %v", err)
+			}
+		})
+	})
+	if fake.calls != 0 {
+		t.Fatalf("expected checker never called with opt-in false, got %d calls", fake.calls)
+	}
+}
+
+// TestCheckChartHermeticity_NotEnforced is the observe/promote-stage
+// regression this whole phase must not break: enforced=false must never
+// fail the build, even if the fake is (incorrectly, hypothetically) handed
+// violations alongside it.
+func TestCheckChartHermeticity_NotEnforced(t *testing.T) {
+	fake := &fakeHermeticityChecker{enforced: false, violations: []ChartPinViolation{{AppFullName: "demo-app", Version: "v1.0.0", Reason: "not recorded"}}}
+	withHermeticityChecker(fake, func() {
+		withEnv(map[string]string{"APP_REGISTRY_CICD_OPT_IN": "true"}, func() {
+			if err := checkChartHermeticity(context.Background(), noopWarn, "demo", map[string]string{"demo-app": "v1.0.0"}); err != nil {
+				t.Fatalf("expected no-op when not enforced, got error: %v", err)
+			}
+		})
+	})
+	if fake.calls != 1 {
+		t.Fatalf("expected checker called exactly once, got %d", fake.calls)
+	}
+}
+
+// TestCheckChartHermeticity_ViolationNamesTheApp is AR-7f's exit criterion:
+// an allocate-stage domain whose member app was never published fails,
+// naming the offending app.
+func TestCheckChartHermeticity_ViolationNamesTheApp(t *testing.T) {
+	fake := &fakeHermeticityChecker{enforced: true, violations: []ChartPinViolation{
+		{AppFullName: "demo-widget", Version: "v1.2.3", Reason: "not recorded in App Registry"},
+	}}
+	withHermeticityChecker(fake, func() {
+		withEnv(map[string]string{"APP_REGISTRY_CICD_OPT_IN": "true"}, func() {
+			err := checkChartHermeticity(context.Background(), noopWarn, "demo", map[string]string{"demo-widget": "v1.2.3"})
+			if err == nil {
+				t.Fatal("expected error naming the unpublished app, got nil")
+			}
+			if !strings.Contains(err.Error(), "demo-widget") {
+				t.Errorf("expected error to name demo-widget, got: %v", err)
+			}
+			if !strings.Contains(err.Error(), "v1.2.3") {
+				t.Errorf("expected error to name the pinned version, got: %v", err)
+			}
+		})
+	})
+}
+
+// TestCheckChartHermeticity_EnforcedNoViolations proves the success path:
+// enforced=true with no violations builds cleanly.
+func TestCheckChartHermeticity_EnforcedNoViolations(t *testing.T) {
+	fake := &fakeHermeticityChecker{enforced: true}
+	withHermeticityChecker(fake, func() {
+		withEnv(map[string]string{"APP_REGISTRY_CICD_OPT_IN": "true"}, func() {
+			if err := checkChartHermeticity(context.Background(), noopWarn, "demo", map[string]string{"demo-app": "v1.0.0"}); err != nil {
+				t.Fatalf("expected no error, got: %v", err)
+			}
+		})
+	})
+}
+
+// TestCheckChartHermeticity_RegistryErrorIsNotFatal proves the fail-open
+// posture on a transport/auth error: this must warn, not fail the chart
+// build, so a registry outage never blocks a chart release on its own (see
+// checkChartHermeticity's doc comment).
+func TestCheckChartHermeticity_RegistryErrorIsNotFatal(t *testing.T) {
+	fake := &fakeHermeticityChecker{err: fmt.Errorf("connection refused")}
+	var warnings []string
+	warn := func(msg string) { warnings = append(warnings, msg) }
+	withHermeticityChecker(fake, func() {
+		withEnv(map[string]string{"APP_REGISTRY_CICD_OPT_IN": "true"}, func() {
+			if err := checkChartHermeticity(context.Background(), warn, "demo", map[string]string{"demo-app": "v1.0.0"}); err != nil {
+				t.Fatalf("expected registry errors to be non-fatal, got: %v", err)
+			}
+		})
+	})
+	if len(warnings) != 1 {
+		t.Fatalf("expected exactly one warning on registry error, got %v", warnings)
+	}
+}
+
+// TestCheckChartHermeticity_PassesChartDomainAndPins locks in the wire
+// contract with the registry: the chart's OWN domain is sent (not any
+// member app's), and every pin's app_full_name/version round-trips.
+func TestCheckChartHermeticity_PassesChartDomainAndPins(t *testing.T) {
+	fake := &fakeHermeticityChecker{enforced: true}
+	withHermeticityChecker(fake, func() {
+		withEnv(map[string]string{"APP_REGISTRY_CICD_OPT_IN": "true"}, func() {
+			appVersions := map[string]string{"demo-a": "v1.0.0", "demo-b": "v2.0.0"}
+			if err := checkChartHermeticity(context.Background(), noopWarn, "demo", appVersions); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	})
+	if fake.lastChartDomain != "demo" {
+		t.Errorf("expected chart_domain %q, got %q", "demo", fake.lastChartDomain)
+	}
+	if len(fake.lastPins) != 2 {
+		t.Fatalf("expected 2 pins, got %v", fake.lastPins)
+	}
+}


### PR DESCRIPTION
Implements **AR-7f — Compose-time chart hermeticity** from `tools/app_registry/PLAN.md` (issue #558). Top of a 2-PR stack — **stacked on #571 (AR-7e)**, review that first. No schema change. **With this, every sub-phase of AR-7 is implemented.**

This is the steady state the issue title asks for: enforce "a chart may only pin images the registry has published" at chart **compose** time, so the failure lands before anything is pushed rather than after every push.

## Where the check runs — the constraint that shaped this

New read-only RPC `ArtifactRegistry.CheckChartHermeticity`, called from `tools/release_helper_go`'s `build-helm-chart` command — a CLI step the release workflow invokes, right after each chart member app's version is resolved and before the chart is packaged or pushed.

**`tools/helm/composer.go` is untouched.** Chart composition still runs inside `bazel build` with zero registry access. A Bazel action that talks to the registry over the network would not be hermetic, would poison the build cache with network-dependent results, and would break chart builds on any machine without registry access — including every contributor's laptop and the `APP_REGISTRY_CICD_OPT_IN=false` path. See ARCHITECTURE.md's "Chart → image lockfile". `build-helm-chart` is also where AR-2c's existing digest resolution already makes registry calls, so this follows the established boundary rather than inventing one.

## Gating and failure posture

**Enforced only for domains at `domain_adoption.stage = 'allocate'`** — the same per-domain gate every other tightening in AR-7 uses. Repo-wide enforcement was rejected in review: it would block every chart build until every member app had released through the registry at least once. Per-domain, a domain meets the strict rule only after it has been releasing through the registry anyway.

**No domain is at `allocate` today, so this ships inert**, the same way AR-5a did. That is stated plainly in PLAN.md along with what would have to change for it to bite.

Two fail-open guarantees, both tested:
- `checkChartHermeticity` reads `APP_REGISTRY_CICD_OPT_IN` and returns before constructing a registry client unless it is exactly `"true"`.
- A transport or auth error talking to the registry is a **warning, not a failure**. Only an actual `enforced=true` response naming violations fails the build.

That second one matters right now: per #569 the deployed server predates these RPCs, so `CheckChartHermeticity` currently returns `Unimplemented` — which this treats as a warning, leaving chart releases unaffected. (The general problem of skew being invisible is tracked in #570.)

## A convention deviation to bless or fold back

The handler lives in a new `server/handlers/chart_hermeticity.go` rather than in `artifact.go`, deviating from this repo's one-file-per-service layout. That was deliberate: AR-7e was being built in parallel against `artifact.go`, and the split kept the rebase mechanical. Worth either blessing or folding back once both land — flagging rather than leaving it to be discovered.

The handler only calls pre-existing repository methods (`DomainAdoption().GetStage`, `Artifacts().GetArtifact`), so no postgres/fake changes were needed.

## Tests

Exit criteria both covered: a chart in an `allocate`-stage domain whose member app was never published fails at compose time naming the app, with nothing pushed; and charts in `observe`/`promote`-stage domains build exactly as they do today — the regression that matters most, since every domain is at `observe` right now.

`tools/helm`'s golden-output tests stay green, unaffected because `composer.go` was not touched.

Verified by deliberately breaking and reverting: the stage gate (both `observe` and `promote` cases), the opt-in gate, the `!enforced` short-circuit, and the registry-error-is-not-fatal posture.

## Verification

`bazel build //tools/...` and `bazel test //tools/...` green (14/14). `postgres_integration_test` passes against real Postgres — **126.1s on the combined stack tip**, running this PR's tests together with #571's.

Ref: #558, #559, #569, #570
