### PR TITLE
fix(app-registry): distinguish version skew from outage in CI recording (#570)

### DIFF
--- a/.github/actions/app-registry-assert/action.yml
+++ b/.github/actions/app-registry-assert/action.yml
@@ -16,6 +16,14 @@ description: >-
   tools/app_registry/ARCHITECTURE.md "AssertApps (additive) vs.
   ReconcileApps (absence sweep)".
 
+  Being the first registry call in a release run also makes this the
+  earliest point a CI/server version-skew defect (issue #570) can be
+  caught: if the deployed app-registry-api doesn't implement AssertApps at
+  all, the CLI exits 4 (exitVersionSkew, see cli/cmd/root.go) and this step
+  emits an `::error::` annotation up front, rather than the skew only
+  surfacing later at whichever RecordBuild/RecordArtifact/BeginPublish call
+  happens to hit a missing RPC first.
+
   Requires RELEASE_HELPER and APP_REGISTRY_CLI env vars already set (see
   .github/actions/download-release-tools).
 
@@ -58,6 +66,22 @@ runs:
       # simply means every app/chart at this ref gets a fresh snapshot.
       run: |
         "$RELEASE_HELPER" manifest-set --git-sha "$GIT_SHA" > "$RUNNER_TEMP/manifest-set.json"
-        "$APP_REGISTRY_CLI" apps assert \
+
+        set +e
+        ASSERT_OUTPUT=$("$APP_REGISTRY_CLI" apps assert \
           --from-plan "$RUNNER_TEMP/manifest-set.json" \
-          --idempotency-key "$IDEMPOTENCY_KEY"
+          --idempotency-key "$IDEMPOTENCY_KEY" 2>&1)
+        ASSERT_EXIT=$?
+        set -e
+
+        if [[ $ASSERT_EXIT -eq 4 ]]; then
+          echo "$ASSERT_OUTPUT"
+          echo "::error title=App Registry: version skew (AssertApps not implemented)::The deployed app-registry-api does not implement AssertApps. This is a CI/server version skew (issue #570), not an outage -- it will NOT clear on retry, and every recording step later in this run will very likely fail the same way. Roll app-registry-api forward, or set APP_REGISTRY_CICD_OPT_IN to false until it is deployed."
+          exit 1
+        elif [[ $ASSERT_EXIT -ne 0 ]]; then
+          echo "$ASSERT_OUTPUT"
+          echo "::warning title=App Registry: AssertApps skipped (registry error)::Could not assert app/chart identity in the App Registry -- a registry outage, auth failure, or other transient error. Recording later in this run is best-effort and may hit issue #547's owner-not-reconciled case as a result."
+          exit 1
+        fi
+
+        echo "$ASSERT_OUTPUT"

--- a/.github/actions/app-registry-begin-publish-batch/action.yml
+++ b/.github/actions/app-registry-begin-publish-batch/action.yml
@@ -20,6 +20,10 @@ description: >-
   does NOT block the other targets in the same batch -- see
   cli/cmd/artifacts.go's newArtifactsBeginPublishBatchCmd.
 
+  Version skew (issue #570): if the whole RPC is missing server-side, the
+  CLI exits 4 (exitVersionSkew) and this step escalates to `::error::`
+  instead of `::warning::`, since that will not clear on retry.
+
 inputs:
   address:
     required: true
@@ -64,7 +68,10 @@ runs:
         set -e
 
         echo "$BATCH_OUTPUT"
-        if [[ $BATCH_EXIT -ne 0 ]]; then
+        if [[ $BATCH_EXIT -eq 4 ]]; then
+          echo "::error title=App Registry: version skew (begin-publish-batch not implemented)::The deployed app-registry-api does not implement BeginPublishBatch. This is a CI/server version skew (issue #570), not an outage -- it will NOT clear on retry. Roll app-registry-api forward, or set APP_REGISTRY_CICD_OPT_IN to false until it is deployed. Targets fall back to being recorded per-leg as before; the release still proceeds."
+          exit 1
+        elif [[ $BATCH_EXIT -ne 0 ]]; then
           echo "::warning title=App Registry: begin-publish-batch skipped or partial (registry error)::Could not transition every release target to 'publishing' up front -- a registry outage, auth failure, or a target whose owner isn't reconciled yet. Recording is best-effort; the release still proceeds. Targets left un-declared fall back to being recorded per-leg as before, and won't show up as 'incomplete' in \`app-registry builds status\` if their own leg never runs -- see OPERATIONS.md."
           exit 1
         fi

--- a/.github/actions/app-registry-begin-publish/action.yml
+++ b/.github/actions/app-registry-begin-publish/action.yml
@@ -31,6 +31,11 @@ description: >-
   `continue-on-error: true`), so a caller can branch on
   `steps.<id>.outcome` to decide whether to attempt FailPublish later.
 
+  Version skew (issue #570): the CLI exits 4 (exitVersionSkew, see
+  cli/cmd/root.go) when the deployed server doesn't implement BeginPublish at
+  all -- that gets an `::error::` annotation instead of the `::warning::` a
+  plain outage gets, since it will not clear on retry.
+
 inputs:
   address:
     required: true
@@ -83,7 +88,11 @@ runs:
         BEGIN_EXIT=$?
         set -e
 
-        if [[ $BEGIN_EXIT -ne 0 ]]; then
+        if [[ $BEGIN_EXIT -eq 4 ]]; then
+          echo "$BEGIN_OUTPUT"
+          echo "::error title=App Registry: version skew (begin-publish not implemented)::The deployed app-registry-api does not implement BeginPublish. This is a CI/server version skew (issue #570), not an outage -- it will NOT clear on retry. Roll app-registry-api forward, or set APP_REGISTRY_CICD_OPT_IN to false until it is deployed. The push still proceeds."
+          exit 1
+        elif [[ $BEGIN_EXIT -ne 0 ]]; then
           echo "$BEGIN_OUTPUT"
           echo "::warning title=App Registry: begin-publish skipped (registry error)::Could not transition ${OWNER} ${VERSION} to 'publishing' in the App Registry -- a registry outage, auth failure, or other transient error. Recording is best-effort; the push still proceeds."
           exit 1

--- a/.github/actions/app-registry-fail-publish/action.yml
+++ b/.github/actions/app-registry-fail-publish/action.yml
@@ -18,6 +18,12 @@ description: >-
   job itself; the release already failed for its own reason by the time
   this step runs.
 
+  Version skew (issue #570): the CLI exits 4 (exitVersionSkew) when the
+  deployed server doesn't implement FailPublish at all -- that gets an
+  `::error::` annotation instead of `::warning::`, same as every other App
+  Registry step, so grepping a run for version-skew annotations finds every
+  occurrence rather than missing this one.
+
 inputs:
   address:
     required: true
@@ -71,7 +77,11 @@ runs:
         FAIL_EXIT=$?
         set -e
 
-        if [[ $FAIL_EXIT -ne 0 ]]; then
+        if [[ $FAIL_EXIT -eq 4 ]]; then
+          echo "$FAIL_OUTPUT"
+          echo "::error title=App Registry: version skew (fail-publish not implemented)::The deployed app-registry-api does not implement FailPublish. This is a CI/server version skew (issue #570), not an outage -- it will NOT clear on retry. ${OWNER} ${VERSION} will sit as 'publishing' until the stale-row reaper expires it (see ENV.md's ARTIFACT_REAPER_TIMEOUT)."
+          exit 1
+        elif [[ $FAIL_EXIT -ne 0 ]]; then
           echo "$FAIL_OUTPUT"
           echo "::warning title=App Registry: fail-publish skipped (registry error)::Could not transition ${OWNER} ${VERSION} to 'failed' in the App Registry -- it will sit as 'publishing' until the stale-row reaper expires it (see ENV.md's ARTIFACT_REAPER_TIMEOUT)."
           exit 1

--- a/.github/actions/app-registry-record-build/action.yml
+++ b/.github/actions/app-registry-record-build/action.yml
@@ -18,6 +18,12 @@ description: >-
   that, and downstream steps that depend on `build-id` are already
   conditioned on it being non-empty so they skip cleanly.
 
+  Version skew (issue #570) is called out separately from a plain outage:
+  the CLI exits 4 (exitVersionSkew, see cli/cmd/root.go) when the deployed
+  app-registry-api doesn't implement RecordBuild at all (codes.Unimplemented)
+  -- a deployment defect that will not clear on retry -- so that case gets
+  an `::error::` annotation instead of the `::warning::` an outage gets.
+
 inputs:
   address:
     required: true
@@ -83,7 +89,16 @@ runs:
         RECORD_EXIT=$?
         set -e
 
-        if [[ $RECORD_EXIT -ne 0 ]]; then
+        if [[ $RECORD_EXIT -eq 4 ]]; then
+          echo "$BUILD_JSON"
+          echo "::error title=App Registry: version skew (RecordBuild not implemented)::The deployed app-registry-api does not implement RecordBuild. This is a CI/server version skew (issue #570), not an outage -- it will NOT clear on retry. Roll app-registry-api forward, or set APP_REGISTRY_CICD_OPT_IN to false until it is deployed. Downstream App Registry steps for this job will skip, since no build-id was returned."
+          {
+            echo "### ❌ App Registry: version skew"
+            echo ""
+            echo "RecordBuild failed for workflow run \`${WORKFLOW_RUN_ID}\` (attempt \`${WORKFLOW_ATTEMPT}\`) -- the deployed server does not implement this RPC. This will not clear on retry. See tools/app_registry/ARCHITECTURE.md#availability-and-bootstrap and OPERATIONS.md."
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit 1
+        elif [[ $RECORD_EXIT -ne 0 ]]; then
           echo "$BUILD_JSON"
           echo "::warning title=App Registry: build recording skipped (registry error)::Could not record this workflow run's build in the App Registry -- a registry outage, auth failure, or other transient error. Recording is best-effort; the release still succeeded. Downstream App Registry steps for this job will skip, since no build-id was returned."
           {

--- a/.github/actions/app-registry-record-image/action.yml
+++ b/.github/actions/app-registry-record-image/action.yml
@@ -13,8 +13,10 @@ description: >-
   error (matching release.yml's `continue-on-error: true` on the calling
   step), but the annotation now distinguishes "app isn't registered yet"
   (owner ran ahead of ReconcileApps -- issue #547, see
-  tools/app_registry/ARCHITECTURE.md "Rejected alternatives") from any other
-  registry failure, instead of swallowing both identically.
+  tools/app_registry/ARCHITECTURE.md "Rejected alternatives") and "version
+  skew" (the deployed server is missing this RPC -- issue #570, an `::error::`
+  since it will not clear on retry) from a plain outage, instead of
+  swallowing all three identically.
 
 inputs:
   address:
@@ -100,6 +102,15 @@ runs:
             echo "This release ran ahead of \`ReconcileApps\`, which runs on push to \`main\` via \`ci.yml\`. This is an accepted, documented tradeoff -- see \`tools/app_registry/ARCHITECTURE.md\` (\"Release-vs-reconcile gap\") and \`tools/app_registry/OPERATIONS.md\` (\"Release ran ahead of reconcile\")."
             echo ""
             echo "**What to do:** wait for \`main\`'s CI to finish reconciling, then re-run this release job -- or accept the miss (the app self-heals on the next reconcile; this specific artifact record does not get backfilled)."
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit 1
+        elif [[ $RECORD_EXIT -eq 4 ]]; then
+          echo "$RECORD_OUTPUT"
+          echo "::error title=App Registry: version skew (artifacts record not implemented)::The deployed app-registry-api does not implement recording an image artifact. This is a CI/server version skew (issue #570), not an outage -- ${OWNER} ${VERSION} was NOT recorded, and it will NOT clear on retry. Roll app-registry-api forward, or set APP_REGISTRY_CICD_OPT_IN to false until it is deployed."
+          {
+            echo "### ❌ App Registry: version skew"
+            echo ""
+            echo "\`${OWNER}\` \`${VERSION}\` was **not recorded** -- the deployed server does not implement this RPC. This will not clear on retry. See tools/app_registry/ARCHITECTURE.md#availability-and-bootstrap and OPERATIONS.md."
           } >> "$GITHUB_STEP_SUMMARY"
           exit 1
         else

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1114,6 +1114,10 @@ jobs:
 
           if [[ $BEGIN_EXIT -eq 0 ]]; then
             echo "✅ ${PUBLISHED_NAME} ${CHART_VERSION} is now 'publishing' in App Registry"
+          elif [[ $BEGIN_EXIT -eq 4 ]]; then
+            echo "$BEGIN_OUTPUT"
+            echo "::error title=App Registry: version skew (begin-publish not implemented)::The deployed app-registry-api does not implement BeginPublish. This is a CI/server version skew (issue #570), not an outage -- it will NOT clear on retry. ${PUBLISHED_NAME} ${CHART_VERSION} was not transitioned to 'publishing'."
+            BEGIN_HAD_FAILURE=1
           else
             echo "$BEGIN_OUTPUT"
             echo "::warning title=App Registry: begin-publish skipped (registry error)::Could not transition ${PUBLISHED_NAME} ${CHART_VERSION} to 'publishing'."
@@ -1268,6 +1272,9 @@ jobs:
 
           if [[ $FAIL_EXIT -eq 0 ]]; then
             echo "⚠️ ${PUBLISHED_NAME} ${CHART_VERSION} marked 'failed' in App Registry"
+          elif [[ $FAIL_EXIT -eq 4 ]]; then
+            echo "$FAIL_OUTPUT"
+            echo "::error title=App Registry: version skew (fail-publish not implemented)::The deployed app-registry-api does not implement FailPublish. This is a CI/server version skew (issue #570), not an outage -- it will NOT clear on retry. ${PUBLISHED_NAME} ${CHART_VERSION} will sit as 'publishing' until the stale-row reaper expires it."
           else
             echo "$FAIL_OUTPUT"
             echo "::warning title=App Registry: fail-publish skipped (registry error)::Could not transition ${PUBLISHED_NAME} ${CHART_VERSION} to 'failed'; it will sit as 'publishing' until the stale-row reaper expires it."
@@ -1388,6 +1395,15 @@ jobs:
               echo "This release ran ahead of \`ReconcileApps\`, which runs on push to \`main\` via \`ci.yml\`. This is an accepted, documented tradeoff -- see \`tools/app_registry/ARCHITECTURE.md\` (\"Release-vs-reconcile gap\") and \`tools/app_registry/OPERATIONS.md\` (\"Release ran ahead of reconcile\")."
               echo ""
               echo "**What to do:** wait for \`main\`'s CI to finish reconciling, then re-run this release job -- or accept the miss (the chart self-heals on the next reconcile; this specific artifact record does not get backfilled)."
+            } >> "$GITHUB_STEP_SUMMARY"
+            RECORDING_HAD_FAILURE=1
+          elif [[ $RECORD_EXIT -eq 4 ]]; then
+            echo "$RECORD_OUTPUT"
+            echo "::error title=App Registry: version skew (artifacts record not implemented)::The deployed app-registry-api does not implement recording a chart artifact. This is a CI/server version skew (issue #570), not an outage -- ${PUBLISHED_NAME} ${CHART_VERSION} was NOT recorded, and it will NOT clear on retry. Roll app-registry-api forward, or set APP_REGISTRY_CICD_OPT_IN to false until it is deployed."
+            {
+              echo "### ❌ App Registry: version skew"
+              echo ""
+              echo "\`${PUBLISHED_NAME}\` \`${CHART_VERSION}\` was **not recorded** -- the deployed server does not implement this RPC. This will not clear on retry. See tools/app_registry/ARCHITECTURE.md#availability-and-bootstrap and OPERATIONS.md."
             } >> "$GITHUB_STEP_SUMMARY"
             RECORDING_HAD_FAILURE=1
           else

--- a/tools/app_registry/ARCHITECTURE.md
+++ b/tools/app_registry/ARCHITECTURE.md
@@ -1282,6 +1282,52 @@ only thing lost is the ability to *make new promotions* during the outage.
 > #558)" → "Availability, restated per adoption stage". Every domain is at
 > `observe` today, so nothing here is wrong yet.
 
+### Version skew vs. outage (issue #570)
+
+"Best-effort" above described every registry-call failure as one bucket: a
+`continue-on-error` step goes red, the job stays green, an operator has to
+read the step log to find out why. Issue #569 showed that bucket hides two
+very different failures. `codes.Unavailable`/`DeadlineExceeded`/
+`Unauthenticated` etc. are an **outage** — transient, self-clearing, exactly
+what "best-effort" is designed to absorb. `codes.Unimplemented` is a
+**deployment defect**: CI's `app-registry` CLI is built from the commit being
+released, the server is whatever was last deployed, and if the CLI calls an
+RPC the server predates, retrying the same release does nothing — only
+rolling the server forward (or turning off `APP_REGISTRY_CICD_OPT_IN`) clears
+it. In #569 that ran silently for two releases across two different missing
+RPCs before anyone noticed, because both cases produced the same
+`::warning::`.
+
+The CLI now classifies this centrally instead of every caller string-grepping
+stderr: `cli/cmd/root.go`'s `exitCodeFor` maps a gRPC status of
+`codes.Unimplemented` to `exitVersionSkew` (process exit code 4), distinct
+from the generic exit 1 every other failure (including every outage code
+above) still gets, and from `exitOwnerNotReconciled` (exit 3, issue #547 —
+an *application*-level rejection, not a missing method). Every composite
+action and inline script in `.github/actions/app-registry-*` and
+`release.yml`'s chart-recording loops branches on exit 4 to emit `::error::`
+instead of `::warning::`, naming it a version-skew/deployment defect that
+will not clear on retry rather than "the registry might be down, try again."
+
+This closes the loudness gap `AssertApps`-first-step notwithstanding: even
+though `app-registry-assert` runs before every other registry call in a
+release (AR-7c, see "`AssertApps` (additive) vs. `ReconcileApps`" above), a
+skew there now surfaces immediately rather than only once whichever
+downstream RPC happens to be the first one the deployed server lacks.
+
+**What this does not do:** the steps stay `continue-on-error: true` at
+adoption stage `observe` (every domain, today), same as before — an
+`::error::` annotation is louder than `::warning::` in the run's summary, but
+it does not turn the job red on its own. Making version skew (or any
+recording failure) actually fail the job at `promote`/`allocate` requires CI
+to read a domain's `domain_adoption.stage` per release, which does not exist
+today (see "Availability, restated per adoption stage" above — that table is
+a design target, not current behavior) and is a reasonable fast-follow, not
+part of this change. The `main`-push reconcile sweep (`ci.yml`,
+`app-registry-reconcile`) already fails red on any error including skew,
+uniformly, because it was already NOT `continue-on-error` (AR-7a) — it needed
+no change here.
+
 ### `APP_REGISTRY_CICD_OPT_IN` — the bootstrap kill switch
 
 "Best-effort" is not enough on its own. The registry is built and released by

--- a/tools/app_registry/OPERATIONS.md
+++ b/tools/app_registry/OPERATIONS.md
@@ -74,18 +74,32 @@ To check whether a specific release actually got recorded:
    succeeded.
 4. A step that ran, shows a red `X` inline but the **job** is still green —
    this is the silent-failure case. The run's summary page (the
-   `::warning::` annotations GitHub surfaces at the top of the run, and the
-   `$GITHUB_STEP_SUMMARY` section below the job list) tells you which kind:
-   - **`App Registry: <owner> not registered yet`** — as of AR-7c (issue
-     #558), this should no longer happen in normal operation: `release.yml`
-     now calls `AssertApps` as the first App Registry step of every job that
-     later resolves an owner by full name (see "AR-7c: AssertApps closed
-     issue #547" below). If you see it anyway, the `AssertApps` step itself
-     probably failed too (a registry outage fails every App Registry step in
-     the same job, `AssertApps` included) — check that step's log first.
-   - **`App Registry: recording skipped (registry error)`** — a genuine
-     registry outage, auth failure, or timeout. Check the step log for the
-     underlying gRPC error (`Unauthenticated`, `Unavailable`, etc.).
+   `::warning::`/`::error::` annotations GitHub surfaces at the top of the
+   run, and the `$GITHUB_STEP_SUMMARY` section below the job list) tells you
+   which kind:
+   - **`::error:: App Registry: version skew (... not implemented)`** (issue
+     #570) — the deployed `app-registry-api` doesn't have an RPC this CLI
+     build calls. **This will not clear on retry or re-run** — CI's CLI is
+     built from the commit being released, the server is whatever was last
+     deployed, and re-running the same release just calls the same missing
+     method again. Roll `app-registry-api` forward to a build that has the
+     RPC, or set `APP_REGISTRY_CICD_OPT_IN=false` until it is deployed. This
+     is an `::error::`, not a `::warning::`, specifically so it doesn't read
+     as "try again later" — see
+     [ARCHITECTURE.md](ARCHITECTURE.md#version-skew-vs-outage-issue-570).
+   - **`::warning:: App Registry: <owner> not registered yet`** — as of AR-7c
+     (issue #558), this should no longer happen in normal operation:
+     `release.yml` now calls `AssertApps` as the first App Registry step of
+     every job that later resolves an owner by full name (see "AR-7c:
+     AssertApps closed issue #547" below). If you see it anyway, the
+     `AssertApps` step itself probably failed too (a registry outage fails
+     every App Registry step in the same job, `AssertApps` included) — check
+     that step's log first.
+   - **`::warning:: App Registry: recording skipped (registry error)`** — a
+     genuine, transient outage: connectivity, auth, or a timeout. Check the
+     step log for the underlying gRPC error (`Unauthenticated`,
+     `Unavailable`, `DeadlineExceeded`, etc.). Re-running later is a
+     reasonable next step here, unlike the version-skew case above.
    The job outcome tells you nothing; only the step log (or now, the run
    summary) does.
 

--- a/tools/app_registry/cli/cmd/BUILD.bazel
+++ b/tools/app_registry/cli/cmd/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "@com_github_google_uuid//:uuid",
         "@com_github_spf13_cobra//:cobra",
         "@org_golang_google_genproto_googleapis_rpc//errdetails",
+        "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//status",
         "@org_golang_google_protobuf//encoding/protojson",
         "@org_golang_google_protobuf//proto",

--- a/tools/app_registry/cli/cmd/root.go
+++ b/tools/app_registry/cli/cmd/root.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/whale-net/everything/tools/app_registry/apierrors"
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
@@ -39,6 +40,25 @@ var rootCmd = &cobra.Command{
 // since a shell script can't import this package.
 const exitOwnerNotReconciled = 3
 
+// exitVersionSkew is the process exit code Execute uses when an RPC fails
+// with codes.Unimplemented -- the deployed app-registry-api does not have a
+// method this CLI build calls (issue #570, the general case #569 was one
+// instance of). Unlike a plain outage (Unavailable, DeadlineExceeded,
+// Unauthenticated -- all still exit 1), Unimplemented does not clear on
+// retry: it means CI's CLI and the deployed server have drifted, and only
+// redeploying the server (or turning off APP_REGISTRY_CICD_OPT_IN) fixes it.
+// Composite actions use this to escalate their annotation from `::warning::`
+// (transient, best-effort-and-move-on) to `::error::` (deployment defect,
+// loud at every adoption stage) -- see
+// tools/app_registry/ARCHITECTURE.md#availability-and-bootstrap.
+//
+// Keep this constant's value in sync with every GitHub Actions call site
+// that checks for it literally, since a shell script can't import this
+// package -- see the "$RECORD_EXIT -eq 4" (or equivalent) branches across
+// .github/actions/app-registry-*/action.yml and release.yml's inline chart
+// loops.
+const exitVersionSkew = 4
+
 // Execute runs the CLI. Called from main.go.
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
@@ -48,14 +68,27 @@ func Execute() {
 }
 
 // exitCodeFor classifies err into a process exit code. Every failure other
-// than the owner-not-reconciled case keeps the CLI's long-standing exit
-// code 1 -- this only carves out one specific, structured signal a caller
-// can rely on; it is not a general error-taxonomy exit-code scheme.
+// than the two carved-out cases below keeps the CLI's long-standing exit
+// code 1 -- this is not a general error-taxonomy exit-code scheme, just the
+// specific, structured signals a caller can rely on.
 func exitCodeFor(err error) int {
 	if isOwnerNotReconciled(err) {
 		return exitOwnerNotReconciled
 	}
+	if isVersionSkew(err) {
+		return exitVersionSkew
+	}
 	return 1
+}
+
+// isVersionSkew reports whether err is a gRPC status with
+// codes.Unimplemented -- the server doesn't have the method at all, as
+// opposed to rejecting the call for a reason of its own (those come back as
+// InvalidArgument, FailedPrecondition, etc. and fall through to exit 1 like
+// always). A non-gRPC error naturally reports false.
+func isVersionSkew(err error) bool {
+	st, ok := status.FromError(err)
+	return ok && st.Code() == codes.Unimplemented
 }
 
 // isOwnerNotReconciled reports whether err is a gRPC status carrying an

--- a/tools/app_registry/cli/cmd/root_test.go
+++ b/tools/app_registry/cli/cmd/root_test.go
@@ -71,3 +71,45 @@ func TestExitCodeFor_NonGRPCErrorFallsBackToOne(t *testing.T) {
 		t.Errorf("exitCodeFor() = %d, want 1", got)
 	}
 }
+
+// TestExitCodeFor_Unimplemented locks in the exit code every
+// app-registry-*/action.yml composite action and release.yml's inline chart
+// loops branch on to distinguish version skew (issue #570) from a plain
+// outage. Changing exitVersionSkew's value without updating those call
+// sites would silently break that branch, same risk exitOwnerNotReconciled's
+// doc comment already calls out for issue #547.
+func TestExitCodeFor_Unimplemented(t *testing.T) {
+	err := status.Error(codes.Unimplemented, "unknown method BeginPublishBatch for service appregistry.v1.ArtifactRegistry")
+	if got := exitCodeFor(err); got != exitVersionSkew {
+		t.Errorf("exitCodeFor() = %d, want %d (exitVersionSkew)", got, exitVersionSkew)
+	}
+}
+
+// TestExitCodeFor_UnimplementedOutranksOwnerNotReconciled is a belt-and-
+// suspenders check: the two carved-out reasons are mutually exclusive in
+// practice (Unimplemented means the server never got far enough to attach
+// an ErrorInfo detail), but isOwnerNotReconciled is checked first in
+// exitCodeFor, so this pins the actual precedence rather than leaving it
+// implicit in the code's dependency line above.
+func TestExitCodeFor_UnimplementedOutranksOwnerNotReconciled(t *testing.T) {
+	err := status.Error(codes.Unimplemented, "unknown method")
+	if isOwnerNotReconciled(err) {
+		t.Fatalf("isOwnerNotReconciled() = true for a plain Unimplemented status, want false")
+	}
+	if got := exitCodeFor(err); got != exitVersionSkew {
+		t.Errorf("exitCodeFor() = %d, want %d (exitVersionSkew)", got, exitVersionSkew)
+	}
+}
+
+// TestExitCodeFor_OtherCodesFallBackToOne covers the specific codes issue
+// #570 says must keep today's best-effort behavior: a plain outage
+// (Unavailable, DeadlineExceeded) or an auth failure must not be
+// misclassified as version skew.
+func TestExitCodeFor_OtherCodesFallBackToOne(t *testing.T) {
+	for _, code := range []codes.Code{codes.Unavailable, codes.DeadlineExceeded, codes.Unauthenticated, codes.PermissionDenied, codes.InvalidArgument} {
+		err := status.Error(code, "some failure")
+		if got := exitCodeFor(err); got != 1 {
+			t.Errorf("exitCodeFor(%s) = %d, want 1", code, got)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Classifies gRPC `Unimplemented` errors (deployed `app-registry-api` missing an RPC the CI-built CLI calls) as a distinct, non-retryable *version skew* case, separate from a plain outage (`Unavailable`, `DeadlineExceeded`, `Unauthenticated`, etc).
- Every `.github/actions/app-registry-*` composite action and `release.yml`'s inline chart-recording loops now emit a loud `::error::` annotation (naming it a deployment defect that will not clear on retry) instead of the generic `::warning::` an outage gets, so a skewed server doesn't produce a green run that silently recorded nothing — the exact failure mode in #569.
- Centralizes the classification in the CLI (`cli/cmd/root.go`'s `exitCodeFor`, extending the exit-code pattern `#547` established for owner-not-reconciled) rather than duplicating gRPC-status string-grepping across every composite action's bash.

## Changes

- `tools/app_registry/cli/cmd/root.go`: new `exitVersionSkew = 4` / `isVersionSkew` (checks `codes.Unimplemented`), wired into `exitCodeFor`. Exit 1 (generic) and exit 3 (`#547`'s owner-not-reconciled) are unchanged.
- `tools/app_registry/cli/cmd/root_test.go`: covers Unimplemented classification, precedence over owner-not-reconciled, and that outage codes still fall back to exit 1.
- 6 composite actions (`app-registry-record-build`, `-record-image`, `-begin-publish`, `-begin-publish-batch`, `-fail-publish`, `-assert`) and 3 inline chart-loop blocks in `release.yml`: branch on exit code 4 to emit `::error::` instead of `::warning::`.
- `tools/app_registry/ARCHITECTURE.md`: new "Version skew vs. outage (issue #570)" subsection, including an explicit "what this does not do" — steps stay `continue-on-error` at adoption stage `observe` (every domain today); making skew fail the job at `promote`/`allocate` needs CI to read `domain_adoption.stage` per release, which doesn't exist yet. Left as a fast-follow rather than folded in here, since it needs new plumbing the issue itself said this change shouldn't require.
- `tools/app_registry/OPERATIONS.md`: added the `::error::` case to the existing silent-failure detection guidance.

`app-registry-reconcile` (`ci.yml`) and `promote.yml` needed no changes — both already fail hard on any error (reconcile since AR-7a, promote was never `continue-on-error`).

## Testing

- `bazel test //tools/app_registry/cli/...` — passes (new tests included).
- `bazel build //tools/app_registry/...` — clean.
- Modified workflow/composite-action YAML validated (`yaml.safe_load` + `bash -n` on embedded `run:` blocks). This part is shell-in-YAML and not Bazel-testable directly; real end-to-end behavior needs an actual CI run against a server missing an RPC — the same way #569/#570 themselves were discovered.

## Related Issues

Closes #570
Ref #569 (fixed and closed separately — confirmed via https://github.com/whale-net/everything/actions/runs/31530259129)