### PR TITLE
fix(app-registry): unblock chart BeginPublish — owner naming + missing repository

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -793,6 +793,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: [plan-release, release, create-github-releases, release-helm-charts, build-release-tools]
     if: always()
+    env:
+      # Same value, same default, and the same override as the
+      # release-helm-charts job's -- see that job's CHART_REPO_URL comment.
+      # Repeated because `env` is per-job; the summary this job writes tells
+      # users where to `helm repo add` from, so it must not drift from where
+      # the charts were actually uploaded.
+      CHART_REPO_URL: ${{ vars.CHART_REPO_URL || 'https://charts.whalenet.dev' }}
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -855,7 +862,7 @@ jobs:
             echo "### 📚 Helm Repository" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "Charts have been published to the Helm repository:" >> $GITHUB_STEP_SUMMARY
-            echo "- **Repository URL:** https://charts.whalenet.dev/" >> $GITHUB_STEP_SUMMARY
+            echo "- **Repository URL:** ${CHART_REPO_URL}/" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             
             echo "### 🏷️ Git Tags" >> $GITHUB_STEP_SUMMARY
@@ -876,7 +883,7 @@ jobs:
             
             echo "**Add the repository:**" >> $GITHUB_STEP_SUMMARY
             echo '```bash' >> $GITHUB_STEP_SUMMARY
-            echo "helm repo add whalenet https://charts.whalenet.dev/" >> $GITHUB_STEP_SUMMARY
+            echo "helm repo add whalenet ${CHART_REPO_URL}/" >> $GITHUB_STEP_SUMMARY
             echo "helm repo update" >> $GITHUB_STEP_SUMMARY
             echo '```' >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
@@ -908,6 +915,16 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write     # Push git tags and read repository content
+    env:
+      # The ChartMuseum this job uploads to, and the base of the
+      # artifact.repository value recorded in the App Registry for every
+      # chart ("$CHART_REPO_URL/<published-name>"). Defined once here rather
+      # than inline per step: the upload step, the App Registry
+      # begin-publish/record steps, and the summary output must all agree on
+      # it, and they only do by construction if they read one value. Override
+      # with a CHART_REPO_URL repository/environment variable to point a fork
+      # or a staging run at a different ChartMuseum.
+      CHART_REPO_URL: ${{ vars.CHART_REPO_URL || 'https://charts.whalenet.dev' }}
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -1128,9 +1145,18 @@ jobs:
           CHART_VERSION=$(basename "$CHART_FILE" | sed -E "s/${PUBLISHED_NAME}-(.+)\.tgz/\1/")
 
           set +e
+          # --repository is REQUIRED here, unlike the image job's
+          # begin-publish, which can leave the server to fall back to the
+          # app's registered image_repository: chart.chart_repository has
+          # never been populated by any write path (migration 008 hardcodes
+          # it to '' in v_current_chart), so a chart's ∅ -> publishing
+          # branch has no server-side value to fall back to. Same URL the
+          # "Record chart artifacts" step below passes -- both write the one
+          # artifact.repository column, so they must agree.
           BEGIN_OUTPUT=$("$APP_REGISTRY_CLI" artifacts begin-publish \
             --kind chart \
             --owner "$PUBLISHED_NAME" \
+            --repository "${CHART_REPO_URL}/${PUBLISHED_NAME}" \
             --version "$CHART_VERSION" \
             --build-id "$BUILD_ID" \
             --idempotency-key "${IDEMPOTENCY_PREFIX}-${PUBLISHED_NAME}-chart-begin" 2>&1)
@@ -1214,9 +1240,9 @@ jobs:
         CHART_REPO_USER: ${{ secrets.CHART_REPO_USER }}
         CHART_REPO_PASS: ${{ secrets.CHART_REPO_PASS }}
       run: |
-        echo "Publishing charts to https://charts.whalenet.dev/..."
+        echo "Publishing charts to ${CHART_REPO_URL}/..."
         
