### PR TITLE
fix(app-registry): strip helm-{domain}- prefix from ChartManifest.Name

### DIFF
--- a/tools/app_registry/server/handlers/BUILD.bazel
+++ b/tools/app_registry/server/handlers/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//tools/app_registry/protos:appregistrypb",
         "//tools/app_registry/server/auth",
         "//tools/app_registry/server/repository",
+        "//tools/appmeta/proto:appmetapb",
         "@org_golang_google_genproto_googleapis_rpc//errdetails",
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//status",

--- a/tools/app_registry/server/handlers/app.go
+++ b/tools/app_registry/server/handlers/app.go
@@ -11,6 +11,7 @@ import (
 	pb "github.com/whale-net/everything/tools/app_registry/protos"
 	"github.com/whale-net/everything/tools/app_registry/server/auth"
 	"github.com/whale-net/everything/tools/app_registry/server/repository"
+	appmetapb "github.com/whale-net/everything/tools/appmeta/proto"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
@@ -39,6 +40,7 @@ func (s *AppServer) ReconcileApps(ctx context.Context, req *pb.ReconcileAppsRequ
 	if req.Manifests == nil {
 		return nil, status.Error(codes.InvalidArgument, "manifests is required")
 	}
+	normalizeChartManifests(req.Manifests.Charts)
 
 	// source is the ordering metadata Reconcile checks against the
 	// reconcile watermark -- see ARCHITECTURE.md "Reconcile watermark" and
@@ -112,6 +114,19 @@ func (s *AppServer) ReconcileApps(ctx context.Context, req *pb.ReconcileAppsRequ
 	return resp.(*pb.ReconcileAppsResponse), nil
 }
 
+// normalizeChartManifests strips the "helm-{domain}-" prefix
+// release_helm_chart's Bazel macro bakes into ChartManifest.Name before it
+// reaches either ReconcileApps or AssertApps, so both key charts the same
+// way they key apps: bare name, domain held separately. See
+// repository.NormalizeChartName and Chart.FullName's doc comments. Mutates
+// in place -- req.Manifests is this call's private, freshly-unmarshaled
+// copy, not shared or cached elsewhere.
+func normalizeChartManifests(charts []*appmetapb.ChartManifest) {
+	for _, cm := range charts {
+		cm.Name = repository.NormalizeChartName(cm.Domain, cm.Name)
+	}
+}
+
 func reconcileResultToPB(r *repository.ReconcileResult, dryRun bool) *pb.ReconcileAppsResponse {
 	return &pb.ReconcileAppsResponse{
 		CreatedApps:            appsToPB(r.CreatedApps),
@@ -159,6 +174,7 @@ func (s *AppServer) AssertApps(ctx context.Context, req *pb.AssertAppsRequest) (
 	if req.Manifests == nil {
 		return nil, status.Error(codes.InvalidArgument, "manifests is required")
 	}
+	normalizeChartManifests(req.Manifests.Charts)
 	if req.IdempotencyKey == "" {
 		return nil, status.Error(codes.InvalidArgument, "idempotency_key is required")
 	}

--- a/tools/app_registry/server/handlers/app_test.go
+++ b/tools/app_registry/server/handlers/app_test.go
@@ -375,6 +375,40 @@ func TestReconcileApps_ChartComposesApps(t *testing.T) {
 	}
 }
 
+// TestReconcileApps_ChartNameStripsHelmDomainPrefix covers the manifest
+// shape release_helm_chart's Bazel macro actually emits: Name carries a
+// "helm-{domain}-" prefix baked in for git tag/tarball naming (e.g.
+// "helm-app-registry-app-registry" when a chart's domain and base name
+// coincide, as with the app-registry chart itself). ReconcileApps must strip
+// that prefix so Chart.FullName() matches the "{domain}-{name}" identifier
+// the release pipeline uses for BeginPublish/RecordArtifact, rather than
+// doubling up the domain (e.g. "app-registry-helm-app-registry-app-registry").
+func TestReconcileApps_ChartNameStripsHelmDomainPrefix(t *testing.T) {
+	ctx := authedCtx()
+	srv := NewAppServer(fake.New())
+
+	resp, err := srv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
+		Manifests: manifestSet(
+			[]*appmetapb.AppManifest{oneApp("app-registry", "svc")},
+			[]*appmetapb.ChartManifest{{Domain: "app-registry", Name: "helm-app-registry-app-registry", Apps: []string{"svc"}}},
+		),
+		IdempotencyKey: "run-4-2",
+	})
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if len(resp.CreatedCharts) != 1 {
+		t.Fatalf("expected 1 created chart, got %+v", resp.CreatedCharts)
+	}
+	chart := resp.CreatedCharts[0]
+	if chart.Name != "app-registry" {
+		t.Fatalf("expected helm-{domain}- prefix stripped from name, got %q", chart.Name)
+	}
+	if chart.FullName != "app-registry-app-registry" {
+		t.Fatalf("expected FullName %q, got %q", "app-registry-app-registry", chart.FullName)
+	}
+}
+
 // ============================================================================
 // Reconcile watermark (issue #545) -- fake-backed handler coverage.
 // See postgres_integration_test.go's "Reconcile watermark" section for the
@@ -822,6 +856,51 @@ func TestAssertApps_ThenRecordArtifact_NoReconcileNeeded(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("RecordArtifact should succeed immediately after AssertApps, with no ReconcileApps ever having run: %v", err)
+	}
+}
+
+// TestAssertApps_ThenRecordArtifact_ChartOwnerFullNameMatches is the chart
+// counterpart of the test above, using the manifest shape release_helm_chart's
+// Bazel macro actually emits (Name carrying a baked-in "helm-{domain}-"
+// prefix) and the "{domain}-{name}" owner string release.yml's PUBLISHED_NAME
+// derives from it (CHART with the literal "helm-" prefix trimmed). Before
+// AssertApps normalized ChartManifest.Name, these two never matched -- see
+// Chart.FullName's doc comment -- and RecordArtifact's chart-owner lookup
+// failed with "not found -- has it been reconciled?" for every chart, most
+// visibly for app-registry's own chart where domain == base name.
+func TestAssertApps_ThenRecordArtifact_ChartOwnerFullNameMatches(t *testing.T) {
+	ctx := authedCtx()
+	repo := fake.New()
+	appSrv := NewAppServer(repo)
+	artSrv := NewArtifactServer(repo)
+
+	if _, err := appSrv.AssertApps(ctx, &pb.AssertAppsRequest{
+		Manifests: manifestSet(
+			[]*appmetapb.AppManifest{oneApp("app-registry", "svc")},
+			[]*appmetapb.ChartManifest{{Domain: "app-registry", Name: "helm-app-registry-app-registry", Apps: []string{"svc"}}},
+		),
+		IdempotencyKey: "assert-6-1",
+	}); err != nil {
+		t.Fatalf("assert: %v", err)
+	}
+
+	build, err := artSrv.RecordBuild(ctx, &pb.RecordBuildRequest{
+		GitSha: "sha1", WorkflowRunId: "run-1", IdempotencyKey: "build-2",
+	})
+	if err != nil {
+		t.Fatalf("record build: %v", err)
+	}
+
+	// PUBLISHED_NAME in release.yml: "${CHART#helm-}" against
+	// "helm-app-registry-app-registry" -- exactly what release.yml passes as
+	// --owner to BeginPublish/RecordArtifact for this chart.
+	_, err = artSrv.RecordArtifact(ctx, &pb.RecordArtifactRequest{
+		BuildId: build.Build.BuildId, Kind: pb.ArtifactKind_ARTIFACT_KIND_CHART,
+		OwnerFullName: "app-registry-app-registry", Version: "v0.0.13", Digest: "sha256:chart13",
+		IdempotencyKey: "artifact-2",
+	})
+	if err != nil {
+		t.Fatalf("RecordArtifact should find the chart AssertApps just created by the release pipeline's owner name: %v", err)
 	}
 }
 

--- a/tools/app_registry/server/repository/models.go
+++ b/tools/app_registry/server/repository/models.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"strings"
 	"time"
 
 	appmetapb "github.com/whale-net/everything/tools/appmeta/proto"
@@ -133,6 +134,19 @@ type Chart struct {
 }
 
 func (c Chart) FullName() string { return c.Domain + "-" + c.Name }
+
+// NormalizeChartName strips the "helm-{domain}-" prefix that
+// release_helm_chart's Bazel macro bakes into ChartManifest.Name (needed
+// there for git tag and tarball naming, e.g. "helm-manmanv2-control-services")
+// so ReconcileApps/AssertApps store and look up charts the same way they do
+// apps: a bare name, with domain held separately. Without this, FullName()
+// would double up the domain (e.g. "app-registry-helm-app-registry-app-registry"
+// for the chart whose domain and base name happen to coincide), which never
+// matches the "{domain}-{name}" identifier the release pipeline uses for
+// BeginPublish/RecordArtifact.
+func NormalizeChartName(domain, name string) string {
+	return strings.TrimPrefix(name, "helm-"+domain+"-")
+}
 
 // ReconcileResult buckets every App/Chart row touched by one ReconcileApps
 // call, matching ReconcileAppsResponse in protos/api_messages_app.proto.


### PR DESCRIPTION
## Summary

- Chart releases via `release.yml` were failing `BeginPublish`/`RecordArtifact` lookups with `chart "<name>" not found -- has it been reconciled?` — most visibly for the `app-registry` chart itself ([run 31556837772](https://github.com/whale-net/everything/actions/runs/31556837772)), where `domain == chart_name == "app-registry"` made the mismatch look like a plain domain-duplication bug in `tools/app_registry/BUILD.bazel`.
- Root cause: `release_helm_chart`'s Bazel macro bakes `"helm-{domain}-{base}"` into `ChartManifest.Name` (needed for git-tag/tarball naming). `ReconcileApps`/`AssertApps` stored that string verbatim as `Chart.Name`, so `Chart.FullName()` (`domain + "-" + name`) doubled the domain up (e.g. `app-registry-helm-app-registry-app-registry`). `release.yml`'s `PUBLISHED_NAME` only strips the literal `"helm-"` prefix (`app-registry-app-registry`), and passes that as `--owner` — the two identifiers never matched, for *any* chart, not just app-registry's.
- Fix: normalize `ChartManifest.Name` once, in the handler layer shared by both `ReconcileApps` and `AssertApps`, stripping the `"helm-{domain}-"` prefix before it reaches the repository — so charts key the same way apps already do (bare name, domain held separately). `Chart.FullName()` then matches `PUBLISHED_NAME` for every chart. No DB migration needed: existing rows self-heal via the next sweep's missing/recreate cycle (the same mechanism the CI warning already described).

## Test plan

- [x] `bazel test //tools/app_registry/...` — all non-Postgres-integration targets pass, including two new regression tests reproducing the exact CI failure (`TestReconcileApps_ChartNameStripsHelmDomainPrefix`, `TestAssertApps_ThenRecordArtifact_ChartOwnerFullNameMatches`)
- [ ] Postgres integration tests (require Docker/testcontainers, unavailable in this session) — will run in CI
- [ ] Watch the next `main` release run for `app-registry`'s chart to confirm `BeginPublish`/`RecordArtifact` succeed post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)