-        REPO_URL="https://charts.whalenet.dev"
+        REPO_URL="$CHART_REPO_URL"
         
         # Verify chart files exist before attempting upload
         CHART_COUNT=$(ls -1 /tmp/helm-charts/*.tgz 2>/dev/null | wc -l)
@@ -1398,7 +1424,7 @@ jobs:
             --build-id "$BUILD_ID" \
             --kind chart \
             --owner "$PUBLISHED_NAME" \
-            --repository "https://charts.whalenet.dev/${PUBLISHED_NAME}" \
+            --repository "${CHART_REPO_URL}/${PUBLISHED_NAME}" \
             --version "$CHART_VERSION" \
             --digest "$CHART_DIGEST" \
             --contains "$CONTAINS_FILE" \
@@ -1450,13 +1476,13 @@ jobs:
     - name: Report deployment URL
       if: steps.plan.outputs.charts != '' && github.event.inputs.dry_run == 'false'
       run: |
-        echo "✅ Helm charts deployed to https://charts.whalenet.dev/!"
+        echo "✅ Helm charts deployed to ${CHART_REPO_URL}/!"
         echo ""
         echo "📦 Helm Repository URL:"
-        echo "  https://charts.whalenet.dev/"
+        echo "  ${CHART_REPO_URL}/"
         echo ""
         echo "Users can add the repository with:"
-        echo "  helm repo add whalenet https://charts.whalenet.dev/"
+        echo "  helm repo add whalenet ${CHART_REPO_URL}/"
         echo "  helm repo update"
         
     - name: Upload helm chart artifacts

--- a/docs/HELM_RELEASE.md
+++ b/docs/HELM_RELEASE.md
@@ -324,6 +324,14 @@ Helm charts are published to https://charts.whalenet.dev/ with basic authenticat
 - `CHART_REPO_USER` - Username for chart repository authentication
 - `CHART_REPO_PASS` - Password for chart repository authentication
 
+**Optional variable:**
+- `CHART_REPO_URL` - ChartMuseum base URL, defaulting to `https://charts.whalenet.dev`.
+  Set it to point a fork or a staging run at a different ChartMuseum. The
+  `release-helm-charts` and `release-summary` jobs both read it, so the upload
+  target, the `artifact.repository` value recorded in the App Registry
+  (`$CHART_REPO_URL/<published-name>`), and the `helm repo add` line in the run
+  summary cannot drift apart.
+
 **Adding the repository:**
 ```bash
 helm repo add whalenet https://charts.whalenet.dev/

--- a/tools/app_registry/ARCHITECTURE.md
+++ b/tools/app_registry/ARCHITECTURE.md
@@ -539,6 +539,23 @@ as a rejection, not a silent fallback to the old behavior. The reaper
 outbox drainer, configured via `ENV.md`'s `ARTIFACT_REAPER_TIMEOUT` /
 `ARTIFACT_REAPER_POLL_INTERVAL` — see `worker/README.md`.
 
+**Where `artifact.repository` comes from on `∅ → publishing`.** That branch
+creates the row from nothing, so it needs a value for the `NOT NULL`
+`repository` column, and there is no single source that serves both kinds.
+An image's is derivable server-side from the owning app's stored
+`image_repository`. A chart's is **not**: `chart.chart_repository` has never
+been populated by any write path, and migration `008` hardcodes it to `''` in
+`v_current_chart` — a chart lives at a ChartMuseum URL that is deployment
+configuration the registry has no way to derive. So `BeginPublishRequest`
+carries an optional `repository`, which wins over the owner row when set;
+chart callers must set it, and `release.yml` passes the same
+`$CHART_REPO_URL/<published-name>` its `RecordArtifact` call already passed.
+A chart taking this branch with neither is rejected rather than recorded with
+an empty repository. This was AR-7b's original blind spot: because
+`BeginPublish` resolved the repository *only* from the owner, every chart
+release failed the transition, so no chart ever reached `publishing` and
+`FailPublish` — gated on that step having succeeded — could never arm.
+
 ### App identity vs. per-build manifest snapshot
 
 Today `app` carries *mutable metadata* — `deploy_unit`, `image_repository`,

--- a/tools/app_registry/cli/cmd/artifacts.go
+++ b/tools/app_registry/cli/cmd/artifacts.go
@@ -118,7 +118,7 @@ func newArtifactsRecordCmd() *cobra.Command {
 // -> publishing transition. See ARCHITECTURE.md "Artifact lifecycle:
 // allocated -> publishing -> published".
 func newArtifactsBeginPublishCmd() *cobra.Command {
-	var kind, owner, version, buildID string
+	var kind, owner, version, buildID, repository string
 	c := &cobra.Command{
 		Use:   "begin-publish",
 		Short: "Begin publishing an artifact, before the push (CI)",
@@ -132,6 +132,7 @@ func newArtifactsBeginPublishCmd() *cobra.Command {
 				OwnerFullName:  owner,
 				Version:        version,
 				BuildId:        buildID,
+				Repository:     repository,
 				IdempotencyKey: idempotencyKeyFlag,
 			}
 			return withClient(cmd, func(rc *registryClient) error {
@@ -147,6 +148,7 @@ func newArtifactsBeginPublishCmd() *cobra.Command {
 	c.Flags().StringVar(&owner, "owner", "", "Owning app or chart, as <domain>-<name>")
 	c.Flags().StringVar(&version, "version", "", "Semver tag, e.g. v1.2.3")
 	c.Flags().StringVar(&buildID, "build-id", "", "Build id returned by 'builds record'")
+	c.Flags().StringVar(&repository, "repository", "", "Where the artifact is about to be pushed. Required for --kind chart; optional for --kind image, which defaults to the app's registered image repository")
 	c.Flags().StringVar(&idempotencyKeyFlag, "idempotency-key", "", "Required. <workflow_run_id>-<attempt>-<owner>-<kind>")
 	_ = c.MarkFlagRequired("kind")
 	_ = c.MarkFlagRequired("owner")

--- a/tools/app_registry/protos/api_messages_artifact.proto
+++ b/tools/app_registry/protos/api_messages_artifact.proto
@@ -92,6 +92,23 @@ message BeginPublishRequest {
 
   // Required. "<workflow_run_id>-<attempt>-<owner_full_name>-<kind>".
   string idempotency_key = 5;
+
+  // Where the artifact is about to be pushed, e.g.
+  // "ghcr.io/whale-net/app-registry-api" or
+  // "https://charts.whalenet.dev/app-registry-app-registry". Consulted ONLY
+  // on the ∅ -> publishing branch (no prior AllocateVersion row for this
+  // version), which has to create the artifact row from nothing and so needs
+  // a value for the NOT NULL artifact.repository column -- an existing
+  // allocated/failed/publishing row keeps the repository it already has.
+  //
+  // Optional, and normally omitted: the server prefers this field but falls
+  // back to the owning app's stored image_repository. That fallback does not
+  // exist for charts -- chart.chart_repository has never been populated by
+  // any write path and migration 008 hardcodes it to '' in v_current_chart
+  // (a chart's ChartMuseum URL is deployment config the registry has no way
+  // to derive) -- so chart callers MUST set this. See RecordArtifactRequest.
+  // repository, which carries the same value for the same reason.
+  string repository = 6;
 }
 
 message BeginPublishResponse {

--- a/tools/app_registry/server/handlers/BUILD.bazel
+++ b/tools/app_registry/server/handlers/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//tools/app_registry/protos:appregistrypb",
         "//tools/app_registry/server/auth",
         "//tools/app_registry/server/repository",
+        "//tools/appmeta/proto:appmetapb",
         "@org_golang_google_genproto_googleapis_rpc//errdetails",
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//status",

--- a/tools/app_registry/server/handlers/app.go
+++ b/tools/app_registry/server/handlers/app.go
@@ -11,6 +11,7 @@ import (
 	pb "github.com/whale-net/everything/tools/app_registry/protos"
 	"github.com/whale-net/everything/tools/app_registry/server/auth"
 	"github.com/whale-net/everything/tools/app_registry/server/repository"
+	appmetapb "github.com/whale-net/everything/tools/appmeta/proto"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
@@ -39,6 +40,7 @@ func (s *AppServer) ReconcileApps(ctx context.Context, req *pb.ReconcileAppsRequ
 	if req.Manifests == nil {
 		return nil, status.Error(codes.InvalidArgument, "manifests is required")
 	}
+	normalizeChartManifests(req.Manifests.Charts)
 
 	// source is the ordering metadata Reconcile checks against the
 	// reconcile watermark -- see ARCHITECTURE.md "Reconcile watermark" and
@@ -112,6 +114,19 @@ func (s *AppServer) ReconcileApps(ctx context.Context, req *pb.ReconcileAppsRequ
 	return resp.(*pb.ReconcileAppsResponse), nil
 }
 
+// normalizeChartManifests strips the "helm-{domain}-" prefix
+// release_helm_chart's Bazel macro bakes into ChartManifest.Name before it
+// reaches either ReconcileApps or AssertApps, so both key charts the same
+// way they key apps: bare name, domain held separately. See
+// repository.NormalizeChartName and Chart.FullName's doc comments. Mutates
+// in place -- req.Manifests is this call's private, freshly-unmarshaled
+// copy, not shared or cached elsewhere.
+func normalizeChartManifests(charts []*appmetapb.ChartManifest) {
+	for _, cm := range charts {
+		cm.Name = repository.NormalizeChartName(cm.Domain, cm.Name)
+	}
+}
+
 func reconcileResultToPB(r *repository.ReconcileResult, dryRun bool) *pb.ReconcileAppsResponse {
 	return &pb.ReconcileAppsResponse{
 		CreatedApps:            appsToPB(r.CreatedApps),
@@ -159,6 +174,7 @@ func (s *AppServer) AssertApps(ctx context.Context, req *pb.AssertAppsRequest) (
 	if req.Manifests == nil {
 		return nil, status.Error(codes.InvalidArgument, "manifests is required")
 	}
+	normalizeChartManifests(req.Manifests.Charts)
 	if req.IdempotencyKey == "" {
 		return nil, status.Error(codes.InvalidArgument, "idempotency_key is required")
 	}

--- a/tools/app_registry/server/handlers/app_test.go
+++ b/tools/app_registry/server/handlers/app_test.go
@@ -375,6 +375,40 @@ func TestReconcileApps_ChartComposesApps(t *testing.T) {
 	}
 }
 
+// TestReconcileApps_ChartNameStripsHelmDomainPrefix covers the manifest
+// shape release_helm_chart's Bazel macro actually emits: Name carries a
+// "helm-{domain}-" prefix baked in for git tag/tarball naming (e.g.
+// "helm-app-registry-app-registry" when a chart's domain and base name
+// coincide, as with the app-registry chart itself). ReconcileApps must strip
+// that prefix so Chart.FullName() matches the "{domain}-{name}" identifier
+// the release pipeline uses for BeginPublish/RecordArtifact, rather than
+// doubling up the domain (e.g. "app-registry-helm-app-registry-app-registry").
+func TestReconcileApps_ChartNameStripsHelmDomainPrefix(t *testing.T) {
+	ctx := authedCtx()
+	srv := NewAppServer(fake.New())
+
+	resp, err := srv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
+		Manifests: manifestSet(
+			[]*appmetapb.AppManifest{oneApp("app-registry", "svc")},
+			[]*appmetapb.ChartManifest{{Domain: "app-registry", Name: "helm-app-registry-app-registry", Apps: []string{"svc"}}},
+		),
+		IdempotencyKey: "run-4-2",
+	})
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if len(resp.CreatedCharts) != 1 {
+		t.Fatalf("expected 1 created chart, got %+v", resp.CreatedCharts)
+	}
+	chart := resp.CreatedCharts[0]
+	if chart.Name != "app-registry" {
+		t.Fatalf("expected helm-{domain}- prefix stripped from name, got %q", chart.Name)
+	}
+	if chart.FullName != "app-registry-app-registry" {
+		t.Fatalf("expected FullName %q, got %q", "app-registry-app-registry", chart.FullName)
+	}
+}
+
 // ============================================================================
 // Reconcile watermark (issue #545) -- fake-backed handler coverage.
 // See postgres_integration_test.go's "Reconcile watermark" section for the
@@ -822,6 +856,51 @@ func TestAssertApps_ThenRecordArtifact_NoReconcileNeeded(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("RecordArtifact should succeed immediately after AssertApps, with no ReconcileApps ever having run: %v", err)
+	}
+}
+
+// TestAssertApps_ThenRecordArtifact_ChartOwnerFullNameMatches is the chart
+// counterpart of the test above, using the manifest shape release_helm_chart's
+// Bazel macro actually emits (Name carrying a baked-in "helm-{domain}-"
+// prefix) and the "{domain}-{name}" owner string release.yml's PUBLISHED_NAME
+// derives from it (CHART with the literal "helm-" prefix trimmed). Before
+// AssertApps normalized ChartManifest.Name, these two never matched -- see
+// Chart.FullName's doc comment -- and RecordArtifact's chart-owner lookup
+// failed with "not found -- has it been reconciled?" for every chart, most
+// visibly for app-registry's own chart where domain == base name.
+func TestAssertApps_ThenRecordArtifact_ChartOwnerFullNameMatches(t *testing.T) {
+	ctx := authedCtx()
+	repo := fake.New()
+	appSrv := NewAppServer(repo)
+	artSrv := NewArtifactServer(repo)
+
+	if _, err := appSrv.AssertApps(ctx, &pb.AssertAppsRequest{
+		Manifests: manifestSet(
+			[]*appmetapb.AppManifest{oneApp("app-registry", "svc")},
+			[]*appmetapb.ChartManifest{{Domain: "app-registry", Name: "helm-app-registry-app-registry", Apps: []string{"svc"}}},
+		),
+		IdempotencyKey: "assert-6-1",
+	}); err != nil {
+		t.Fatalf("assert: %v", err)
+	}
+
+	build, err := artSrv.RecordBuild(ctx, &pb.RecordBuildRequest{
+		GitSha: "sha1", WorkflowRunId: "run-1", IdempotencyKey: "build-2",
+	})
+	if err != nil {
+		t.Fatalf("record build: %v", err)
+	}
+
+	// PUBLISHED_NAME in release.yml: "${CHART#helm-}" against
+	// "helm-app-registry-app-registry" -- exactly what release.yml passes as
+	// --owner to BeginPublish/RecordArtifact for this chart.
+	_, err = artSrv.RecordArtifact(ctx, &pb.RecordArtifactRequest{
+		BuildId: build.Build.BuildId, Kind: pb.ArtifactKind_ARTIFACT_KIND_CHART,
+		OwnerFullName: "app-registry-app-registry", Version: "v0.0.13", Digest: "sha256:chart13",
+		IdempotencyKey: "artifact-2",
+	})
+	if err != nil {
+		t.Fatalf("RecordArtifact should find the chart AssertApps just created by the release pipeline's owner name: %v", err)
 	}
 }
 

--- a/tools/app_registry/server/handlers/artifact.go
+++ b/tools/app_registry/server/handlers/artifact.go
@@ -438,6 +438,14 @@ func (s *ArtifactServer) BeginPublish(ctx context.Context, req *pb.BeginPublishR
 	if err != nil {
 		return nil, err
 	}
+	// The caller's own repository wins over the owner row's when supplied.
+	// Required for charts, which have no usable stored repository at all --
+	// see BeginPublishRequest.repository's doc comment. Images normally omit
+	// it and fall back to the app's stored image_repository, which is the
+	// same value RecordArtifact would go on to use.
+	if req.Repository != "" {
+		repo = req.Repository
+	}
 
 	artifact, err := s.beginPublishOne(ctx, req.IdempotencyKey, kind, ownerID, req.Version, req.BuildId, repo)
 	if err != nil {

--- a/tools/app_registry/server/handlers/artifact_test.go
+++ b/tools/app_registry/server/handlers/artifact_test.go
@@ -901,6 +901,92 @@ func TestBeginPublish_NoPriorAllocation_TagPath(t *testing.T) {
 	}
 }
 
+// TestBeginPublish_Chart_RepositoryComesFromRequest proves a chart's
+// ∅ -> publishing branch cannot lean on its owner row the way an image's
+// can. chart.chart_repository is structurally always '' -- no write path has
+// ever populated it, and migration 008 hardcodes it in v_current_chart --
+// so there is nothing server-side to fall back to and the caller must supply
+// the repository itself.
+//
+// Regression test for the release pipeline's chart leg failing every run
+// with "repository is required to begin publishing chart <version> with no
+// prior allocation": release.yml passed --repository to `artifacts record`
+// but not to `artifacts begin-publish`, so no chart ever reached
+// "publishing" and the failure path (FailPublish, gated on this step having
+// succeeded) could never arm.
+func TestBeginPublish_Chart_RepositoryComesFromRequest(t *testing.T) {
+	repo, artifactSrv := setupAllocate(t)
+	appSrv := NewAppServer(repo)
+	ctx := authedCtx()
+
+	if _, err := appSrv.ReconcileApps(ctx, &pb.ReconcileAppsRequest{
+		Manifests: manifestSet(
+			[]*appmetapb.AppManifest{
+				{Domain: "demo", Name: "image-app", DeployUnit: appmetapb.DeployUnit_DEPLOY_UNIT_IMAGE,
+					Registry: "ghcr.io", Organization: "whale-net", RepoName: "demo-image-app"},
+			},
+			// Named the way release_helm_chart's Bazel macro names charts,
+			// so this exercises the same normalized "demo-bundle" full name
+			// release.yml's PUBLISHED_NAME passes as --owner.
+			[]*appmetapb.ChartManifest{{Domain: "demo", Name: "helm-demo-bundle", AppRefs: []string{"demo/image-app"}}},
+		),
+		IdempotencyKey: "begin-chart-reconcile",
+	}); err != nil {
+		t.Fatalf("reconcile chart: %v", err)
+	}
+	build := recordBuild(t, artifactSrv, "run-chart-begin")
+
+	// No repository anywhere: rejected outright, rather than quietly
+	// creating a row with an empty artifact.repository.
+	_, err := artifactSrv.BeginPublish(ctx, &pb.BeginPublishRequest{
+		Kind: pb.ArtifactKind_ARTIFACT_KIND_CHART, OwnerFullName: "demo-bundle",
+		Version: "v0.0.15", BuildId: build.BuildId, IdempotencyKey: "chart-begin-no-repo",
+	})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("expected InvalidArgument for a chart BeginPublish with no repository, got %v", err)
+	}
+
+	const chartRepo = "https://charts.example.test/demo-bundle"
+	begun, err := artifactSrv.BeginPublish(ctx, &pb.BeginPublishRequest{
+		Kind: pb.ArtifactKind_ARTIFACT_KIND_CHART, OwnerFullName: "demo-bundle",
+		Version: "v0.0.15", BuildId: build.BuildId, Repository: chartRepo,
+		IdempotencyKey: "chart-begin-with-repo",
+	})
+	if err != nil {
+		t.Fatalf("BeginPublish for a chart with a request repository: %v", err)
+	}
+	if begun.Artifact.State != pb.ArtifactState_ARTIFACT_STATE_PUBLISHING {
+		t.Fatalf("expected state PUBLISHING, got %v", begun.Artifact.State)
+	}
+	if begun.Artifact.Repository != chartRepo {
+		t.Fatalf("artifact.repository = %q, want the request's %q", begun.Artifact.Repository, chartRepo)
+	}
+}
+
+// TestBeginPublish_Image_RequestRepositoryOverridesOwner proves the request
+// field is not chart-only: when an image caller sets it, it wins over the
+// app's stored image_repository. Omitting it (the normal image case) still
+// falls back to that stored value -- see
+// TestBeginPublish_NoPriorAllocation_TagPath.
+func TestBeginPublish_Image_RequestRepositoryOverridesOwner(t *testing.T) {
+	_, artifactSrv := setupAllocate(t)
+	ctx := authedCtx()
+	build := recordBuild(t, artifactSrv, "run-image-begin-repo-override")
+
+	const override = "ghcr.io/whale-net/somewhere-else"
+	begun, err := artifactSrv.BeginPublish(ctx, &pb.BeginPublishRequest{
+		Kind: pb.ArtifactKind_ARTIFACT_KIND_IMAGE, OwnerFullName: "demo-image-app",
+		Version: "v9.9.9", BuildId: build.BuildId, Repository: override,
+		IdempotencyKey: "image-begin-repo-override",
+	})
+	if err != nil {
+		t.Fatalf("BeginPublish: %v", err)
+	}
+	if begun.Artifact.Repository != override {
+		t.Fatalf("artifact.repository = %q, want the request's %q", begun.Artifact.Repository, override)
+	}
+}
+
 // TestBeginPublish_RejectsPublishedRow proves publishing -> published is
 // terminal: BeginPublish against an already-published version is
 // FailedPrecondition, not a silent no-op or re-publish.

--- a/tools/app_registry/server/repository/models.go
+++ b/tools/app_registry/server/repository/models.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"strings"
 	"time"
 
 	appmetapb "github.com/whale-net/everything/tools/appmeta/proto"
@@ -133,6 +134,19 @@ type Chart struct {
 }
 
 func (c Chart) FullName() string { return c.Domain + "-" + c.Name }
+
+// NormalizeChartName strips the "helm-{domain}-" prefix that
+// release_helm_chart's Bazel macro bakes into ChartManifest.Name (needed
+// there for git tag and tarball naming, e.g. "helm-manmanv2-control-services")
+// so ReconcileApps/AssertApps store and look up charts the same way they do
+// apps: a bare name, with domain held separately. Without this, FullName()
+// would double up the domain (e.g. "app-registry-helm-app-registry-app-registry"
+// for the chart whose domain and base name happen to coincide), which never
+// matches the "{domain}-{name}" identifier the release pipeline uses for
+// BeginPublish/RecordArtifact.
+func NormalizeChartName(domain, name string) string {
+	return strings.TrimPrefix(name, "helm-"+domain+"-")
+}
 
 // ReconcileResult buckets every App/Chart row touched by one ReconcileApps
 // call, matching ReconcileAppsResponse in protos/api_messages_app.proto.

--- a/tools/app_registry/server/repository/repository.go
+++ b/tools/app_registry/server/repository/repository.go
@@ -236,6 +236,14 @@ type ArtifactRepository interface {
 	// branch; an existing row keeps whatever AllocateVersion (or a prior
 	// BeginPublish) already gave it. published is ErrFailedPrecondition.
 	//
+	// The handler builds repositoryHint from BeginPublishRequest.repository
+	// when the caller sets it, and only otherwise from the owner row's
+	// stored image_repository/chart_repository. Chart callers must set it:
+	// chart.chart_repository is structurally always '' (no write path has
+	// ever populated it, and migration 008 hardcodes it in v_current_chart),
+	// so a chart taking the ∅ branch with no request-supplied repository is
+	// rejected here rather than silently recorded with an empty repository.
+	//
 	// publishing -> publishing (AR-7d, issue #558) is a legal, idempotent
 	// heartbeat/re-arm, not a rejection: it refreshes state_changed_at (and
 	// build_id) without changing state. This exists because


### PR DESCRIPTION
Two bugs that together stop the release pipeline from ever transitioning a
chart to `publishing`. Found triaging
[run 31564279457](https://github.com/whale-net/everything/actions/runs/31564279457/job/94014002233).

## The symptom

```
rpc error: code = InvalidArgument desc = invalid argument: repository is
required to begin publishing chart v0.0.15 with no prior allocation
```

The run reports **success**. Every step reports `success`. The
`Begin publish (charts) in App Registry` step is `continue-on-error`, so its
`exit 1` never propagates — what you see is an annotation on a green run.
This is issue #570's pattern again: the failure is real, invisible to any
status check, and does not clear on retry.

## Bug 1 — `chart_repository` is structurally always `''`

`BeginPublish` resolves `artifact.repository` from the owner row alone
(`resolveOwnerAndDomain`). For images that works — `app.image_repository`
carries a real value. For charts it cannot: `chart.chart_repository` has
never been populated by any write path, and migration `008` hardcodes it to
`''::text` in `v_current_chart`. That is correct as far as it goes — a
chart's ChartMuseum URL is deployment configuration the registry has no way
to derive — but it leaves `BeginPublish` with nothing to use.

Charts also never have a prior allocation to fall back on: `release.yml`'s
begin-publish-batch targets file is built from the image matrix only
(`[.include[] | {kind: "image", ...}]`). So a chart *always* takes the
`∅ → publishing` branch, which is exactly the branch that has to create the
row from nothing and therefore needs a value for the `NOT NULL` `repository`
column.

`release.yml` already passed `--repository` to `artifacts record`.
`artifacts begin-publish` had no such flag to pass it to.

**Fix:** `BeginPublishRequest.repository` (field 6, optional), preferred over
the owner row when set; a matching `artifacts begin-publish --repository`
flag; `release.yml`'s chart leg passes it. Images are unchanged — they still
omit it and fall back to the app's stored `image_repository`.

### What this was costing

- No chart has ever reached `publishing`, so `GetReleaseRun` cannot tell a
  chart leg that died mid-push from one that never started.
- `Fail publish (charts)` is gated on
  `steps.app-registry-begin-publish.outcome == 'success'`, so it could never
  arm — a genuinely failed chart push leaves no `failed` row either.
- `RecordArtifact` kept working the whole time, creating the row directly in
  `published` via the pre-cutover fallback. That is why chart artifacts *are*
  recorded despite this, and why nothing surfaced until the annotation.

## Bug 2 — `helm-{domain}-` prefix doubles the domain

`release_helm_chart`'s Bazel macro bakes `helm-{domain}-{base}` into
`ChartManifest.Name` (it needs that for git tag and tarball naming).
`ReconcileApps`/`AssertApps` stored it verbatim as `Chart.Name`, so
`Chart.FullName()` doubled the domain. From the reconcile job on this same
commit:

```
"name":     "helm-manmanv2-control-services",
"fullName": "manmanv2-helm-manmanv2-control-services"
```

Meanwhile `release.yml`'s `PUBLISHED_NAME` strips only the literal `helm-`,
giving `manmanv2-control-services`, and passes that as `--owner`.

**Fix:** normalize once in the handler layer shared by both RPCs, so charts
key the way apps already do — bare name, domain held separately. Existing
rows self-heal through the next sweep's missing/recreate cycle; no migration.

### One thing a reviewer should sanity-check

On the failing run, `BeginPublish` for `app-registry-app-registry` got *past*
the owner lookup — it returned the repository error, not `chart not found`.
But reconcile reports the live chart as
`app-registry-helm-app-registry-app-registry`. Both can only be true if a
second, stale row exists under the bare name, which `GetChartByFullName`
still resolves because it does not filter on `status`.

**This is inference, not something I confirmed** — I did not query the
registry. If it holds, the release pipeline is currently transacting against
a dead row, and this PR's normalization is what points it at the live one. It
also suggests `resolveOwnerAndDomain` should probably reject `MISSING` owners
the way it already rejects `ARCHIVED`. Deliberately not done here: it is a
separate behavioural change, and it would be better decided against real data
than against my reading of a log.

## Also: parameterized the ChartMuseum URL

`https://charts.whalenet.dev` was hardcoded in seven places across two jobs,
and this fix would have made it eight — with a new correctness requirement,
since begin-publish and record both write the single `artifact.repository`
column and must agree.

Now a `CHART_REPO_URL` job env, defaulting to the same value and overridable
via a `CHART_REPO_URL` repository variable. The upload target, both registry
calls, and the `helm repo add` line in the run summary read one value.
Documented in `docs/HELM_RELEASE.md`.

## Verification

- `bazel build //tools/...` — success.
- `bazel test //tools/...` — 14/14 pass.
- Two new handler tests: `TestBeginPublish_Chart_RepositoryComesFromRequest`
  (rejected without a repository, and the row carries exactly the one the
  caller passed) and
  `TestBeginPublish_Image_RequestRepositoryOverridesOwner`.
- **Not run:** the Docker-backed `postgres_integration_test` — Docker is down
  in my environment. No repository-layer code changed, so it is unaffected in
  substance, and CI's `Test Database Integration` job covers it. Please don't
  merge on a red database job on my say-so.

## Still open, not fixed here

Charts are absent from `BeginPublishBatch`'s targets file, so a chart job that
never starts still leaves no row at all — the gap AR-7d closed for images.
Worth its own change; it needs the chart plan step's output, which this job
does not have at plan time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
